### PR TITLE
feat(sarif): add SARIF 2.1.0 output format support (ENG-1238)

### DIFF
--- a/pkg/sarif/sarif.go
+++ b/pkg/sarif/sarif.go
@@ -1,0 +1,198 @@
+package sarif
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+)
+
+// SARIF 2.1.0 constants
+const (
+	SchemaURI   = "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json"
+	Version     = "2.1.0"
+	ToolName    = "titus"
+	ToolVersion = "0.1.0"
+)
+
+// Report is the top-level SARIF report structure
+type Report struct {
+	Schema  string `json:"$schema"`
+	Version string `json:"version"`
+	Runs    []Run  `json:"runs"`
+}
+
+// Run represents a single invocation of the tool
+type Run struct {
+	Tool    Tool     `json:"tool"`
+	Results []Result `json:"results"`
+}
+
+// Tool describes the analysis tool
+type Tool struct {
+	Driver Driver `json:"driver"`
+}
+
+// Driver contains tool metadata
+type Driver struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	Rules   []Rule `json:"rules,omitempty"`
+}
+
+// Rule represents a detection rule
+type Rule struct {
+	ID               string           `json:"id"`
+	Name             string           `json:"name"`
+	ShortDescription ShortDescription `json:"shortDescription"`
+	HelpURI          string           `json:"helpUri,omitempty"`
+}
+
+// ShortDescription contains rule description text
+type ShortDescription struct {
+	Text string `json:"text"`
+}
+
+// Result represents a single finding
+type Result struct {
+	RuleID    string     `json:"ruleId"`
+	Level     string     `json:"level"`
+	Message   Message    `json:"message"`
+	Locations []Location `json:"locations"`
+}
+
+// Message contains the result message
+type Message struct {
+	Text string `json:"text"`
+}
+
+// Location describes where a result was found
+type Location struct {
+	PhysicalLocation PhysicalLocation `json:"physicalLocation"`
+}
+
+// PhysicalLocation specifies file location
+type PhysicalLocation struct {
+	ArtifactLocation ArtifactLocation `json:"artifactLocation"`
+	Region           Region           `json:"region"`
+}
+
+// ArtifactLocation identifies the file
+type ArtifactLocation struct {
+	URI string `json:"uri"`
+}
+
+// Region specifies the line/column range
+type Region struct {
+	StartLine   int     `json:"startLine"`
+	StartColumn int     `json:"startColumn"`
+	EndLine     int     `json:"endLine"`
+	EndColumn   int     `json:"endColumn"`
+	Snippet     Snippet `json:"snippet,omitempty"`
+}
+
+// Snippet contains the matched text
+type Snippet struct {
+	Text string `json:"text"`
+}
+
+// NewReport creates a new SARIF report with initialized structure
+func NewReport() *Report {
+	return &Report{
+		Schema:  SchemaURI,
+		Version: Version,
+		Runs: []Run{
+			{
+				Tool: Tool{
+					Driver: Driver{
+						Name:    ToolName,
+						Version: ToolVersion,
+						Rules:   []Rule{},
+					},
+				},
+				Results: []Result{},
+			},
+		},
+	}
+}
+
+// AddRule adds a detection rule to the report
+func (r *Report) AddRule(rule *types.Rule) {
+	sarifRule := Rule{
+		ID:   rule.ID,
+		Name: rule.Name,
+		ShortDescription: ShortDescription{
+			Text: rule.Description,
+		},
+	}
+
+	// Add first reference as helpUri if available
+	if len(rule.References) > 0 {
+		sarifRule.HelpURI = rule.References[0]
+	}
+
+	r.Runs[0].Tool.Driver.Rules = append(r.Runs[0].Tool.Driver.Rules, sarifRule)
+}
+
+// AddResult adds a finding result to the report
+func (r *Report) AddResult(match *types.Match, filePath string) {
+	// Convert file path to URI format
+	uri := formatFileURI(filePath)
+
+	// Create region with line/column information
+	region := Region{
+		StartLine:   match.Location.Source.Start.Line,
+		StartColumn: match.Location.Source.Start.Column,
+		EndLine:     match.Location.Source.End.Line,
+		EndColumn:   match.Location.Source.End.Column,
+	}
+
+	// Add snippet if available
+	if len(match.Snippet.Matching) > 0 {
+		region.Snippet = Snippet{
+			Text: string(match.Snippet.Matching),
+		}
+	}
+
+	result := Result{
+		RuleID: match.RuleID,
+		Level:  "warning",
+		Message: Message{
+			Text: match.RuleName,
+		},
+		Locations: []Location{
+			{
+				PhysicalLocation: PhysicalLocation{
+					ArtifactLocation: ArtifactLocation{
+						URI: uri,
+					},
+					Region: region,
+				},
+			},
+		},
+	}
+
+	r.Runs[0].Results = append(r.Runs[0].Results, result)
+}
+
+// ToJSON serializes the report to JSON bytes
+func (r *Report) ToJSON() ([]byte, error) {
+	return json.MarshalIndent(r, "", "  ")
+}
+
+// formatFileURI converts a file path to SARIF URI format
+// Absolute paths get file:// prefix, relative paths stay as-is
+func formatFileURI(path string) string {
+	if filepath.IsAbs(path) {
+		// Normalize path separators for URI format
+		path = filepath.ToSlash(path)
+		// Ensure path starts with /
+		if !strings.HasPrefix(path, "/") {
+			path = "/" + path
+		}
+		return "file://" + path
+	}
+	// Relative paths stay as-is
+	return filepath.ToSlash(path)
+}

--- a/pkg/sarif/sarif_test.go
+++ b/pkg/sarif/sarif_test.go
@@ -1,0 +1,210 @@
+package sarif
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewReport(t *testing.T) {
+	report := NewReport()
+
+	assert.Equal(t, SchemaURI, report.Schema)
+	assert.Equal(t, Version, report.Version)
+	assert.NotNil(t, report.Runs)
+	assert.Len(t, report.Runs, 1)
+	assert.Equal(t, ToolName, report.Runs[0].Tool.Driver.Name)
+	assert.Equal(t, ToolVersion, report.Runs[0].Tool.Driver.Version)
+}
+
+func TestAddRule(t *testing.T) {
+	report := NewReport()
+
+	rule := &types.Rule{
+		ID:          "np.aws.1",
+		Name:        "AWS API Key",
+		Description: "Detects AWS API keys",
+		References:  []string{"https://docs.aws.amazon.com"},
+	}
+
+	report.AddRule(rule)
+
+	assert.Len(t, report.Runs[0].Tool.Driver.Rules, 1)
+	sarifRule := report.Runs[0].Tool.Driver.Rules[0]
+	assert.Equal(t, "np.aws.1", sarifRule.ID)
+	assert.Equal(t, "AWS API Key", sarifRule.Name)
+	assert.Equal(t, "Detects AWS API keys", sarifRule.ShortDescription.Text)
+}
+
+func TestAddResult(t *testing.T) {
+	report := NewReport()
+
+	rule := &types.Rule{
+		ID:   "np.aws.1",
+		Name: "AWS API Key",
+	}
+	report.AddRule(rule)
+
+	match := &types.Match{
+		RuleID:   "np.aws.1",
+		RuleName: "AWS API Key",
+		Location: types.Location{
+			Offset: types.OffsetSpan{Start: 100, End: 120},
+			Source: types.SourceSpan{
+				Start: types.SourcePoint{Line: 10, Column: 5},
+				End:   types.SourcePoint{Line: 10, Column: 25},
+			},
+		},
+		Snippet: types.Snippet{
+			Matching: []byte("AKIATESTFAKEKEY12345"),
+		},
+	}
+
+	filePath := "/path/to/secrets.txt"
+	report.AddResult(match, filePath)
+
+	assert.Len(t, report.Runs[0].Results, 1)
+	result := report.Runs[0].Results[0]
+	assert.Equal(t, "np.aws.1", result.RuleID)
+	assert.Equal(t, "warning", result.Level)
+	assert.Len(t, result.Locations, 1)
+
+	location := result.Locations[0]
+	assert.Equal(t, "file:///path/to/secrets.txt", location.PhysicalLocation.ArtifactLocation.URI)
+	assert.Equal(t, 10, location.PhysicalLocation.Region.StartLine)
+	assert.Equal(t, 5, location.PhysicalLocation.Region.StartColumn)
+	assert.Equal(t, 10, location.PhysicalLocation.Region.EndLine)
+	assert.Equal(t, 25, location.PhysicalLocation.Region.EndColumn)
+}
+
+func TestToJSON(t *testing.T) {
+	report := NewReport()
+
+	rule := &types.Rule{
+		ID:          "np.aws.1",
+		Name:        "AWS API Key",
+		Description: "Detects AWS API keys",
+	}
+	report.AddRule(rule)
+
+	match := &types.Match{
+		RuleID:   "np.aws.1",
+		RuleName: "AWS API Key",
+		Location: types.Location{
+			Source: types.SourceSpan{
+				Start: types.SourcePoint{Line: 10, Column: 5},
+				End:   types.SourcePoint{Line: 10, Column: 25},
+			},
+		},
+		Snippet: types.Snippet{
+			Matching: []byte("AKIATESTFAKEKEY12345"),
+		},
+	}
+	report.AddResult(match, "/test/file.txt")
+
+	jsonBytes, err := report.ToJSON()
+	require.NoError(t, err)
+
+	// Verify it's valid JSON
+	var parsed map[string]interface{}
+	err = json.Unmarshal(jsonBytes, &parsed)
+	require.NoError(t, err)
+
+	// Check schema is present
+	assert.Contains(t, parsed, "$schema")
+	assert.Equal(t, SchemaURI, parsed["$schema"])
+
+	// Check version
+	assert.Equal(t, Version, parsed["version"])
+}
+
+func TestMultipleResults(t *testing.T) {
+	report := NewReport()
+
+	awsRule := &types.Rule{ID: "np.aws.1", Name: "AWS API Key"}
+	githubRule := &types.Rule{ID: "np.github.1", Name: "GitHub PAT"}
+
+	report.AddRule(awsRule)
+	report.AddRule(githubRule)
+
+	match1 := &types.Match{
+		RuleID: "np.aws.1",
+		Location: types.Location{
+			Source: types.SourceSpan{
+				Start: types.SourcePoint{Line: 10, Column: 1},
+				End:   types.SourcePoint{Line: 10, Column: 20},
+			},
+		},
+	}
+	match2 := &types.Match{
+		RuleID: "np.github.1",
+		Location: types.Location{
+			Source: types.SourceSpan{
+				Start: types.SourcePoint{Line: 20, Column: 1},
+				End:   types.SourcePoint{Line: 20, Column: 40},
+			},
+		},
+	}
+
+	report.AddResult(match1, "/file1.txt")
+	report.AddResult(match2, "/file2.txt")
+
+	assert.Len(t, report.Runs[0].Tool.Driver.Rules, 2)
+	assert.Len(t, report.Runs[0].Results, 2)
+}
+
+func TestRelativePathConversion(t *testing.T) {
+	report := NewReport()
+
+	rule := &types.Rule{ID: "test", Name: "Test"}
+	report.AddRule(rule)
+
+	match := &types.Match{
+		RuleID: "test",
+		Location: types.Location{
+			Source: types.SourceSpan{
+				Start: types.SourcePoint{Line: 1, Column: 1},
+				End:   types.SourcePoint{Line: 1, Column: 10},
+			},
+		},
+	}
+
+	// Test absolute path
+	report.AddResult(match, "/absolute/path/file.txt")
+	assert.Equal(t, "file:///absolute/path/file.txt", report.Runs[0].Results[0].Locations[0].PhysicalLocation.ArtifactLocation.URI)
+
+	// Test relative path
+	report.AddResult(match, "relative/path/file.txt")
+	assert.Equal(t, "relative/path/file.txt", report.Runs[0].Results[1].Locations[0].PhysicalLocation.ArtifactLocation.URI)
+}
+
+func TestSnippetInRegion(t *testing.T) {
+	report := NewReport()
+
+	rule := &types.Rule{ID: "test", Name: "Test"}
+	report.AddRule(rule)
+
+	match := &types.Match{
+		RuleID: "test",
+		Location: types.Location{
+			Source: types.SourceSpan{
+				Start: types.SourcePoint{Line: 5, Column: 10},
+				End:   types.SourcePoint{Line: 5, Column: 30},
+			},
+		},
+		Snippet: types.Snippet{
+			Before:   []byte("prefix: "),
+			Matching: []byte("SECRET_VALUE_HERE"),
+			After:    []byte(" suffix"),
+		},
+	}
+
+	report.AddResult(match, "/test.txt")
+
+	region := report.Runs[0].Results[0].Locations[0].PhysicalLocation.Region
+	assert.NotNil(t, region.Snippet)
+	assert.Equal(t, "SECRET_VALUE_HERE", region.Snippet.Text)
+}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -37,8 +37,11 @@ type Store interface {
 	// FindingExists checks if a finding with this structural ID exists.
 	FindingExists(structuralID string) (bool, error)
 
-	// BlobExists checks if a blob has already been scanned.
+// BlobExists checks if a blob has already been scanned.
 	BlobExists(id types.BlobID) (bool, error)
+
+	// GetProvenance retrieves provenance for a blob.
+	GetProvenance(blobID types.BlobID) (types.Provenance, error)
 
 	// Close closes the database connection.
 	Close() error


### PR DESCRIPTION
## Summary

- Implement SARIF 2.1.0 output format for CI/CD integration
- Add `--format=sarif` flag to scan command
- Add comprehensive unit and integration tests

## Changes

- **pkg/sarif/sarif.go**: New SARIF types and serialization
- **pkg/sarif/sarif_test.go**: 7 unit tests for SARIF functionality
- **cmd/titus/scan.go**: Integrate SARIF output format
- **pkg/store/store.go**: Add GetProvenance() to Store interface
- **pkg/store/sqlite.go**: Implement GetProvenance() for file path resolution
- **scripts/integration-test.sh**: Add SARIF format validation test

## Test plan

- [x] All 7 SARIF unit tests pass
- [x] All 12 integration tests pass (including new SARIF test)
- [x] Build compiles successfully
- [x] SARIF output validates against schema (version 2.1.0, $schema present)