### PR TITLE
fix(kubernetes): add named capture groups to bootstrap token rules

### DIFF
--- a/pkg/rule/rules/kubernetes.yml
+++ b/pkg/rule/rules/kubernetes.yml
@@ -13,7 +13,7 @@ rules:
     (?: token | Token | TOKEN | bootstrap | BOOTSTRAP)
     .{0,8}
     \b
-    ([a-z0-9]{6}\.[a-z0-9]{16})
+    (?P<token>[a-z0-9]{6}\.[a-z0-9]{16})
     \b
 
   categories: [api, secret, fuzzy]
@@ -40,8 +40,8 @@ rules:
 
   pattern: |
     (?x)
-    token-id: \s+ ([a-z0-9]{6}) \s+
-    token-secret: \s+ ([a-z0-9]{16}) \b
+    token-id: \s+ (?P<token_id>[a-z0-9]{6}) \s+
+    token-secret: \s+ (?P<token_secret>[a-z0-9]{16}) \b
 
   categories: [api, secret]
 


### PR DESCRIPTION
## Summary

- Convert anonymous capture groups to named capture groups for Kubernetes bootstrap token rules
- `np.kubernetes.1`: Added `(?P<token>...)` for combined token format (e.g., `be8dfd.da8a689a46edc282`)
- `np.kubernetes.2`: Added `(?P<token_id>...)` and `(?P<token_secret>...)` for structured YAML format

This change aligns the Kubernetes rules with Titus validator requirements, which expect named capture groups using `(?P<name>...)` syntax.

**Note:** Kubernetes bootstrap tokens are cluster-specific and cannot be validated via a universal HTTP API endpoint, so these remain detection-only rules (no validator added).

## Test plan

- [x] `go test ./pkg/rule/...` passes
- [x] `titus rules list` shows both rules load correctly
- [x] `titus scan` detects test tokens for both rule patterns
- [x] Verified named capture groups are correctly formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)