### PR TITLE
perf: parallelize scan pipeline with worker pool and batched transactions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -82,6 +82,7 @@ require (
 	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546 // indirect
 	golang.org/x/net v0.47.0 // indirect
+	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.39.0 // indirect
 	golang.org/x/text v0.32.0 // indirect
 	golang.org/x/time v0.14.0 // indirect

--- a/pkg/enum/filesystem.go
+++ b/pkg/enum/filesystem.go
@@ -6,11 +6,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	gitignore "github.com/sabhiram/go-gitignore"
 
 	"github.com/praetorian-inc/titus/pkg/types"
+	"golang.org/x/sync/errgroup"
 )
 
 // FilesystemEnumerator enumerates files from a filesystem directory.
@@ -23,8 +25,14 @@ func NewFilesystemEnumerator(config Config) *FilesystemEnumerator {
 	return &FilesystemEnumerator{config: config}
 }
 
+// fileEntry holds metadata collected during the walk phase.
+type fileEntry struct {
+	path string
+}
 
 // Enumerate walks the filesystem and yields file blobs.
+// Phase 1: Walk directory tree and collect eligible file paths (fast, sequential).
+// Phase 2: Read files and invoke callback in parallel.
 func (e *FilesystemEnumerator) Enumerate(ctx context.Context, callback func(content []byte, blobID types.BlobID, prov types.Provenance) error) error {
 	// Load .gitignore patterns if present
 	var ignore *gitignore.GitIgnore
@@ -33,43 +41,38 @@ func (e *FilesystemEnumerator) Enumerate(ctx context.Context, callback func(cont
 		ignore, _ = gitignore.CompileIgnoreFile(gitignorePath)
 	}
 
-	return filepath.Walk(e.config.Root, func(path string, info os.FileInfo, err error) error {
+	// Phase 1: Walk and collect eligible file paths
+	var files []fileEntry
+	err := filepath.Walk(e.config.Root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
 
-		// Check context cancellation
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
 		}
 
-		// Skip directories
 		if info.IsDir() {
-			// Skip hidden directories if not included
 			if !e.config.IncludeHidden && isHidden(info.Name()) {
 				return filepath.SkipDir
 			}
 			return nil
 		}
 
-		// Skip symlinks unless configured to follow
 		if info.Mode()&os.ModeSymlink != 0 && !e.config.FollowSymlinks {
 			return nil
 		}
 
-		// Skip hidden files if not included
 		if !e.config.IncludeHidden && isHidden(info.Name()) {
 			return nil
 		}
 
-		// Apply size limit
 		if e.config.MaxFileSize > 0 && info.Size() > e.config.MaxFileSize {
 			return nil
 		}
 
-		// Check gitignore patterns
 		if ignore != nil {
 			relPath, err := filepath.Rel(e.config.Root, path)
 			if err != nil {
@@ -80,55 +83,105 @@ func (e *FilesystemEnumerator) Enumerate(ctx context.Context, callback func(cont
 			}
 		}
 
-		// Read file content
-		content, err := os.ReadFile(path)
-		if err != nil {
-			return fmt.Errorf("failed to read file %s: %w", path, err)
-		}
+		files = append(files, fileEntry{path: path})
+		return nil
+	})
+	if err != nil {
+		return err
+	}
 
-		// Check if binary
-		binary := isBinary(content)
+	// Phase 2: Read and process files in parallel
+	numReaders := runtime.NumCPU()
+	if numReaders < 1 {
+		numReaders = 1
+	}
 
-		// Handle binary files with extraction enabled
-		if binary && e.config.ExtractArchives != "" {
-			ext := getExtension(path)
-			if shouldExtract(e.config, ext) {
-				// Try to extract text from binary file
-				extracted, err := ExtractText(path, content, e.config.ExtractLimits)
-				if err == nil && len(extracted) > 0 {
-					// Yield each extracted piece of content
-					for _, ec := range extracted {
-						blobID := types.ComputeBlobID(ec.Content)
-						prov := types.ArchiveProvenance{
-							ArchivePath: path,
-							MemberPath:  ec.Name,
-						}
-						if err := callback(ec.Content, blobID, prov); err != nil {
-							return err
-						}
-					}
-				}
-				// Skip the binary file itself (extracted or not)
-				return nil
+	origCtx := ctx
+	g, ctx := errgroup.WithContext(ctx)
+	pathsCh := make(chan fileEntry, numReaders*2)
+
+	// Feed paths to readers
+	g.Go(func() error {
+		defer close(pathsCh)
+		for _, f := range files {
+			select {
+			case pathsCh <- f:
+			case <-ctx.Done():
+				return ctx.Err()
 			}
 		}
+		return nil
+	})
 
-		// Skip binary files (not extracted or extraction disabled)
-		if binary {
+	// Parallel readers
+	for i := 0; i < numReaders; i++ {
+		g.Go(func() error {
+			for f := range pathsCh {
+				if err := e.processFile(ctx, f.path, callback); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return err
+	}
+	// If the caller's context was cancelled but all goroutines finished
+	// before noticing, propagate the cancellation.
+	if origCtx.Err() != nil {
+		return origCtx.Err()
+	}
+	return nil
+}
+
+// processFile reads a single file and invokes the callback.
+func (e *FilesystemEnumerator) processFile(ctx context.Context, path string, callback func(content []byte, blobID types.BlobID, prov types.Provenance) error) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("failed to read file %s: %w", path, err)
+	}
+
+	binary := isBinary(content)
+
+	// Handle binary files with extraction enabled
+	if binary && e.config.ExtractArchives != "" {
+		ext := getExtension(path)
+		if shouldExtract(e.config, ext) {
+			extracted, err := ExtractText(path, content, e.config.ExtractLimits)
+			if err == nil && len(extracted) > 0 {
+				for _, ec := range extracted {
+					blobID := types.ComputeBlobID(ec.Content)
+					prov := types.ArchiveProvenance{
+						ArchivePath: path,
+						MemberPath:  ec.Name,
+					}
+					if err := callback(ec.Content, blobID, prov); err != nil {
+						return err
+					}
+				}
+			}
 			return nil
 		}
+	}
 
-		// Compute blob ID
-		blobID := types.ComputeBlobID(content)
+	if binary {
+		return nil
+	}
 
-		// Create file provenance
-		prov := types.FileProvenance{
-			FilePath: path,
-		}
+	blobID := types.ComputeBlobID(content)
+	prov := types.FileProvenance{
+		FilePath: path,
+	}
 
-		// Yield to callback
-		return callback(content, blobID, prov)
-	})
+	return callback(content, blobID, prov)
 }
 
 // shouldExtract checks if a file type should be extracted based on config.
@@ -159,12 +212,9 @@ func isHidden(name string) bool {
 
 // isBinary detects if content is binary by checking first 8KB for null bytes.
 func isBinary(content []byte) bool {
-	// Check first 8KB
 	checkSize := len(content)
 	if checkSize > 8192 {
 		checkSize = 8192
 	}
-
-	// Look for null bytes
 	return bytes.IndexByte(content[:checkSize], 0) != -1
 }

--- a/pkg/store/memory.go
+++ b/pkg/store/memory.go
@@ -194,6 +194,10 @@ func (m *MemoryStore) GetProvenance(blobID types.BlobID) (types.Provenance, erro
 	return provs[0], nil
 }
 
+func (s *MemoryStore) ExecBatch(fn func(Store) error) error {
+	return fn(s)
+}
+
 // Close closes the database connection.
 // For in-memory store, this is a no-op.
 func (m *MemoryStore) Close() error {

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -44,6 +44,10 @@ type Store interface {
 	// GetProvenance retrieves provenance for a blob.
 	GetProvenance(blobID types.BlobID) (types.Provenance, error)
 
+	// ExecBatch executes fn within a database transaction for batched writes.
+	// The Store passed to fn uses the transaction; the outer Store is unchanged.
+	ExecBatch(fn func(Store) error) error
+
 	// Close closes the database connection.
 	Close() error
 }


### PR DESCRIPTION
## Summary

- Parallelize the blob processing pipeline with a configurable `--workers` flag (default: `runtime.NumCPU()`)
- Replace sequential callback → single-writer goroutine architecture with producer → N workers pattern
- Each worker matches, computes line/col, validates, and flushes DB writes in batched transactions (64 blobs per transaction)
- Parallelize filesystem enumerator with `NumCPU()` reader goroutines
- Fix data race in vectorscan matcher's shared dedup field for concurrent `MatchWithBlobID` calls
- Add `ExecBatch` to Store interface for transactional write batching

**Benchmarks on `/tmp/kubernetes` (235MB, 27K files, 459 rules):**

| Config | Before | After | Speedup |
|--------|--------|-------|---------|
| Disk, 12 workers | 41s | **16s** | **2.6x** |
| Memory, 12 workers | — | **12.6s** | — |
| Memory, 1 worker | — | **14.4s** | — |

NoseyParker reference: 3.4s (192 rules, Rust, git packfile I/O)

Remaining gap is primarily: Hyperscan rule compilation (~8s startup), 459 vs 192 rules (~9s matching), and filesystem syscall overhead (~5s for 27K individual file reads vs NP's git packfile approach).

## Test plan

- [x] `go test -race -tags vectorscan ./pkg/store/...` — no races
- [x] `go test -race -tags vectorscan ./pkg/enum/...` — no races, context cancellation test passes
- [x] `go test -race -tags vectorscan ./pkg/matcher/...` — dedup race fixed (6 pre-existing test failures unchanged)
- [x] `CGO_ENABLED=0 go build ./cmd/titus` — regexp2 fallback builds and works
- [x] Match count identical between `--workers 1` and `--workers 12` (1465 matches)
- [x] Verified against NoseyParker on kubernetes repo — same findings detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)