### PR TITLE
perf(rules): rewrite 3 rules for Hyperscan compatibility (2.1x faster)

### DIFF
--- a/pkg/matcher/vectorscan.go
+++ b/pkg/matcher/vectorscan.go
@@ -56,10 +56,12 @@ type VectorscanMatcher struct {
 // routed to the regexp2 fallback without attempting Hyperscan compilation.
 // This optimization allows the fast path (single batch compilation) to succeed
 // immediately, reducing initialization time from ~24 seconds to ~100-200ms.
+//
+// Note: np.azure.5, np.redis.1, np.redis.2 were previously incompatible due to
+// lookbehind/lookahead assertions. They have been rewritten to be Hyperscan-
+// compatible by moving the filtering logic to ignore_if_contains.
 var knownIncompatiblePatterns = map[string]bool{
-	"np.azure.5": true,
-	"np.redis.1": true,
-	"np.redis.2": true,
+	// Currently empty - all rules are Hyperscan-compatible
 }
 
 // NewVectorscan creates a new Hyperscan/Vectorscan-based matcher.

--- a/pkg/rule/rules/azure.yml
+++ b/pkg/rule/rules/azure.yml
@@ -182,17 +182,22 @@ rules:
 - name: Azure API Management Subscription Key
   id: np.azure.5
 
+  # Hyperscan-compatible pattern (no lookbehind/lookahead)
+  # Comment filtering and all-zeros/all-f rejection moved to ignore_if_contains
   pattern: |
     (?ix)
-    (?<![#/])                                            # Not immediately preceded by comment markers
-    (?:["']?Ocp-Apim-Subscription-Key["']?|subscription[-_]key)  # Header name with optional quotes
-    \s*[:=]\s*                                           # Separator
-    ['"]?                                                # Optional quote
-    (?P<key>
-      (?!0{32}|f{32})                                    # Reject all-zeros or all-F's patterns
-      [0-9a-f]{32}                                       # 32 hex characters
-    )
-    ['"]?                                                # Optional closing quote
+    (?:["']?Ocp-Apim-Subscription-Key["']?|subscription[-_]key)  (?# Header name with optional quotes )
+    \s*[:=]\s*                                                   (?# Separator )
+    ['"]?                                                        (?# Optional quote )
+    (?P<key>[0-9a-f]{32})                                        (?# 32 hex characters )
+    ['"]?                                                        (?# Optional closing quote )
+
+  pattern_requirements:
+    ignore_if_contains:
+      - "00000000000000000000000000000000"
+      - "ffffffffffffffffffffffffffffffff"
+      - "// "
+      - "# "
 
   references:
   - https://learn.microsoft.com/en-us/azure/api-management/api-management-subscriptions

--- a/pkg/rule/rules/redis.yml
+++ b/pkg/rule/rules/redis.yml
@@ -1,16 +1,17 @@
 rules:
   - id: np.redis.1
     name: Redis URI Connection String
+    # Hyperscan-compatible pattern (no lookbehind)
+    # Comment filtering moved to ignore_if_contains
     pattern: |
       (?xi)
-      (?<! [#/] .{0,50} )                                             (?# not in comments )
       (?: redis | rediss | redis\+sentinel ) ://                      (?# URI scheme )
-        (?: (?P<username>[a-zA-Z0-9%;._~!$&'()*+,;=-]{1,})           (?# username - optional )
+        (?: (?P<username>[a-zA-Z0-9%;._~!$&'()*+,;=-]{1,})            (?# username - optional )
           :
         )?
-        (?P<password>[a-zA-Z0-9%;._~!$&'()*+,;=/+-]{8,})             (?# password - named capture, min 8 chars )
-      @ (?P<host>[a-zA-Z0-9_.-]{1,}) (?: :(?P<port>\d{1,5}))?        (?# hostname and optional port )
-      (?: / (?P<db>\d{1,2}))?                                        (?# optional database number )
+        (?P<password>[a-zA-Z0-9%;._~!$&'()*+,;=/+-]{8,})              (?# password - min 8 chars )
+      @ (?P<host>[a-zA-Z0-9_.-]{1,}) (?: :(?P<port>\d{1,5}))?         (?# hostname and optional port )
+      (?: / (?P<db>\d{1,2}))?                                         (?# optional database number )
       \b
 
     pattern_requirements:
@@ -23,6 +24,8 @@ rules:
         - ":password@"
         - ":secret@"
         - "localhost"
+        - "# redis"
+        - "// redis"
 
     min_entropy: 3.0
 
@@ -55,18 +58,25 @@ rules:
 
   - id: np.redis.2
     name: Python Redis Client Debug Output
+    # Hyperscan-compatible pattern (no lookahead)
+    # "None" filtering moved to ignore_if_contains
     pattern: |
       (?xi)
       redis\.(?:client\.Redis|connection\.(?:Connection|SSLConnection|ConnectionPool))  (?# Python Redis class )
       .*?
       (?:password|passwd|pwd)                                         (?# password key )
       \s*=\s*                                                         (?# equals separator )
-      (?! None )                                                      (?# exclude None )
-      (?P<password>[a-zA-Z0-9+/=_-]{8,})                              (?# password value - named capture )
+      (?P<password>[a-zA-Z0-9+/=_-]{8,})                              (?# password value )
       (?:,|\s)                                                        (?# separator )
       .*?
       host\s*=\s*                                                     (?# host key )
-      (?P<host>[a-zA-Z0-9_.-]+)                                       (?# host value - named capture )
+      (?P<host>[a-zA-Z0-9_.-]+)                                       (?# host value )
+
+    pattern_requirements:
+      ignore_if_contains:
+        - "password=None"
+        - "passwd=None"
+        - "pwd=None"
 
     min_entropy: 3.0
 


### PR DESCRIPTION
## Summary

Rewrote 3 rules that were using Hyperscan-incompatible regex features (lookbehinds, lookaheads) so they can now use the fast Hyperscan engine instead of the slow regexp2 fallback.

**Rules modified:**
- `np.azure.5` - Azure API Management Subscription Key
- `np.redis.1` - Redis URI Connection String  
- `np.redis.2` - Python Redis Client Debug Output

**Changes:**
| Rule | Removed Feature | Replacement |
|------|----------------|-------------|
| np.azure.5 | `(?<![#/])` lookbehind | `ignore_if_contains: ["// ", "# "]` |
| np.azure.5 | `(?!0{32}\|f{32})` lookahead | `ignore_if_contains: ["000...", "fff..."]` |
| np.redis.1 | `(?<! [#/] .{0,50} )` lookbehind | `ignore_if_contains: ["# redis", "// redis"]` |
| np.redis.2 | `(?! None )` lookahead | `ignore_if_contains: ["password=None", ...]` |

All named capture groups preserved for regexp2 extraction.

## Performance Impact

Tested scanning `/tmp/kubernetes` (28,364 files):

| Version | Time | CPU | Speedup |
|---------|------|-----|---------|
| Before (3 regexp2 fallback) | 77.66s | 52.43s | - |
| After (all Hyperscan) | 37.15s | 16.50s | **2.1x** |

## Test plan

- [x] All 456 patterns compile successfully with Hyperscan
- [x] Build passes: `GOWORK=off go build -tags vectorscan ./...`
- [x] Benchmark verified: 2.1x speedup on kubernetes repo
- [x] Backend review completed