### PR TITLE
Add HTTP validators for 8 AI services

### DIFF
--- a/pkg/validator/validators/mistral.yaml
+++ b/pkg/validator/validators/mistral.yaml
@@ -11,7 +11,8 @@ validators:
       type: bearer
       secret_group: "1"
     headers:
-      Accept: "application/json"
+      - name: "Accept"
+        value: "application/json"
 
     success_codes: [200]
     failure_codes: [401, 403]

--- a/pkg/validator/validators/perplexity.yaml
+++ b/pkg/validator/validators/perplexity.yaml
@@ -11,7 +11,8 @@ validators:
       type: bearer
       secret_group: "1"
     headers:
-      Content-Type: "application/json"
+      - name: "Content-Type"
+        value: "application/json"
 
     success_codes: [200, 400, 422]
     failure_codes: [401, 403]

--- a/pkg/validator/validators/stabilityai.yaml
+++ b/pkg/validator/validators/stabilityai.yaml
@@ -11,7 +11,8 @@ validators:
       type: bearer
       secret_group: "1"
     headers:
-      Accept: "application/json"
+      - name: "Accept"
+        value: "application/json"
 
     success_codes: [200]
     failure_codes: [401, 403]


### PR DESCRIPTION
## Summary
Adds HTTP validators for AI service API keys:
- Groq (np.groq.1)
- Mistral (kingfisher.mistral.1)
- Replicate (kingfisher.replicate.1)
- HuggingFace (np.huggingface.1)
- Perplexity (kingfisher.perplexity.1)
- ElevenLabs (kingfisher.elevenlabs.1)
- Stability AI (kingfisher.stabilityai.1)
- Cohere (kingfisher.cohere.1)

## Test plan
- [x] Verify validators load correctly
- [x] Test validation with sample keys

Closes LAB-529, LAB-581, LAB-634, LAB-540, LAB-615, LAB-494, LAB-660