### PR TITLE
feat(scan): add incremental scanning to skip already-scanned blobs (ENG-1240)

### DIFF
--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -283,6 +283,16 @@ func (s *SQLiteStore) FindingExists(structuralID string) (bool, error) {
 	return count > 0, nil
 }
 
+// BlobExists checks if a blob has already been scanned.
+func (s *SQLiteStore) BlobExists(id types.BlobID) (bool, error) {
+	var count int
+	err := s.db.QueryRow("SELECT COUNT(*) FROM blobs WHERE id = ?", id.Hex()).Scan(&count)
+	if err != nil {
+		return false, fmt.Errorf("checking blob existence: %w", err)
+	}
+	return count > 0, nil
+}
+
 // Close closes the database connection.
 func (s *SQLiteStore) Close() error {
 	return s.db.Close()

--- a/pkg/store/sqlite_test.go
+++ b/pkg/store/sqlite_test.go
@@ -213,6 +213,29 @@ func TestSQLite_AddProvenance_Git(t *testing.T) {
 	assert.Equal(t, "abc123", commitHash)
 }
 
+func TestSQLite_BlobExists(t *testing.T) {
+	// Arrange
+	store, err := NewSQLite(":memory:")
+	require.NoError(t, err)
+	defer store.Close()
+
+	blobID := types.ComputeBlobID([]byte("test content"))
+
+	// Act & Assert - blob should not exist initially
+	exists, err := store.BlobExists(blobID)
+	require.NoError(t, err)
+	assert.False(t, exists)
+
+	// Add the blob
+	err = store.AddBlob(blobID, 12)
+	require.NoError(t, err)
+
+	// Act & Assert - blob should exist now
+	exists, err = store.BlobExists(blobID)
+	require.NoError(t, err)
+	assert.True(t, exists)
+}
+
 func TestSQLite_Close(t *testing.T) {
 	// Arrange
 	store, err := NewSQLite(":memory:")

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -34,6 +34,9 @@ type Store interface {
 	// FindingExists checks if a finding with this structural ID exists.
 	FindingExists(structuralID string) (bool, error)
 
+	// BlobExists checks if a blob has already been scanned.
+	BlobExists(id types.BlobID) (bool, error)
+
 	// Close closes the database connection.
 	Close() error
 }

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -227,6 +227,25 @@ pass "Context extraction with --context-lines=0 works - all $total_no_context fi
 
 rm -f "$CONTEXT_FILE" "$CONTEXT_DB" "$NO_CONTEXT_FILE" "$NO_CONTEXT_DB"
 
+# Test 13: Incremental Scanning
+echo "=== Test 13: Incremental Scanning ==="
+INCREMENTAL_DB="/tmp/titus-incremental.db"
+rm -f "$INCREMENTAL_DB"
+
+# First scan
+$TITUS scan "$TESTDATA_DIR" --output="$INCREMENTAL_DB" --format=human > /tmp/titus-inc1.txt 2>&1
+
+# Second scan with incremental - should skip all blobs
+$TITUS scan "$TESTDATA_DIR" --output="$INCREMENTAL_DB" --format=human --incremental > /tmp/titus-inc2.txt 2>&1
+
+# Verify second scan mentions skipped blobs
+if ! grep -q "skipped" /tmp/titus-inc2.txt; then
+    fail "Expected incremental scan to report skipped blobs"
+fi
+
+pass "Incremental scanning works"
+rm -f "$INCREMENTAL_DB" /tmp/titus-inc1.txt /tmp/titus-inc2.txt
+
 # Cleanup
 rm -f "$RESULTS_FILE"
 


### PR DESCRIPTION
## Summary

Implement incremental scanning mode that improves performance for repeated scans of large repositories by skipping already-scanned blobs.

**Linear:** ENG-1240

## Features

- Add `--incremental` flag to scan command
- Add `BlobExists()` method to Store interface
- Skip scanning blobs that exist in datastore
- Report number of skipped blobs in output

## Usage

```bash
# First scan - scans everything
titus scan /path/to/repo

# Second scan - skips already-scanned blobs
titus scan /path/to/repo --incremental
# Output: Scan complete: 0 matches, 0 findings (4 blobs skipped)
```

## Changes

- **cmd/titus/scan.go**: Add --incremental flag and skip logic
- **pkg/store/store.go**: Add BlobExists to interface
- **pkg/store/sqlite.go**: Implement BlobExists method
- **pkg/store/sqlite_test.go**: Add BlobExists unit test
- **scripts/integration-test.sh**: Add incremental scanning test

## Test plan

- [x] BlobExists unit test passes
- [x] All 13 integration tests pass (including new incremental test)
- [x] Build compiles successfully
- [x] Verified incremental mode reports skipped blobs