### PR TITLE
Add HTTP validators for 9 credential types

### DIFF
--- a/pkg/validator/validators/notion.yaml
+++ b/pkg/validator/validators/notion.yaml
@@ -12,7 +12,8 @@ validators:
       type: bearer
       secret_group: "1"
     headers:
-      Notion-Version: "2022-06-28"
+      - name: "Notion-Version"
+        value: "2022-06-28"
 
     success_codes: [200]
     failure_codes: [401, 403]

--- a/pkg/validator/validators/pulumi.yaml
+++ b/pkg/validator/validators/pulumi.yaml
@@ -13,8 +13,10 @@ validators:
       header_name: "Authorization"
       header_prefix: "token "
     headers:
-      Accept: "application/vnd.pulumi+8"
-      Content-Type: "application/json"
+      - name: "Accept"
+        value: "application/vnd.pulumi+8"
+      - name: "Content-Type"
+        value: "application/json"
 
     success_codes: [200]
     failure_codes: [401, 403]

--- a/pkg/validator/validators/sentry.yaml
+++ b/pkg/validator/validators/sentry.yaml
@@ -13,7 +13,8 @@ validators:
       type: bearer
       secret_group: "1"
     headers:
-      Accept: "application/json"
+      - name: "Accept"
+        value: "application/json"
 
     success_codes: [200]
     failure_codes: [401, 403]

--- a/pkg/validator/validators/snyk.yaml
+++ b/pkg/validator/validators/snyk.yaml
@@ -11,7 +11,8 @@ validators:
       type: bearer
       secret_group: "1"
     headers:
-      Accept: "application/json"
+      - name: "Accept"
+        value: "application/json"
 
     success_codes: [200]
     failure_codes: [401, 403]

--- a/pkg/validator/validators/tailscale.yaml
+++ b/pkg/validator/validators/tailscale.yaml
@@ -11,7 +11,8 @@ validators:
       type: bearer
       secret_group: "1"
     headers:
-      Accept: "application/json"
+      - name: "Accept"
+        value: "application/json"
 
     success_codes: [200]
     failure_codes: [401, 403]


### PR DESCRIPTION
## Summary
Adds HTTP validators for:
- Netlify API Key (kingfisher.netlify.1, 2)
- Vercel API Token (kingfisher.vercel.1)
- Pulumi API Key (kingfisher.pulumi.1)
- Snyk API Key (kingfisher.snyk.1)
- Postman API Key (np.postman.1)
- Tailscale API Key (kingfisher.tailscale.1)
- Notion API Token (kingfisher.notion.1, 2)
- Sentry Access Token (kingfisher.sentry.1, 2, 3)
- New Relic API Key (np.newrelic.3, 4, 7)

## Test plan
- [x] Verify validators load correctly
- [x] Test validation with sample keys

Closes LAB-587, LAB-679, LAB-627, LAB-654, LAB-621, LAB-665, LAB-591, LAB-649, LAB-589