### PR TITLE
feat(burp): add feature parity with NoseyParker extension

### DIFF
--- a/burp/src/main/java/com/praetorian/titus/burp/BulkScanHandler.java
+++ b/burp/src/main/java/com/praetorian/titus/burp/BulkScanHandler.java
@@ -1,0 +1,175 @@
+package com.praetorian.titus.burp;
+
+import burp.api.montoya.MontoyaApi;
+import burp.api.montoya.proxy.ProxyHttpRequestResponse;
+
+import javax.swing.*;
+import java.security.MessageDigest;
+import java.util.HexFormat;
+import java.util.List;
+
+/**
+ * Handler for bulk scanning all in-scope responses from proxy history.
+ */
+public class BulkScanHandler {
+
+    private final MontoyaApi api;
+    private final ScanQueue scanQueue;
+    private final FastPathFilter fastPathFilter;
+    private final DedupCache dedupCache;
+    private final SettingsTab settingsTab;
+
+    public BulkScanHandler(MontoyaApi api, ScanQueue scanQueue,
+                           FastPathFilter fastPathFilter, DedupCache dedupCache,
+                           SettingsTab settingsTab) {
+        this.api = api;
+        this.scanQueue = scanQueue;
+        this.fastPathFilter = fastPathFilter;
+        this.dedupCache = dedupCache;
+        this.settingsTab = settingsTab;
+    }
+
+    /**
+     * Scan all in-scope responses from proxy history.
+     * Runs in a background thread to avoid UI freeze.
+     */
+    public void scanAllInScope() {
+        api.logging().logToOutput("Starting bulk scan of in-scope proxy history...");
+
+        SwingWorker<BulkScanResult, Void> worker = new SwingWorker<>() {
+            @Override
+            protected BulkScanResult doInBackground() {
+                int queued = 0;
+                int skipped = 0;
+                int outOfScope = 0;
+                int alreadyScanned = 0;
+
+                List<ProxyHttpRequestResponse> history = api.proxy().history();
+                int total = history.size();
+
+                api.logging().logToOutput("Bulk scan: Processing " + total + " proxy history items");
+
+                boolean scanRequest = settingsTab != null && settingsTab.isRequestScanEnabled();
+
+                for (int i = 0; i < history.size(); i++) {
+                    ProxyHttpRequestResponse item = history.get(i);
+
+                    // Check scope
+                    if (!api.scope().isInScope(item.request().url())) {
+                        outOfScope++;
+                        continue;
+                    }
+
+                    // Check if response exists
+                    if (item.response() == null) {
+                        skipped++;
+                        continue;
+                    }
+
+                    // Fast-path filter
+                    if (!fastPathFilter.shouldScan(item.response())) {
+                        skipped++;
+                        continue;
+                    }
+
+                    // Check content hash to avoid rescanning identical content
+                    String contentHash = hashContent(item.response().body().toString());
+                    String url = item.request().url();
+
+                    // Use dedup cache to check if already processed
+                    if (dedupCache.hasProcessedUrl(url, contentHash)) {
+                        alreadyScanned++;
+                        continue;
+                    }
+
+                    // Queue for scanning
+                    ScanJob job = new ScanJob(
+                        item.request(),
+                        item.response(),
+                        ScanJob.Source.ACTIVE,
+                        scanRequest
+                    );
+
+                    if (scanQueue.enqueue(job)) {
+                        queued++;
+                        dedupCache.markUrlProcessed(url, contentHash);
+                    } else {
+                        skipped++;
+                    }
+
+                    // Progress logging every 500 items
+                    if ((i + 1) % 500 == 0) {
+                        api.logging().logToOutput(String.format(
+                            "Bulk scan progress: %d/%d (queued=%d, skipped=%d)",
+                            i + 1, total, queued, skipped
+                        ));
+                    }
+                }
+
+                return new BulkScanResult(queued, skipped, outOfScope, alreadyScanned, total);
+            }
+
+            @Override
+            protected void done() {
+                try {
+                    BulkScanResult result = get();
+                    String message = String.format(
+                        "Bulk scan complete:\n" +
+                        "  Total items: %d\n" +
+                        "  Queued: %d\n" +
+                        "  Skipped (filtered): %d\n" +
+                        "  Out of scope: %d\n" +
+                        "  Already scanned: %d",
+                        result.total(), result.queued(), result.skipped(),
+                        result.outOfScope(), result.alreadyScanned()
+                    );
+
+                    api.logging().logToOutput(message);
+
+                    JOptionPane.showMessageDialog(
+                        null,
+                        message,
+                        "Bulk Scan Complete",
+                        JOptionPane.INFORMATION_MESSAGE
+                    );
+                } catch (Exception e) {
+                    api.logging().logToError("Bulk scan failed: " + e.getMessage());
+                    JOptionPane.showMessageDialog(
+                        null,
+                        "Bulk scan failed: " + e.getMessage(),
+                        "Bulk Scan Error",
+                        JOptionPane.ERROR_MESSAGE
+                    );
+                }
+            }
+        };
+
+        worker.execute();
+    }
+
+    private String hashContent(String content) {
+        if (content == null || content.isEmpty()) {
+            return "";
+        }
+
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(content.getBytes());
+            return HexFormat.of().formatHex(hash);
+        } catch (Exception e) {
+            // Fallback to simple hash
+            return String.valueOf(content.hashCode());
+        }
+    }
+
+    /**
+     * Result of a bulk scan operation.
+     */
+    public record BulkScanResult(
+        int queued,
+        int skipped,
+        int outOfScope,
+        int alreadyScanned,
+        int total
+    ) {}
+}

--- a/burp/src/main/java/com/praetorian/titus/burp/FindingsExporter.java
+++ b/burp/src/main/java/com/praetorian/titus/burp/FindingsExporter.java
@@ -1,0 +1,155 @@
+package com.praetorian.titus.burp;
+
+import burp.api.montoya.MontoyaApi;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import javax.swing.*;
+import java.awt.*;
+import java.io.File;
+import java.io.FileWriter;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Exports findings to JSON format.
+ */
+public class FindingsExporter {
+
+    private final MontoyaApi api;
+    private final Gson gson;
+
+    public FindingsExporter(MontoyaApi api) {
+        this.api = api;
+        this.gson = new GsonBuilder()
+            .setPrettyPrinting()
+            .create();
+    }
+
+    /**
+     * Export report structure.
+     */
+    public record ExportReport(
+        String export_time,
+        String extension_version,
+        int total_findings,
+        List<ExportedFinding> findings
+    ) {}
+
+    /**
+     * Individual finding in export.
+     */
+    public record ExportedFinding(
+        String rule_id,
+        String secret_preview,
+        List<String> urls,
+        int occurrence_count,
+        String first_seen
+    ) {}
+
+    /**
+     * Export findings to JSON file.
+     * Shows a file chooser dialog and exports on user confirmation.
+     *
+     * @param dedupCache The dedup cache containing findings
+     * @param parent     Parent component for dialogs
+     */
+    public void exportFindings(DedupCache dedupCache, Component parent) {
+        Collection<DedupCache.FindingRecord> findings = dedupCache.getAllFindings();
+
+        if (findings.isEmpty()) {
+            JOptionPane.showMessageDialog(
+                parent,
+                "No findings to export.",
+                "Export Findings",
+                JOptionPane.INFORMATION_MESSAGE
+            );
+            return;
+        }
+
+        // Show file chooser
+        JFileChooser fileChooser = new JFileChooser();
+        fileChooser.setDialogTitle("Export Findings to JSON");
+        fileChooser.setSelectedFile(new File("titus-findings.json"));
+
+        int result = fileChooser.showSaveDialog(parent);
+        if (result != JFileChooser.APPROVE_OPTION) {
+            return;
+        }
+
+        File file = fileChooser.getSelectedFile();
+
+        // Ensure .json extension
+        if (!file.getName().toLowerCase().endsWith(".json")) {
+            file = new File(file.getPath() + ".json");
+        }
+
+        // Check if file exists
+        if (file.exists()) {
+            int overwrite = JOptionPane.showConfirmDialog(
+                parent,
+                "File already exists. Overwrite?",
+                "Confirm Overwrite",
+                JOptionPane.YES_NO_OPTION
+            );
+            if (overwrite != JOptionPane.YES_OPTION) {
+                return;
+            }
+        }
+
+        try {
+            List<ExportedFinding> exportedFindings = new ArrayList<>();
+
+            for (DedupCache.FindingRecord finding : findings) {
+                exportedFindings.add(new ExportedFinding(
+                    finding.ruleId,
+                    maskSecret(finding.secretPreview),
+                    new ArrayList<>(finding.urls),
+                    finding.occurrenceCount,
+                    finding.firstSeen != null ? finding.firstSeen.toString() : "unknown"
+                ));
+            }
+
+            ExportReport report = new ExportReport(
+                Instant.now().toString(),
+                "1.0.0",
+                exportedFindings.size(),
+                exportedFindings
+            );
+
+            try (FileWriter writer = new FileWriter(file)) {
+                gson.toJson(report, writer);
+            }
+
+            api.logging().logToOutput("Exported " + exportedFindings.size() + " findings to " + file.getPath());
+
+            JOptionPane.showMessageDialog(
+                parent,
+                "Exported " + exportedFindings.size() + " findings to:\n" + file.getPath(),
+                "Export Complete",
+                JOptionPane.INFORMATION_MESSAGE
+            );
+
+        } catch (Exception e) {
+            api.logging().logToError("Export failed: " + e.getMessage());
+            JOptionPane.showMessageDialog(
+                parent,
+                "Export failed: " + e.getMessage(),
+                "Export Error",
+                JOptionPane.ERROR_MESSAGE
+            );
+        }
+    }
+
+    /**
+     * Mask a secret for export (shows first and last 4 chars).
+     */
+    private String maskSecret(String secret) {
+        if (secret == null || secret.length() < 12) {
+            return secret;
+        }
+        return secret.substring(0, 4) + "..." + secret.substring(secret.length() - 4);
+    }
+}

--- a/burp/src/main/java/com/praetorian/titus/burp/MessagePersistence.java
+++ b/burp/src/main/java/com/praetorian/titus/burp/MessagePersistence.java
@@ -1,0 +1,171 @@
+package com.praetorian.titus.burp;
+
+import burp.api.montoya.MontoyaApi;
+import burp.api.montoya.core.ByteArray;
+import burp.api.montoya.http.message.requests.HttpRequest;
+import burp.api.montoya.http.message.responses.HttpResponse;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+
+/**
+ * Persists and restores HTTP messages across extension reloads.
+ * Uses Burp's persistence API to store serialized messages.
+ */
+public class MessagePersistence {
+
+    private static final String KEY_MESSAGES = "titus.persisted_messages";
+    private static final int MAX_MESSAGES = 1000;
+
+    private final MontoyaApi api;
+    private final Gson gson;
+
+    public MessagePersistence(MontoyaApi api) {
+        this.api = api;
+        this.gson = new GsonBuilder().create();
+    }
+
+    /**
+     * Serializable message format.
+     * Burp HTTP objects cannot be serialized directly, so we store raw bytes.
+     */
+    public record PersistedMessage(
+        String url,
+        String method,
+        String requestBase64,
+        String responseBase64,
+        long timestamp,
+        boolean scanRequest
+    ) {}
+
+    /**
+     * Persist messages from the table model.
+     *
+     * @param entries List of request entries to persist
+     */
+    public void persistMessages(List<RequestsTableModel.RequestEntry> entries) {
+        List<PersistedMessage> messages = new ArrayList<>();
+
+        // Take last MAX_MESSAGES entries
+        int start = Math.max(0, entries.size() - MAX_MESSAGES);
+        for (int i = start; i < entries.size(); i++) {
+            RequestsTableModel.RequestEntry entry = entries.get(i);
+            ScanJob job = entry.scanJob();
+
+            if (job == null || job.request() == null || job.response() == null) {
+                continue;
+            }
+
+            try {
+                String requestBase64 = Base64.getEncoder().encodeToString(
+                    job.request().toByteArray().getBytes()
+                );
+                String responseBase64 = Base64.getEncoder().encodeToString(
+                    job.response().toByteArray().getBytes()
+                );
+
+                messages.add(new PersistedMessage(
+                    job.url(),
+                    job.request().method(),
+                    requestBase64,
+                    responseBase64,
+                    job.queuedAt(),
+                    job.scanRequest()
+                ));
+            } catch (Exception e) {
+                api.logging().logToError("Failed to serialize message: " + e.getMessage());
+            }
+        }
+
+        try {
+            String json = gson.toJson(messages);
+            api.persistence().extensionData().setString(KEY_MESSAGES, json);
+            api.logging().logToOutput("Persisted " + messages.size() + " messages");
+        } catch (Exception e) {
+            api.logging().logToError("Failed to persist messages: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Restore messages from persistence.
+     *
+     * @return List of restored scan jobs
+     */
+    public List<ScanJob> restoreMessages() {
+        List<ScanJob> jobs = new ArrayList<>();
+
+        try {
+            String json = api.persistence().extensionData().getString(KEY_MESSAGES);
+            if (json == null || json.isEmpty()) {
+                return jobs;
+            }
+
+            Type listType = new TypeToken<List<PersistedMessage>>(){}.getType();
+            List<PersistedMessage> messages = gson.fromJson(json, listType);
+
+            if (messages == null) {
+                return jobs;
+            }
+
+            for (PersistedMessage msg : messages) {
+                try {
+                    byte[] requestBytes = Base64.getDecoder().decode(msg.requestBase64());
+                    byte[] responseBytes = Base64.getDecoder().decode(msg.responseBase64());
+
+                    HttpRequest request = HttpRequest.httpRequest(
+                        ByteArray.byteArray(requestBytes)
+                    );
+                    HttpResponse response = HttpResponse.httpResponse(
+                        ByteArray.byteArray(responseBytes)
+                    );
+
+                    jobs.add(new ScanJob(
+                        request,
+                        response,
+                        ScanJob.Source.PASSIVE,
+                        msg.timestamp(),
+                        msg.scanRequest()
+                    ));
+                } catch (Exception e) {
+                    api.logging().logToError("Failed to deserialize message: " + e.getMessage());
+                }
+            }
+
+            api.logging().logToOutput("Restored " + jobs.size() + " messages from persistence");
+
+        } catch (Exception e) {
+            api.logging().logToError("Failed to restore messages: " + e.getMessage());
+        }
+
+        return jobs;
+    }
+
+    /**
+     * Clear persisted messages.
+     */
+    public void clear() {
+        try {
+            api.persistence().extensionData().setString(KEY_MESSAGES, "");
+            api.logging().logToOutput("Cleared persisted messages");
+        } catch (Exception e) {
+            api.logging().logToError("Failed to clear persisted messages: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Check if there are persisted messages.
+     */
+    public boolean hasPersistedMessages() {
+        try {
+            String json = api.persistence().extensionData().getString(KEY_MESSAGES);
+            return json != null && !json.isEmpty() && !json.equals("[]");
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/burp/src/main/java/com/praetorian/titus/burp/RequestsTableModel.java
+++ b/burp/src/main/java/com/praetorian/titus/burp/RequestsTableModel.java
@@ -1,0 +1,159 @@
+package com.praetorian.titus.burp;
+
+import javax.swing.table.AbstractTableModel;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * Custom TableModel for the HTTP requests table.
+ * Stores scanned HTTP requests with method, URL, status, size, and time.
+ */
+public class RequestsTableModel extends AbstractTableModel {
+
+    private static final String[] COLUMNS = {"#", "Method", "URL", "Status", "Size", "Time"};
+    private static final int MAX_ROWS = 1000;
+
+    private final List<RequestEntry> entries = new ArrayList<>();
+    private final SimpleDateFormat timeFormat = new SimpleDateFormat("HH:mm:ss");
+
+    /**
+     * Entry record for table data.
+     */
+    public record RequestEntry(
+        int index,
+        String method,
+        String url,
+        int status,
+        int size,
+        long timestamp,
+        ScanJob scanJob
+    ) {}
+
+    @Override
+    public int getRowCount() {
+        return entries.size();
+    }
+
+    @Override
+    public int getColumnCount() {
+        return COLUMNS.length;
+    }
+
+    @Override
+    public String getColumnName(int column) {
+        return COLUMNS[column];
+    }
+
+    @Override
+    public Class<?> getColumnClass(int column) {
+        return switch (column) {
+            case 0, 3, 4 -> Integer.class;
+            default -> String.class;
+        };
+    }
+
+    @Override
+    public Object getValueAt(int row, int column) {
+        if (row < 0 || row >= entries.size()) {
+            return null;
+        }
+
+        RequestEntry entry = entries.get(row);
+        return switch (column) {
+            case 0 -> entry.index();
+            case 1 -> entry.method();
+            case 2 -> truncateUrl(entry.url(), 80);
+            case 3 -> entry.status();
+            case 4 -> entry.size();
+            case 5 -> formatTime(entry.timestamp());
+            default -> null;
+        };
+    }
+
+    /**
+     * Add an entry from a scan job.
+     * Must be called on EDT (Event Dispatch Thread).
+     */
+    public void addEntry(ScanJob job) {
+        // Enforce max rows (FIFO - remove oldest)
+        if (entries.size() >= MAX_ROWS) {
+            entries.remove(0);
+            fireTableRowsDeleted(0, 0);
+        }
+
+        int responseSize = 0;
+        int status = 0;
+
+        if (job.response() != null) {
+            status = job.response().statusCode();
+            if (job.response().body() != null) {
+                responseSize = job.response().body().length();
+            }
+        }
+
+        RequestEntry entry = new RequestEntry(
+            entries.size() + 1,
+            job.request().method(),
+            job.url(),
+            status,
+            responseSize,
+            job.queuedAt(),
+            job
+        );
+
+        entries.add(entry);
+        int lastRow = entries.size() - 1;
+        fireTableRowsInserted(lastRow, lastRow);
+    }
+
+    /**
+     * Get the scan job at the specified row.
+     */
+    public ScanJob getJobAt(int row) {
+        if (row < 0 || row >= entries.size()) {
+            return null;
+        }
+        return entries.get(row).scanJob();
+    }
+
+    /**
+     * Get all entries (for persistence).
+     */
+    public List<RequestEntry> getEntries() {
+        return new ArrayList<>(entries);
+    }
+
+    /**
+     * Clear all entries.
+     */
+    public void clear() {
+        int size = entries.size();
+        if (size > 0) {
+            entries.clear();
+            fireTableRowsDeleted(0, size - 1);
+        }
+    }
+
+    /**
+     * Get the number of entries.
+     */
+    public int getEntryCount() {
+        return entries.size();
+    }
+
+    private String truncateUrl(String url, int maxLength) {
+        if (url == null) {
+            return "";
+        }
+        if (url.length() <= maxLength) {
+            return url;
+        }
+        return url.substring(0, maxLength - 3) + "...";
+    }
+
+    private String formatTime(long timestamp) {
+        return timeFormat.format(new Date(timestamp));
+    }
+}

--- a/burp/src/main/java/com/praetorian/titus/burp/RequestsView.java
+++ b/burp/src/main/java/com/praetorian/titus/burp/RequestsView.java
@@ -1,0 +1,153 @@
+package com.praetorian.titus.burp;
+
+import burp.api.montoya.MontoyaApi;
+import burp.api.montoya.ui.editor.HttpRequestEditor;
+import burp.api.montoya.ui.editor.HttpResponseEditor;
+
+import javax.swing.*;
+import javax.swing.border.TitledBorder;
+import javax.swing.event.ListSelectionEvent;
+import javax.swing.table.DefaultTableCellRenderer;
+import java.awt.*;
+
+/**
+ * Main panel containing the requests table and split request/response viewers.
+ */
+public class RequestsView extends JPanel {
+
+    private final MontoyaApi api;
+    private final RequestsTableModel tableModel;
+    private final JTable requestsTable;
+    private final HttpRequestEditor requestEditor;
+    private final HttpResponseEditor responseEditor;
+    private final JLabel statusLabel;
+
+    public RequestsView(MontoyaApi api, RequestsTableModel tableModel) {
+        this.api = api;
+        this.tableModel = tableModel;
+
+        setLayout(new BorderLayout());
+        setBorder(new TitledBorder("Scanned Requests"));
+
+        // Create table
+        requestsTable = new JTable(tableModel);
+        requestsTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        requestsTable.setAutoResizeMode(JTable.AUTO_RESIZE_LAST_COLUMN);
+        requestsTable.getSelectionModel().addListSelectionListener(this::onSelectionChanged);
+
+        // Configure column widths
+        configureColumnWidths();
+
+        // Center-align numeric columns
+        DefaultTableCellRenderer centerRenderer = new DefaultTableCellRenderer();
+        centerRenderer.setHorizontalAlignment(JLabel.CENTER);
+        requestsTable.getColumnModel().getColumn(0).setCellRenderer(centerRenderer); // #
+        requestsTable.getColumnModel().getColumn(3).setCellRenderer(centerRenderer); // Status
+        requestsTable.getColumnModel().getColumn(4).setCellRenderer(centerRenderer); // Size
+
+        JScrollPane tableScroll = new JScrollPane(requestsTable);
+        tableScroll.setPreferredSize(new Dimension(800, 200));
+
+        // Create Burp editors (read-only)
+        requestEditor = api.userInterface().createHttpRequestEditor();
+        responseEditor = api.userInterface().createHttpResponseEditor();
+
+        // Wrap editors in panels with labels
+        JPanel requestPanel = createEditorPanel("Request", requestEditor.uiComponent());
+        JPanel responsePanel = createEditorPanel("Response", responseEditor.uiComponent());
+
+        // Split pane for request/response (horizontal)
+        JSplitPane viewerSplit = new JSplitPane(
+            JSplitPane.HORIZONTAL_SPLIT,
+            requestPanel,
+            responsePanel
+        );
+        viewerSplit.setResizeWeight(0.5);
+        viewerSplit.setOneTouchExpandable(true);
+
+        // Main split: table above, viewers below (vertical)
+        JSplitPane mainSplit = new JSplitPane(
+            JSplitPane.VERTICAL_SPLIT,
+            tableScroll,
+            viewerSplit
+        );
+        mainSplit.setResizeWeight(0.35);
+        mainSplit.setOneTouchExpandable(true);
+
+        add(mainSplit, BorderLayout.CENTER);
+
+        // Status bar
+        statusLabel = new JLabel("0 requests");
+        statusLabel.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
+        add(statusLabel, BorderLayout.SOUTH);
+    }
+
+    private void configureColumnWidths() {
+        requestsTable.getColumnModel().getColumn(0).setPreferredWidth(40);   // #
+        requestsTable.getColumnModel().getColumn(0).setMaxWidth(60);
+        requestsTable.getColumnModel().getColumn(1).setPreferredWidth(60);   // Method
+        requestsTable.getColumnModel().getColumn(1).setMaxWidth(80);
+        requestsTable.getColumnModel().getColumn(2).setPreferredWidth(400);  // URL
+        requestsTable.getColumnModel().getColumn(3).setPreferredWidth(50);   // Status
+        requestsTable.getColumnModel().getColumn(3).setMaxWidth(70);
+        requestsTable.getColumnModel().getColumn(4).setPreferredWidth(70);   // Size
+        requestsTable.getColumnModel().getColumn(4).setMaxWidth(100);
+        requestsTable.getColumnModel().getColumn(5).setPreferredWidth(70);   // Time
+        requestsTable.getColumnModel().getColumn(5).setMaxWidth(100);
+    }
+
+    private JPanel createEditorPanel(String title, Component editor) {
+        JPanel panel = new JPanel(new BorderLayout());
+        panel.setBorder(BorderFactory.createTitledBorder(title));
+        panel.add(editor, BorderLayout.CENTER);
+        return panel;
+    }
+
+    private void onSelectionChanged(ListSelectionEvent e) {
+        if (e.getValueIsAdjusting()) {
+            return;
+        }
+
+        int selectedRow = requestsTable.getSelectedRow();
+        if (selectedRow >= 0) {
+            ScanJob job = tableModel.getJobAt(selectedRow);
+            if (job != null) {
+                requestEditor.setRequest(job.request());
+                responseEditor.setResponse(job.response());
+            }
+        }
+    }
+
+    /**
+     * Update the status label with current count.
+     */
+    public void updateStatus() {
+        int count = tableModel.getEntryCount();
+        statusLabel.setText(count + " request" + (count != 1 ? "s" : ""));
+    }
+
+    /**
+     * Get the underlying table component.
+     */
+    public JTable getTable() {
+        return requestsTable;
+    }
+
+    /**
+     * Get the table model.
+     */
+    public RequestsTableModel getTableModel() {
+        return tableModel;
+    }
+
+    /**
+     * Clear all entries and viewers.
+     */
+    public void clear() {
+        tableModel.clear();
+        // Clear editors by setting null (creates blank display)
+        requestEditor.setRequest(null);
+        responseEditor.setResponse(null);
+        updateStatus();
+    }
+}

--- a/burp/src/main/java/com/praetorian/titus/burp/ScanJob.java
+++ b/burp/src/main/java/com/praetorian/titus/burp/ScanJob.java
@@ -10,7 +10,8 @@ public record ScanJob(
     HttpRequest request,
     HttpResponse response,
     Source source,
-    long queuedAt
+    long queuedAt,
+    boolean scanRequest
 ) {
     /**
      * Source of the scan job.
@@ -21,10 +22,17 @@ public record ScanJob(
     }
 
     /**
-     * Create a scan job with current timestamp.
+     * Create a scan job with current timestamp (response only).
      */
     public ScanJob(HttpRequest request, HttpResponse response, Source source) {
-        this(request, response, source, System.currentTimeMillis());
+        this(request, response, source, System.currentTimeMillis(), false);
+    }
+
+    /**
+     * Create a scan job with current timestamp and request scanning option.
+     */
+    public ScanJob(HttpRequest request, HttpResponse response, Source source, boolean scanRequest) {
+        this(request, response, source, System.currentTimeMillis(), scanRequest);
     }
 
     /**

--- a/burp/src/main/java/com/praetorian/titus/burp/ScanParametersPanel.java
+++ b/burp/src/main/java/com/praetorian/titus/burp/ScanParametersPanel.java
@@ -1,0 +1,155 @@
+package com.praetorian.titus.burp;
+
+import burp.api.montoya.MontoyaApi;
+
+import javax.swing.*;
+import javax.swing.border.TitledBorder;
+import java.awt.*;
+
+/**
+ * UI panel for configurable scan parameters.
+ */
+public class ScanParametersPanel extends JPanel {
+
+    private static final String KEY_WORKERS = "titus.workers";
+    private static final String KEY_MAX_FILE_SIZE = "titus.max_file_size_mb";
+    private static final String KEY_SNIPPET_LENGTH = "titus.snippet_length";
+
+    private static final int DEFAULT_WORKERS = 4;
+    private static final int DEFAULT_MAX_FILE_SIZE_MB = 10;
+    private static final int DEFAULT_SNIPPET_LENGTH = 256;
+
+    private final MontoyaApi api;
+    private final JSpinner workersSpinner;
+    private final JSpinner maxFileSizeSpinner;
+    private final JSpinner snippetLengthSpinner;
+
+    private ParameterChangeListener changeListener;
+
+    /**
+     * Listener for parameter changes.
+     */
+    public interface ParameterChangeListener {
+        void onParametersChanged(int workers, int maxFileSizeMB, int snippetLength);
+    }
+
+    public ScanParametersPanel(MontoyaApi api) {
+        this.api = api;
+
+        setBorder(new TitledBorder("Scan Parameters"));
+        setLayout(new GridBagLayout());
+        setMaximumSize(new Dimension(Integer.MAX_VALUE, 150));
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.insets = new Insets(5, 5, 5, 5);
+        gbc.anchor = GridBagConstraints.WEST;
+
+        // Workers
+        gbc.gridx = 0; gbc.gridy = 0;
+        add(new JLabel("Worker threads:"), gbc);
+        gbc.gridx = 1;
+        workersSpinner = new JSpinner(new SpinnerNumberModel(DEFAULT_WORKERS, 1, 16, 1));
+        workersSpinner.setPreferredSize(new Dimension(60, 25));
+        add(workersSpinner, gbc);
+        gbc.gridx = 2;
+        JLabel workersHint = new JLabel("(1-16)");
+        workersHint.setForeground(Color.GRAY);
+        add(workersHint, gbc);
+
+        // Max file size
+        gbc.gridx = 0; gbc.gridy = 1;
+        add(new JLabel("Max file size:"), gbc);
+        gbc.gridx = 1;
+        maxFileSizeSpinner = new JSpinner(new SpinnerNumberModel(DEFAULT_MAX_FILE_SIZE_MB, 1, 100, 1));
+        maxFileSizeSpinner.setPreferredSize(new Dimension(60, 25));
+        add(maxFileSizeSpinner, gbc);
+        gbc.gridx = 2;
+        JLabel sizeHint = new JLabel("MB");
+        sizeHint.setForeground(Color.GRAY);
+        add(sizeHint, gbc);
+
+        // Snippet length
+        gbc.gridx = 0; gbc.gridy = 2;
+        add(new JLabel("Snippet length:"), gbc);
+        gbc.gridx = 1;
+        snippetLengthSpinner = new JSpinner(new SpinnerNumberModel(DEFAULT_SNIPPET_LENGTH, 64, 1024, 64));
+        snippetLengthSpinner.setPreferredSize(new Dimension(60, 25));
+        add(snippetLengthSpinner, gbc);
+        gbc.gridx = 2;
+        JLabel snippetHint = new JLabel("chars");
+        snippetHint.setForeground(Color.GRAY);
+        add(snippetHint, gbc);
+
+        // Note about restart
+        gbc.gridx = 0; gbc.gridy = 3; gbc.gridwidth = 3;
+        JLabel noteLabel = new JLabel("Note: Changes take effect on next scan batch");
+        noteLabel.setForeground(Color.GRAY);
+        noteLabel.setFont(noteLabel.getFont().deriveFont(Font.ITALIC, 11f));
+        add(noteLabel, gbc);
+
+        // Add change listeners to persist settings
+        workersSpinner.addChangeListener(e -> saveSettings());
+        maxFileSizeSpinner.addChangeListener(e -> saveSettings());
+        snippetLengthSpinner.addChangeListener(e -> saveSettings());
+
+        // Load saved values
+        loadSettings();
+    }
+
+    public void setChangeListener(ParameterChangeListener listener) {
+        this.changeListener = listener;
+    }
+
+    public int getWorkers() {
+        return (Integer) workersSpinner.getValue();
+    }
+
+    public int getMaxFileSizeMB() {
+        return (Integer) maxFileSizeSpinner.getValue();
+    }
+
+    public int getSnippetLength() {
+        return (Integer) snippetLengthSpinner.getValue();
+    }
+
+    /**
+     * Get max file size in bytes.
+     */
+    public int getMaxFileSizeBytes() {
+        return getMaxFileSizeMB() * 1024 * 1024;
+    }
+
+    private void loadSettings() {
+        try {
+            String workersStr = api.persistence().extensionData().getString(KEY_WORKERS);
+            if (workersStr != null && !workersStr.isEmpty()) {
+                workersSpinner.setValue(Integer.parseInt(workersStr));
+            }
+
+            String maxSizeStr = api.persistence().extensionData().getString(KEY_MAX_FILE_SIZE);
+            if (maxSizeStr != null && !maxSizeStr.isEmpty()) {
+                maxFileSizeSpinner.setValue(Integer.parseInt(maxSizeStr));
+            }
+
+            String snippetStr = api.persistence().extensionData().getString(KEY_SNIPPET_LENGTH);
+            if (snippetStr != null && !snippetStr.isEmpty()) {
+                snippetLengthSpinner.setValue(Integer.parseInt(snippetStr));
+            }
+        } catch (Exception e) {
+            api.logging().logToError("Failed to load scan parameters: " + e.getMessage());
+        }
+    }
+
+    private void saveSettings() {
+        try {
+            api.persistence().extensionData().setString(KEY_WORKERS, String.valueOf(getWorkers()));
+            api.persistence().extensionData().setString(KEY_MAX_FILE_SIZE, String.valueOf(getMaxFileSizeMB()));
+            api.persistence().extensionData().setString(KEY_SNIPPET_LENGTH, String.valueOf(getSnippetLength()));
+
+            if (changeListener != null) {
+                changeListener.onParametersChanged(getWorkers(), getMaxFileSizeMB(), getSnippetLength());
+            }
+        } catch (Exception e) {
+            api.logging().logToError("Failed to save scan parameters: " + e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Brings the Titus Burp extension to feature parity with the NoseyParker Burp extension by implementing 6 new features:

- **Requests Table UI**: New "Requests" tab with method/URL/status/size columns and synchronized request/response viewers using Burp's native editors
- **Bulk Scan**: "Scan All In-Scope Responses" context menu option with SwingWorker background processing and progress dialog
- **Request Scanning**: Option to scan request bodies in addition to responses
- **Configurable Parameters**: UI controls for workers, max file size, and snippet length settings
- **Message Persistence**: HTTP messages persist across extension reloads using Burp's persistence API with Base64 encoding
- **Export Findings**: JSON export with masked secrets and file chooser dialog

Also includes a fix for Gson serialization of `java.time.Instant` with a custom TypeAdapter.

### New Files (6)
| File | Purpose |
|------|---------|
| `BulkScanHandler.java` | Background bulk scanning with deduplication |
| `FindingsExporter.java` | JSON export with masked secrets |
| `MessagePersistence.java` | HTTP message serialization/persistence |
| `RequestsTableModel.java` | Custom table model with FIFO eviction |
| `RequestsView.java` | Split-pane request/response viewers |
| `ScanParametersPanel.java` | Configurable scan parameter UI |

### Modified Files (6)
| File | Changes |
|------|---------|
| `DedupCache.java` | URL tracking for bulk scan dedup, Instant TypeAdapter |
| `FastPathFilter.java` | Configurable max size, request scanning filter |
| `ScanJob.java` | Added `scanRequest` field |
| `ScanQueue.java` | Listener interface, request body scanning |
| `SettingsTab.java` | Tabbed UI, persistence integration, export button |
| `TitusExtension.java` | Bulk scan handler, context menu |

## Test plan

- [x] Extension loads without errors in Burp Suite
- [x] "Titus" tab shows "Settings" and "Requests" sub-tabs
- [x] Passive scanning populates Requests table
- [x] Clicking table row shows request/response in viewers
- [x] "Scan request bodies" checkbox enables request scanning
- [x] Right-click → "Scan All In-Scope Responses" works
- [x] "Export Findings to JSON" exports correctly
- [x] Requests persist after extension reload
- [x] Dedup cache persists without Instant serialization errors