### PR TITLE
Add HTTP validators for DevOps tools

### DIFF
--- a/pkg/validator/validators/circleci.yaml
+++ b/pkg/validator/validators/circleci.yaml
@@ -12,7 +12,8 @@ validators:
       secret_group: "token"
       header_name: "Circle-Token"
     headers:
-      Accept: "application/json"
+      - name: "Accept"
+        value: "application/json"
 
     success_codes: [200]
     failure_codes: [401, 403]
@@ -29,7 +30,8 @@ validators:
       secret_group: "token"
       header_name: "Circle-Token"
     headers:
-      Accept: "application/json"
+      - name: "Accept"
+        value: "application/json"
 
     success_codes: [200]
     failure_codes: [401, 403]

--- a/pkg/validator/validators/datadog.yaml
+++ b/pkg/validator/validators/datadog.yaml
@@ -12,7 +12,8 @@ validators:
       secret_group: "api_key"
       header_name: "DD-API-KEY"
     headers:
-      Accept: "application/json"
+      - name: "Accept"
+        value: "application/json"
 
     success_codes: [200]
     failure_codes: [401, 403]

--- a/pkg/validator/validators/heroku.yaml
+++ b/pkg/validator/validators/heroku.yaml
@@ -11,7 +11,8 @@ validators:
       type: bearer
       secret_group: "1"
     headers:
-      Accept: "application/vnd.heroku+json; version=3"
+      - name: "Accept"
+        value: "application/vnd.heroku+json; version=3"
 
     success_codes: [200]
     failure_codes: [401, 403]

--- a/pkg/validator/validators/intercom.yaml
+++ b/pkg/validator/validators/intercom.yaml
@@ -11,7 +11,8 @@ validators:
       type: bearer
       secret_group: "1"
     headers:
-      Accept: "application/json"
+      - name: "Accept"
+        value: "application/json"
 
     success_codes: [200]
     failure_codes: [401, 403]

--- a/pkg/validator/validators/linear.yaml
+++ b/pkg/validator/validators/linear.yaml
@@ -12,7 +12,8 @@ validators:
       secret_group: "1"
       header_name: "Authorization"
     headers:
-      Content-Type: "application/json"
+      - name: "Content-Type"
+        value: "application/json"
     body: '{"query": "{ viewer { id } }"}'
 
     success_codes: [200]


### PR DESCRIPTION
## Summary
Adds HTTP validators for:
- Linear API Key (kingfisher.linear.1)
- Heroku API Key (np.heroku.1)
- CircleCI Personal Access Token (kingfisher.circleci.1)
- CircleCI Project Token (kingfisher.circleci.2)
- Datadog API Key (kingfisher.datadog.2)
- Intercom API Token (kingfisher.intercom.1)

## Test plan
- [x] Verify validators load correctly
- [x] Test validation with sample keys

Closes LAB-566, LAB-536, LAB-492, LAB-546