### PR TITLE
fix(rules): increase reCAPTCHA pattern distance to handle JSON configs

### DIFF
--- a/pkg/rule/rules/recaptcha.yml
+++ b/pkg/rule/rules/recaptcha.yml
@@ -4,7 +4,7 @@ rules:
     pattern: |
       (?xi)
       recaptcha
-      (?:.|[\n\r]){0,16}?
+      (?:.|[\n\r]){0,40}?
       \b
       (
         6l[c-f][a-z0-9_-].{36}
@@ -16,6 +16,7 @@ rules:
     examples:
       - recaptcha apikey = 6Lcr--w-BBBBBw-w-w----w-w-www-www--ww-w-
       - recaptcha_secret = 6Lcw--w-AAAAAw-w-w----w-w-www-www--ww-w-
+      - '"recaptcha": { "site_key": "6Lcs--w-AAAAAw-w-w----w-w-www-www--ww-w-" }'
     validation:
       type: Http
       content:


### PR DESCRIPTION
## Summary
- Increased reCAPTCHA pattern distance from `{0,16}` to `{0,40}` characters
- Added JSON config example to test cases

## Problem
The previous pattern required `recaptcha` to appear within 16 characters of the key. This missed valid detections in JSON config files with standard formatting:

```json
"recaptcha": {
  "site_key": "6LesCQEbAAAAAPncX6AwaRN93XCHX6Zq9oSkze0K"
}
```

The distance between `recaptcha` and the key in formatted JSON is ~18+ characters (`": {\n  "site_key": "`), exceeding the 16-char limit.

## Solution
Increased the allowed distance from `{0,16}` to `{0,40}` to accommodate standard JSON formatting while still maintaining context relevance.

## Test plan
- [x] Tested against real-world config file that was previously missing reCAPTCHA detection
- [x] Verified `go test ./pkg/rule/...` passes
- [x] Built and ran scan - now detects reCAPTCHA keys in JSON configs