### PR TITLE
fix(looker): restrict kingfisher.looker.1 pattern to .looker.com domains

### DIFF
--- a/pkg/rule/rules/looker.yml
+++ b/pkg/rule/rules/looker.yml
@@ -8,7 +8,7 @@ rules:
       (?xi)
       \b
       (
-        https?://[a-z0-9.-]+(?::\d{2,5})?
+        https?://[a-z0-9.-]+\.looker\.com(?::\d{2,5})?
       )
       (?:/api/(?:4\.0|3\.1))?
       \b
@@ -16,6 +16,11 @@ rules:
       - https://example.cloud.looker.com
       - https://example.cloud.looker.com:19999
       - https://example.cloud.looker.com:19999/api/4.0
+    negative_examples:
+      - https://graph.microsoft.com
+      - https://app-peco.azurewebsites.net
+      - https://login.microsoftonline.com
+      - https://example.azure-api.net
 
   - name: Looker Client ID
     id: kingfisher.looker.2


### PR DESCRIPTION
## Summary

- Fixed `kingfisher.looker.1` (Looker Base URL) rule which was matching **any HTTPS URL** due to overly broad pattern
- Pattern now requires `.looker.com` in the domain to match standard Looker hosting patterns
- Added negative examples to document expected non-matches

## Problem

The original pattern `https?://[a-z0-9.-]+(?::\d{2,5})?` matched any URL, causing false positives like:
- `https://graph.microsoft.com`
- `https://app-peco.azurewebsites.net`
- `https://login.microsoftonline.com`

## Solution

Changed pattern to `https?://[a-z0-9.-]+\.looker\.com(?::\d{2,5})?` which specifically targets Looker URLs.

## Test Results

**Before fix:** 76 matches, 11 findings (9 false positives from `kingfisher.looker.1`)
**After fix:** 3 matches, 3 findings (only real secrets)

## Test plan

- [x] Verified pattern matches valid Looker URLs (`*.looker.com`)
- [x] Verified pattern ignores non-Looker URLs
- [x] Tested against file with known false positives
- [x] Rules load successfully (`titus rules list`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)