### PR TITLE
fix(rapidapi): add named capture group and separate validator file

### DIFF
--- a/pkg/rule/rules/rapidapi.yml
+++ b/pkg/rule/rules/rapidapi.yml
@@ -9,7 +9,7 @@ rules:
       (?:SECRET|PRIVATE|ACCESS|KEY|TOKEN)
       (?:.|[\n\r]){0,32}?
       \b
-      (
+      (?P<key>
         [A-Za-z0-9_-]{50}
       )
       \b
@@ -20,22 +20,9 @@ rules:
     examples:
       - rapidapi_key=abcdefghij1234567890ABCDEFGHIJ1234567890abcdefghij
       - '"rapidapiKey":"ABCDEFGHIJ1234567890abcdefghij1234567890ABCDEFGHIJ"'
+    negative_examples:
+      - rapidapi_example=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+      - rapidapi_key=your_api_key_here_placeholder_text_example_12345
     references:
       - https://docs.rapidapi.com/docs/configuring-api-security
       - https://docs.rapidapi.com/docs/keys-and-key-rotation
-    validation:
-      type: Http
-      content:
-        request:
-          method: GET
-          url: "https://weatherapi-com.p.rapidapi.com/current.json?q=London"
-          headers:
-            x-rapidapi-key: "{{ TOKEN }}"
-            x-rapidapi-host: "weatherapi-com.p.rapidapi.com"
-            Accept: application/json
-          response_matcher:
-            - report_response: true
-            - type: StatusMatch
-              status: [200]
-            - type: WordMatch
-              words: ['"country"']

--- a/pkg/validator/validators/rapidapi.yaml
+++ b/pkg/validator/validators/rapidapi.yaml
@@ -1,0 +1,21 @@
+# pkg/validator/validators/rapidapi.yaml
+# RapidAPI uses custom header authentication (x-rapidapi-key)
+# Validation uses a public API endpoint to test key validity
+validators:
+  - name: rapidapi-key
+    rule_ids:
+      - kingfisher.rapidapi.1
+    http:
+      method: GET
+      url: https://weatherapi-com.p.rapidapi.com/current.json?q=London
+      auth:
+        type: header
+        header_name: x-rapidapi-key
+        secret_group: "key"  # Matches (?P<key>...) in rule regex
+      headers:
+        - name: x-rapidapi-host
+          value: weatherapi-com.p.rapidapi.com
+        - name: Accept
+          value: application/json
+      success_codes: [200]
+      failure_codes: [401, 403]


### PR DESCRIPTION
## Summary

Fixes RapidAPI rule for proper validator integration (LAB-630).

### Issues Found During Audit:
1. **❌ Missing Named Capture Group**: Used `([A-Za-z0-9_-]{50})` instead of `(?P<key>...)`
2. **❌ No Separate Validator File**: Had embedded validation but Titus requires validators in `pkg/validator/validators/`

### Changes:

**Rule (pkg/rule/rules/rapidapi.yml):**
- Convert anonymous capture group to named: `(?P<key>...)`
- Add `negative_examples` for placeholder patterns
- Remove embedded validation block (moved to separate validator)

**New Validator (pkg/validator/validators/rapidapi.yaml):**
- Uses `header` auth type with `x-rapidapi-key` header
- References named capture group: `secret_group: "key"`
- Additional header for `x-rapidapi-host` requirement
- Validates against `weatherapi-com.p.rapidapi.com` endpoint

## Test Results

```
✅ go test ./pkg/validator/... -run TestLoadEmbeddedValidators → PASS
✅ titus rules list | grep rapidapi → kingfisher.rapidapi.1
✅ Named capture group extraction verified:
   NamedGroups: {'key': 'base64-encoded-value'}
```

## Test plan

- [x] Validator loads successfully (TestLoadEmbeddedValidators)
- [x] Rule detects RapidAPI keys
- [x] Named capture group `key` is populated
- [x] Build passes

Closes LAB-630

🤖 Generated with [Claude Code](https://claude.com/claude-code)