### PR TITLE
feat(store): add datastore merging capability

### DIFF
--- a/cmd/titus/merge.go
+++ b/cmd/titus/merge.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/praetorian-inc/titus/pkg/store"
+	"github.com/spf13/cobra"
+)
+
+var (
+	mergeOutput string
+)
+
+var mergeCmd = &cobra.Command{
+	Use:   "merge <source1.db> <source2.db> [source3.db...]",
+	Short: "Merge multiple Titus databases",
+	Long: `Merge multiple Titus databases into a single output database.
+
+This is useful for combining results from distributed scans or
+merging results from different scan targets.
+
+Deduplication is automatic - duplicate blobs, matches, and findings
+are only stored once in the merged database.`,
+	Args: cobra.MinimumNArgs(2),
+	RunE: runMerge,
+}
+
+func init() {
+	mergeCmd.Flags().StringVarP(&mergeOutput, "output", "o", "merged.db", "Output database path")
+}
+
+func runMerge(cmd *cobra.Command, args []string) error {
+	stats, err := store.Merge(store.MergeConfig{
+		SourcePaths: args,
+		DestPath:    mergeOutput,
+	})
+	if err != nil {
+		return fmt.Errorf("merge failed: %w", err)
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Merge complete:\n")
+	fmt.Fprintf(cmd.OutOrStdout(), "  Sources processed: %d\n", stats.SourcesProcessed)
+	fmt.Fprintf(cmd.OutOrStdout(), "  Blobs merged: %d\n", stats.BlobsMerged)
+	fmt.Fprintf(cmd.OutOrStdout(), "  Matches merged: %d\n", stats.MatchesMerged)
+	fmt.Fprintf(cmd.OutOrStdout(), "  Findings merged: %d\n", stats.FindingsMerged)
+	fmt.Fprintf(cmd.OutOrStdout(), "  Provenance merged: %d\n", stats.ProvenanceMerged)
+	fmt.Fprintf(cmd.OutOrStdout(), "Output: %s\n", mergeOutput)
+
+	return nil
+}

--- a/cmd/titus/merge_test.go
+++ b/cmd/titus/merge_test.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/praetorian-inc/titus/pkg/store"
+	"github.com/praetorian-inc/titus/pkg/types"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newMergeCmd creates a fresh merge command for testing
+func newMergeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "merge <source1.db> <source2.db> [source3.db...]",
+		Short: "Merge multiple Titus databases",
+		Args:  cobra.MinimumNArgs(2),
+		RunE:  runMerge,
+	}
+	cmd.Flags().StringVarP(&mergeOutput, "output", "o", "merged.db", "Output database path")
+	return cmd
+}
+
+func TestMergeCmd_RequiresMinimumArgs(t *testing.T) {
+	// Test with no args - the Args validator should reject
+	cmd := newMergeCmd()
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "requires at least 2 arg")
+
+	// Test with one arg
+	cmd = newMergeCmd()
+	cmd.SetArgs([]string{"source1.db"})
+	err = cmd.Execute()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "requires at least 2 arg")
+}
+
+func TestMergeCmd_MergesTwoDatabases(t *testing.T) {
+	// Create temp directory
+	tmpDir, err := os.MkdirTemp("", "titus-merge-cmd-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Create source1 with data
+	source1Path := filepath.Join(tmpDir, "source1.db")
+	source1, err := store.NewSQLite(source1Path)
+	require.NoError(t, err)
+	err = source1.AddBlob(types.ComputeBlobID([]byte("content1")), 8)
+	require.NoError(t, err)
+	err = source1.AddFinding(&types.Finding{ID: "finding1", RuleID: "rule1"})
+	require.NoError(t, err)
+	source1.Close()
+
+	// Create source2 with data
+	source2Path := filepath.Join(tmpDir, "source2.db")
+	source2, err := store.NewSQLite(source2Path)
+	require.NoError(t, err)
+	err = source2.AddBlob(types.ComputeBlobID([]byte("content2")), 8)
+	require.NoError(t, err)
+	err = source2.AddFinding(&types.Finding{ID: "finding2", RuleID: "rule2"})
+	require.NoError(t, err)
+	source2.Close()
+
+	// Run merge command
+	destPath := filepath.Join(tmpDir, "merged.db")
+	var buf bytes.Buffer
+	cmd := newMergeCmd()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{source1Path, source2Path, "--output", destPath})
+
+	err = cmd.Execute()
+	require.NoError(t, err)
+
+	// Verify output
+	output := buf.String()
+	assert.Contains(t, output, "Merge complete")
+	assert.Contains(t, output, "Sources processed: 2")
+	assert.Contains(t, output, "Blobs merged: 2")
+	assert.Contains(t, output, "Findings merged: 2")
+
+	// Verify merged database
+	dest, err := store.NewSQLite(destPath)
+	require.NoError(t, err)
+	defer dest.Close()
+
+	exists1, _ := dest.FindingExists("finding1")
+	exists2, _ := dest.FindingExists("finding2")
+	assert.True(t, exists1)
+	assert.True(t, exists2)
+}
+
+func TestMergeCmd_ReportsDeduplication(t *testing.T) {
+	// Create temp directory
+	tmpDir, err := os.MkdirTemp("", "titus-merge-cmd-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Create two sources with duplicate data
+	content := []byte("same content")
+	blobID := types.ComputeBlobID(content)
+
+	source1Path := filepath.Join(tmpDir, "source1.db")
+	source1, err := store.NewSQLite(source1Path)
+	require.NoError(t, err)
+	err = source1.AddBlob(blobID, int64(len(content)))
+	require.NoError(t, err)
+	err = source1.AddFinding(&types.Finding{ID: "same-finding", RuleID: "rule1"})
+	require.NoError(t, err)
+	source1.Close()
+
+	source2Path := filepath.Join(tmpDir, "source2.db")
+	source2, err := store.NewSQLite(source2Path)
+	require.NoError(t, err)
+	err = source2.AddBlob(blobID, int64(len(content)))
+	require.NoError(t, err)
+	err = source2.AddFinding(&types.Finding{ID: "same-finding", RuleID: "rule1"})
+	require.NoError(t, err)
+	source2.Close()
+
+	// Run merge command
+	destPath := filepath.Join(tmpDir, "merged.db")
+	var buf bytes.Buffer
+	cmd := newMergeCmd()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{source1Path, source2Path, "--output", destPath})
+
+	err = cmd.Execute()
+	require.NoError(t, err)
+
+	// Verify output shows deduplication (only 1 blob, 1 finding even though 2 sources)
+	output := buf.String()
+	assert.Contains(t, output, "Blobs merged: 1")
+	assert.Contains(t, output, "Findings merged: 1")
+}
+
+func TestMergeCmd_FailsWithInvalidSource(t *testing.T) {
+	// Create temp directory
+	tmpDir, err := os.MkdirTemp("", "titus-merge-cmd-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Run merge command with non-existent source
+	destPath := filepath.Join(tmpDir, "merged.db")
+	cmd := newMergeCmd()
+	cmd.SetArgs([]string{"/nonexistent/source1.db", "/nonexistent/source2.db", "--output", destPath})
+
+	err = cmd.Execute()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "merge failed")
+}

--- a/cmd/titus/root.go
+++ b/cmd/titus/root.go
@@ -26,6 +26,7 @@ func init() {
 	rootCmd.AddCommand(scanCmd)
 	rootCmd.AddCommand(rulesCmd)
 	rootCmd.AddCommand(versionCmd)
+	rootCmd.AddCommand(mergeCmd)
 }
 
 // Execute runs the root command.

--- a/pkg/store/merge.go
+++ b/pkg/store/merge.go
@@ -1,0 +1,262 @@
+package store
+
+import (
+	"database/sql"
+	"fmt"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// MergeConfig configures the merge operation.
+type MergeConfig struct {
+	// SourcePaths are the database files to merge from.
+	SourcePaths []string
+	// DestPath is the destination database file.
+	DestPath string
+}
+
+// MergeStats tracks merge operation statistics.
+type MergeStats struct {
+	BlobsMerged      int
+	MatchesMerged    int
+	FindingsMerged   int
+	ProvenanceMerged int
+	SourcesProcessed int
+}
+
+// Merge combines multiple Titus databases into one.
+// Deduplication is handled via INSERT OR IGNORE on primary keys.
+func Merge(cfg MergeConfig) (*MergeStats, error) {
+	if len(cfg.SourcePaths) == 0 {
+		return nil, fmt.Errorf("no source databases specified")
+	}
+	if cfg.DestPath == "" {
+		return nil, fmt.Errorf("destination path is required")
+	}
+
+	// Open/create destination database
+	destDB, err := sql.Open("sqlite3", cfg.DestPath)
+	if err != nil {
+		return nil, fmt.Errorf("opening destination database: %w", err)
+	}
+	defer destDB.Close()
+
+	// Initialize schema on destination
+	if err := CreateSchema(destDB); err != nil {
+		return nil, fmt.Errorf("creating schema: %w", err)
+	}
+
+	stats := &MergeStats{}
+
+	// Process each source database
+	for _, sourcePath := range cfg.SourcePaths {
+		sourceStats, err := mergeFrom(destDB, sourcePath)
+		if err != nil {
+			return stats, fmt.Errorf("merging from %s: %w", sourcePath, err)
+		}
+		stats.BlobsMerged += sourceStats.BlobsMerged
+		stats.MatchesMerged += sourceStats.MatchesMerged
+		stats.FindingsMerged += sourceStats.FindingsMerged
+		stats.ProvenanceMerged += sourceStats.ProvenanceMerged
+		stats.SourcesProcessed++
+	}
+
+	return stats, nil
+}
+
+// mergeFrom copies data from a source database to the destination.
+func mergeFrom(destDB *sql.DB, sourcePath string) (*MergeStats, error) {
+	// Open source database
+	sourceDB, err := sql.Open("sqlite3", sourcePath)
+	if err != nil {
+		return nil, fmt.Errorf("opening source database: %w", err)
+	}
+	defer sourceDB.Close()
+
+	stats := &MergeStats{}
+
+	// Start transaction for efficiency
+	tx, err := destDB.Begin()
+	if err != nil {
+		return nil, fmt.Errorf("starting transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	// Merge blobs
+	blobCount, err := mergeBlobs(tx, sourceDB)
+	if err != nil {
+		return nil, fmt.Errorf("merging blobs: %w", err)
+	}
+	stats.BlobsMerged = blobCount
+
+	// Merge matches
+	matchCount, err := mergeMatches(tx, sourceDB)
+	if err != nil {
+		return nil, fmt.Errorf("merging matches: %w", err)
+	}
+	stats.MatchesMerged = matchCount
+
+	// Merge findings
+	findingCount, err := mergeFindings(tx, sourceDB)
+	if err != nil {
+		return nil, fmt.Errorf("merging findings: %w", err)
+	}
+	stats.FindingsMerged = findingCount
+
+	// Merge provenance
+	provCount, err := mergeProvenance(tx, sourceDB)
+	if err != nil {
+		return nil, fmt.Errorf("merging provenance: %w", err)
+	}
+	stats.ProvenanceMerged = provCount
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("committing transaction: %w", err)
+	}
+
+	return stats, nil
+}
+
+func mergeBlobs(tx *sql.Tx, sourceDB *sql.DB) (int, error) {
+	rows, err := sourceDB.Query("SELECT id, size FROM blobs")
+	if err != nil {
+		return 0, err
+	}
+	defer rows.Close()
+
+	stmt, err := tx.Prepare("INSERT OR IGNORE INTO blobs (id, size) VALUES (?, ?)")
+	if err != nil {
+		return 0, err
+	}
+	defer stmt.Close()
+
+	count := 0
+	for rows.Next() {
+		var id string
+		var size int64
+		if err := rows.Scan(&id, &size); err != nil {
+			return count, err
+		}
+		result, err := stmt.Exec(id, size)
+		if err != nil {
+			return count, err
+		}
+		affected, _ := result.RowsAffected()
+		if affected > 0 {
+			count++
+		}
+	}
+	return count, rows.Err()
+}
+
+func mergeMatches(tx *sql.Tx, sourceDB *sql.DB) (int, error) {
+	rows, err := sourceDB.Query(`
+		SELECT blob_id, rule_id, structural_id, offset_start, offset_end,
+		       snippet_before, snippet_matching, snippet_after, groups_json
+		FROM matches
+	`)
+	if err != nil {
+		return 0, err
+	}
+	defer rows.Close()
+
+	stmt, err := tx.Prepare(`
+		INSERT OR IGNORE INTO matches
+		(blob_id, rule_id, structural_id, offset_start, offset_end,
+		 snippet_before, snippet_matching, snippet_after, groups_json)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`)
+	if err != nil {
+		return 0, err
+	}
+	defer stmt.Close()
+
+	count := 0
+	for rows.Next() {
+		var blobID, ruleID, structuralID string
+		var offsetStart, offsetEnd int64
+		var snippetBefore, snippetMatching, snippetAfter []byte
+		var groupsJSON string
+
+		if err := rows.Scan(&blobID, &ruleID, &structuralID, &offsetStart, &offsetEnd,
+			&snippetBefore, &snippetMatching, &snippetAfter, &groupsJSON); err != nil {
+			return count, err
+		}
+		result, err := stmt.Exec(blobID, ruleID, structuralID, offsetStart, offsetEnd,
+			snippetBefore, snippetMatching, snippetAfter, groupsJSON)
+		if err != nil {
+			return count, err
+		}
+		affected, _ := result.RowsAffected()
+		if affected > 0 {
+			count++
+		}
+	}
+	return count, rows.Err()
+}
+
+func mergeFindings(tx *sql.Tx, sourceDB *sql.DB) (int, error) {
+	rows, err := sourceDB.Query("SELECT structural_id, rule_id, groups_json FROM findings")
+	if err != nil {
+		return 0, err
+	}
+	defer rows.Close()
+
+	stmt, err := tx.Prepare("INSERT OR IGNORE INTO findings (structural_id, rule_id, groups_json) VALUES (?, ?, ?)")
+	if err != nil {
+		return 0, err
+	}
+	defer stmt.Close()
+
+	count := 0
+	for rows.Next() {
+		var structuralID, ruleID, groupsJSON string
+		if err := rows.Scan(&structuralID, &ruleID, &groupsJSON); err != nil {
+			return count, err
+		}
+		result, err := stmt.Exec(structuralID, ruleID, groupsJSON)
+		if err != nil {
+			return count, err
+		}
+		affected, _ := result.RowsAffected()
+		if affected > 0 {
+			count++
+		}
+	}
+	return count, rows.Err()
+}
+
+func mergeProvenance(tx *sql.Tx, sourceDB *sql.DB) (int, error) {
+	rows, err := sourceDB.Query("SELECT blob_id, type, path, repo_path, commit_hash FROM provenance")
+	if err != nil {
+		return 0, err
+	}
+	defer rows.Close()
+
+	stmt, err := tx.Prepare(`
+		INSERT OR IGNORE INTO provenance (blob_id, type, path, repo_path, commit_hash)
+		VALUES (?, ?, ?, ?, ?)
+	`)
+	if err != nil {
+		return 0, err
+	}
+	defer stmt.Close()
+
+	count := 0
+	for rows.Next() {
+		var blobID, provType string
+		var path, repoPath, commitHash *string
+		if err := rows.Scan(&blobID, &provType, &path, &repoPath, &commitHash); err != nil {
+			return count, err
+		}
+		result, err := stmt.Exec(blobID, provType, path, repoPath, commitHash)
+		if err != nil {
+			return count, err
+		}
+		affected, _ := result.RowsAffected()
+		if affected > 0 {
+			count++
+		}
+	}
+	return count, rows.Err()
+}

--- a/pkg/store/merge_test.go
+++ b/pkg/store/merge_test.go
@@ -1,0 +1,234 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMerge_EmptySources(t *testing.T) {
+	_, err := Merge(MergeConfig{
+		SourcePaths: []string{},
+		DestPath:    "/tmp/dest.db",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no source databases")
+}
+
+func TestMerge_NoDestination(t *testing.T) {
+	_, err := Merge(MergeConfig{
+		SourcePaths: []string{"/tmp/source.db"},
+		DestPath:    "",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "destination path is required")
+}
+
+func TestMerge_SingleSource(t *testing.T) {
+	// Create temp directory
+	tmpDir, err := os.MkdirTemp("", "titus-merge-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Create source database with data
+	sourcePath := filepath.Join(tmpDir, "source.db")
+	source, err := NewSQLite(sourcePath)
+	require.NoError(t, err)
+
+	// Add test data
+	blobID := types.ComputeBlobID([]byte("test content"))
+	err = source.AddBlob(blobID, 12)
+	require.NoError(t, err)
+
+	finding := &types.Finding{
+		ID:     "finding1",
+		RuleID: "np.test.1",
+		Groups: [][]byte{[]byte("secret")},
+	}
+	err = source.AddFinding(finding)
+	require.NoError(t, err)
+
+	prov := types.FileProvenance{FilePath: "/path/to/file.txt"}
+	err = source.AddProvenance(blobID, prov)
+	require.NoError(t, err)
+
+	source.Close()
+
+	// Merge to destination
+	destPath := filepath.Join(tmpDir, "dest.db")
+	stats, err := Merge(MergeConfig{
+		SourcePaths: []string{sourcePath},
+		DestPath:    destPath,
+	})
+	require.NoError(t, err)
+
+	// Verify stats
+	assert.Equal(t, 1, stats.BlobsMerged)
+	assert.Equal(t, 1, stats.FindingsMerged)
+	assert.Equal(t, 1, stats.ProvenanceMerged)
+	assert.Equal(t, 1, stats.SourcesProcessed)
+
+	// Verify data in destination
+	dest, err := NewSQLite(destPath)
+	require.NoError(t, err)
+	defer dest.Close()
+
+	exists, err := dest.FindingExists("finding1")
+	require.NoError(t, err)
+	assert.True(t, exists)
+}
+
+func TestMerge_MultipleSources(t *testing.T) {
+	// Create temp directory
+	tmpDir, err := os.MkdirTemp("", "titus-merge-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Create source1 with data
+	source1Path := filepath.Join(tmpDir, "source1.db")
+	source1, err := NewSQLite(source1Path)
+	require.NoError(t, err)
+
+	blobID1 := types.ComputeBlobID([]byte("content1"))
+	err = source1.AddBlob(blobID1, 8)
+	require.NoError(t, err)
+	err = source1.AddFinding(&types.Finding{ID: "finding1", RuleID: "rule1"})
+	require.NoError(t, err)
+	source1.Close()
+
+	// Create source2 with data
+	source2Path := filepath.Join(tmpDir, "source2.db")
+	source2, err := NewSQLite(source2Path)
+	require.NoError(t, err)
+
+	blobID2 := types.ComputeBlobID([]byte("content2"))
+	err = source2.AddBlob(blobID2, 8)
+	require.NoError(t, err)
+	err = source2.AddFinding(&types.Finding{ID: "finding2", RuleID: "rule2"})
+	require.NoError(t, err)
+	source2.Close()
+
+	// Merge both sources
+	destPath := filepath.Join(tmpDir, "merged.db")
+	stats, err := Merge(MergeConfig{
+		SourcePaths: []string{source1Path, source2Path},
+		DestPath:    destPath,
+	})
+	require.NoError(t, err)
+
+	// Verify stats
+	assert.Equal(t, 2, stats.BlobsMerged)
+	assert.Equal(t, 2, stats.FindingsMerged)
+	assert.Equal(t, 2, stats.SourcesProcessed)
+
+	// Verify both findings exist in merged database
+	dest, err := NewSQLite(destPath)
+	require.NoError(t, err)
+	defer dest.Close()
+
+	exists1, err := dest.FindingExists("finding1")
+	require.NoError(t, err)
+	assert.True(t, exists1)
+
+	exists2, err := dest.FindingExists("finding2")
+	require.NoError(t, err)
+	assert.True(t, exists2)
+}
+
+func TestMerge_Deduplication(t *testing.T) {
+	// Create temp directory
+	tmpDir, err := os.MkdirTemp("", "titus-merge-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Create two sources with the same data (simulating duplicate finds)
+	content := []byte("duplicate content")
+	blobID := types.ComputeBlobID(content)
+
+	source1Path := filepath.Join(tmpDir, "source1.db")
+	source1, err := NewSQLite(source1Path)
+	require.NoError(t, err)
+	err = source1.AddBlob(blobID, int64(len(content)))
+	require.NoError(t, err)
+	err = source1.AddFinding(&types.Finding{ID: "duplicate-finding", RuleID: "rule1"})
+	require.NoError(t, err)
+	source1.Close()
+
+	source2Path := filepath.Join(tmpDir, "source2.db")
+	source2, err := NewSQLite(source2Path)
+	require.NoError(t, err)
+	// Same blob ID and finding ID
+	err = source2.AddBlob(blobID, int64(len(content)))
+	require.NoError(t, err)
+	err = source2.AddFinding(&types.Finding{ID: "duplicate-finding", RuleID: "rule1"})
+	require.NoError(t, err)
+	source2.Close()
+
+	// Merge both sources
+	destPath := filepath.Join(tmpDir, "merged.db")
+	stats, err := Merge(MergeConfig{
+		SourcePaths: []string{source1Path, source2Path},
+		DestPath:    destPath,
+	})
+	require.NoError(t, err)
+
+	// First source adds the blob and finding
+	// Second source should skip them (deduplication)
+	assert.Equal(t, 1, stats.BlobsMerged, "should only merge 1 unique blob")
+	assert.Equal(t, 1, stats.FindingsMerged, "should only merge 1 unique finding")
+	assert.Equal(t, 2, stats.SourcesProcessed)
+}
+
+func TestMerge_WithMatches(t *testing.T) {
+	// Create temp directory
+	tmpDir, err := os.MkdirTemp("", "titus-merge-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Create source with match data
+	sourcePath := filepath.Join(tmpDir, "source.db")
+	source, err := NewSQLite(sourcePath)
+	require.NoError(t, err)
+
+	blobID := types.ComputeBlobID([]byte("test content with secret"))
+	err = source.AddBlob(blobID, 25)
+	require.NoError(t, err)
+
+	match := &types.Match{
+		BlobID:       blobID,
+		RuleID:       "np.test.1",
+		StructuralID: "match-struct-id",
+		Location: types.Location{
+			Offset: types.OffsetSpan{Start: 10, End: 16},
+		},
+		Snippet: types.Snippet{Matching: []byte("secret")},
+		Groups:  [][]byte{[]byte("secret")},
+	}
+	err = source.AddMatch(match)
+	require.NoError(t, err)
+	source.Close()
+
+	// Merge
+	destPath := filepath.Join(tmpDir, "dest.db")
+	stats, err := Merge(MergeConfig{
+		SourcePaths: []string{sourcePath},
+		DestPath:    destPath,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, stats.MatchesMerged)
+
+	// Verify match exists in destination
+	dest, err := NewSQLite(destPath)
+	require.NoError(t, err)
+	defer dest.Close()
+
+	matches, err := dest.GetMatches(blobID)
+	require.NoError(t, err)
+	assert.Len(t, matches, 1)
+	assert.Equal(t, "np.test.1", matches[0].RuleID)
+}


### PR DESCRIPTION
## Summary
- Add ability to merge multiple Titus databases into a single output database
- Implement `titus merge` command for combining scan results
- Automatic deduplication of blobs, matches, findings, and provenance records
- Statistics reporting shows what was merged and what was deduplicated

## Usage
```bash
# Merge two databases
titus merge scan1.db scan2.db -o combined.db

# Merge multiple databases
titus merge scan1.db scan2.db scan3.db -o combined.db
```

## Use Cases
- Combining results from distributed scans
- Merging results from different scan targets
- Consolidating multiple scan databases

## Test plan
- [x] Unit tests for store.Merge function
- [x] Unit tests for merge command
- [x] Tests for deduplication behavior
- [x] Integration tests pass
- [x] Build succeeds

**Linear:** ENG-1243