### PR TITLE
fix(okta): add named capture group and validator

### DIFF
--- a/pkg/rule/rules/okta.yml
+++ b/pkg/rule/rules/okta.yml
@@ -7,7 +7,7 @@ rules:
   # bit more restrictive here, not allowing `-` at the end, so that we can use
   # the word boundary `\b` zero-width assertion, and also requiring "okta" or
   # "ssws" out front.
-  pattern: '(?i)(?s)(?:okta|ssws).{0,40}\b(00[a-z0-9_-]{39}[a-z0-9_])\b'
+  pattern: '(?i)(?s)(?:okta|ssws).{0,40}\b(?P<token>00[a-z0-9_-]{39}[a-z0-9_])\b'
 
   categories: [api, secret]
 

--- a/pkg/validator/validators/okta.yaml
+++ b/pkg/validator/validators/okta.yaml
@@ -1,0 +1,29 @@
+# pkg/validator/validators/okta.yaml
+# NOTE: Rules using this validator must define named capture groups in their regex patterns.
+# Expected named group: "token" (e.g., pattern: (?P<token>00[a-z0-9_-]{39}[a-z0-9_]))
+#
+# LIMITATION: Okta API tokens are org-specific. Validation requires knowing the Okta
+# org domain (e.g., dev-123456.okta.com). The current regex does not capture the domain.
+#
+# For full validation, either:
+# 1. Configure OKTA_DOMAIN environment variable
+# 2. Use a Go validator that extracts domain from surrounding context
+# 3. Manually test with known org URLs
+#
+# Reference: https://developer.okta.com/docs/guides/create-an-api-token/main/
+validators:
+  - name: okta-api-token
+    rule_ids:
+      - np.okta.1
+    http:
+      method: GET
+      # URL requires org-specific domain - use OKTA_DOMAIN env var or configure manually
+      # Example: https://dev-123456.okta.com/api/v1/users/me
+      url: https://${OKTA_DOMAIN}/api/v1/users/me
+      auth:
+        type: header
+        header_name: Authorization
+        header_value: "SSWS ${token}"
+        secret_group: token  # Named capture group from regex pattern
+      success_codes: [200]
+      failure_codes: [401, 403]


### PR DESCRIPTION
## Summary

- Fix `np.okta.1` rule to use named capture group for validator compatibility
- Add Okta API token validator configuration

## Changes

- `pkg/rule/rules/okta.yml` - Changed anonymous capture `(00[...])` to named capture `(?P<token>00[...])`
- `pkg/validator/validators/okta.yaml` - New validator file for HTTP-based token validation

## Audit Finding

The Okta API Token rule (`np.okta.1`) was using an anonymous capture group, which prevents Titus validators from extracting the secret for validation. This fix converts it to a named capture group.

## Known Limitation

**Okta tokens are org-specific.** Unlike services like GitHub or Stripe, Okta API tokens require knowing the organization's domain (e.g., `dev-123456.okta.com`) to validate. The validator is configured to use `${OKTA_DOMAIN}` environment variable.

**Options for full validation:**
1. Set `OKTA_DOMAIN` env var before running `titus scan --validate`
2. Implement a Go validator that extracts domain from surrounding context (e.g., from config files, env vars in the same file)
3. Accept that Okta validation requires manual domain configuration

## Test plan

- [x] `titus rules list` shows np.okta.1
- [x] `TestLoadEmbeddedValidators` passes  
- [x] Test scan detects Okta tokens correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)