### PR TITLE
Add named capture groups and validator for Stripe rules

### DIFF
--- a/pkg/rule/rules/stripe.yml
+++ b/pkg/rule/rules/stripe.yml
@@ -6,7 +6,7 @@ rules:
 - name: Stripe API Key
   id: np.stripe.1
 
-  pattern: '(?i)\b((?:sk|rk)_live_[a-z0-9]{24})\b'
+  pattern: '(?i)\b(?P<key>(?:sk|rk)_live_[a-z0-9]{24})\b'
 
   categories:
   - api
@@ -22,7 +22,7 @@ rules:
 - name: Stripe API Test Key
   id: np.stripe.2
 
-  pattern: '(?i)\b((?:sk|rk)_test_[a-z0-9]{24})\b'
+  pattern: '(?i)\b(?P<key>(?:sk|rk)_test_[a-z0-9]{24})\b'
 
   categories:
   - api

--- a/pkg/validator/validators/stripe.yaml
+++ b/pkg/validator/validators/stripe.yaml
@@ -1,0 +1,16 @@
+# pkg/validator/validators/stripe.yaml
+# Stripe uses Basic Auth with the API key as the password
+# Validation uses the balance endpoint which is read-only
+validators:
+  - name: stripe-api-key
+    rule_ids:
+      - np.stripe.1
+      - np.stripe.2
+    http:
+      method: GET
+      url: https://api.stripe.com/v1/balance
+      auth:
+        type: basic
+        secret_group: "key"
+      success_codes: [200]
+      failure_codes: [401]


### PR DESCRIPTION
## Summary
- Add named capture groups to np.stripe.1 and np.stripe.2 patterns
- Create Stripe validator using Basic Auth with balance endpoint

## Changes
- `pkg/rule/rules/stripe.yml`: Changed `(...)` to `(?P<key>...)` for both rules
- `pkg/validator/validators/stripe.yaml`: New validator file for Stripe API key validation

## Testing
- Verified rules load correctly with `titus rules list`
- Tested scanning with sample Stripe keys
- Validator tests pass (TestLoadEmbeddedValidators)

Fixes LAB-663