### PR TITLE
fix: default --output to :memory: for pure Go builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,19 @@ titus scan --directory path/to/dir
 titus scan --file config.json --rules custom-rules.json
 ```
 
+### Output Options
+
+The `--output` flag controls where scan results are stored during a scan:
+
+- `:memory:` (default) — results are held in-memory for the duration of the scan. This is the default and works on all platforms.
+- `<file-path>` — writes results to a SQLite database file (requires a CGO-enabled build with SQLite support; not available in prebuilt release binaries).
+
+Results can also be emitted to stdout in different formats using `--format`:
+
+- `human` (default) — summarized findings printed to the console
+- `json` — full match details as JSON
+- `sarif` — SARIF 2.1.0 for CI/CD integration
+
 ### Server Mode (for Burp Integration)
 
 Titus can run as a streaming server for integration with Burp Suite:

--- a/cmd/titus/scan.go
+++ b/cmd/titus/scan.go
@@ -43,7 +43,7 @@ func init() {
 	scanCmd.Flags().StringVar(&scanRulesPath, "rules", "", "Path to custom rules file or directory")
 	scanCmd.Flags().StringVar(&scanRulesInclude, "rules-include", "", "Include rules matching regex pattern (comma-separated)")
 	scanCmd.Flags().StringVar(&scanRulesExclude, "rules-exclude", "", "Exclude rules matching regex pattern (comma-separated)")
-	scanCmd.Flags().StringVar(&scanOutputPath, "output", "titus.db", "Output database path")
+	scanCmd.Flags().StringVar(&scanOutputPath, "output", ":memory:", "Output store path (:memory: for in-memory, or a file path if SQLite is available)")
 	scanCmd.Flags().StringVar(&scanOutputFormat, "format", "human", "Output format: json, sarif, human")
 	scanCmd.Flags().BoolVar(&scanGit, "git", false, "Treat target as git repository (enumerate git history)")
 	scanCmd.Flags().Int64Var(&scanMaxFileSize, "max-file-size", 10*1024*1024, "Maximum file size to scan (bytes)")

--- a/cmd/titus/scan_test.go
+++ b/cmd/titus/scan_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScanCommand_Exists(t *testing.T) {
+	cmd, _, err := rootCmd.Find([]string{"scan"})
+	require.NoError(t, err)
+	assert.Equal(t, "scan", cmd.Name())
+}
+
+func TestScanCommand_DefaultOutputIsMemory(t *testing.T) {
+	cmd, _, err := rootCmd.Find([]string{"scan"})
+	require.NoError(t, err)
+
+	flag := cmd.Flags().Lookup("output")
+	require.NotNil(t, flag, "--output flag should exist")
+	assert.Equal(t, ":memory:", flag.DefValue,
+		"default --output should be :memory: so scan works without SQLite")
+}

--- a/pkg/store/store_default_test.go
+++ b/pkg/store/store_default_test.go
@@ -1,0 +1,29 @@
+//go:build !wasm
+
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew_MemoryPath(t *testing.T) {
+	s, err := New(Config{Path: ":memory:"})
+	require.NoError(t, err)
+	require.NotNil(t, s)
+	defer s.Close()
+}
+
+func TestNew_EmptyPath(t *testing.T) {
+	_, err := New(Config{Path: ""})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "path is required")
+}
+
+func TestNew_FilePathReturnsError(t *testing.T) {
+	_, err := New(Config{Path: "titus.db"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "file-based storage not supported")
+}


### PR DESCRIPTION
## Summary
- Changed `--output` flag default from `"titus.db"` to `":memory:"` so the `scan` command works out of the box on pure Go builds (no SQLite/CGO required)
- Added "Output Options" section to README documenting `--output` and `--format` flags
- Added regression tests for the default flag value and `store.New()` on native builds

Fixes [LAB-697](https://linear.app/praetorianlabs/issue/LAB-697/fix-scan-command-failing-with-file-based-storage-not-supported-error)

## Test plan
- [x] `TestScanCommand_DefaultOutputIsMemory` — verifies default is `:memory:`
- [x] `TestNew_MemoryPath` / `TestNew_EmptyPath` / `TestNew_FilePathReturnsError` — covers all `store.New()` paths
- [x] Full test suite passes (`go test ./...` — 11 packages)
- [x] Build succeeds with `CGO_ENABLED=0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)