### PR TITLE
Add HTTP validators for 28 services

### DIFF
--- a/pkg/validator/validators/assemblyai.yaml
+++ b/pkg/validator/validators/assemblyai.yaml
@@ -1,0 +1,16 @@
+validators:
+
+- name: assemblyai-api-key
+  rule_ids:
+    - kingfisher.assemblyai.1
+
+  http:
+    method: GET
+    url: "https://api.assemblyai.com/v2/transcript?limit=1"
+    auth:
+      type: header
+      secret_group: "token"
+      header_name: "Authorization"
+
+    success_codes: [200]
+    failure_codes: [401, 403]

--- a/pkg/validator/validators/buildkite.yaml
+++ b/pkg/validator/validators/buildkite.yaml
@@ -1,0 +1,15 @@
+validators:
+
+- name: buildkite-api-key
+  rule_ids:
+    - kingfisher.buildkite.1
+
+  http:
+    method: GET
+    url: "https://api.buildkite.com/v2/access-token"
+    auth:
+      type: bearer
+      secret_group: "token"
+
+    success_codes: [200]
+    failure_codes: [401, 403]

--- a/pkg/validator/validators/cerebras.yaml
+++ b/pkg/validator/validators/cerebras.yaml
@@ -1,0 +1,15 @@
+validators:
+
+- name: cerebras-api-key
+  rule_ids:
+    - kingfisher.cerebras.1
+
+  http:
+    method: GET
+    url: "https://api.cerebras.ai/v1/models"
+    auth:
+      type: bearer
+      secret_group: "token"
+
+    success_codes: [200]
+    failure_codes: [401, 403]

--- a/pkg/validator/validators/cloudflare.yaml
+++ b/pkg/validator/validators/cloudflare.yaml
@@ -1,0 +1,36 @@
+validators:
+
+- name: cloudflare-api-token
+  rule_ids:
+    - kingfisher.cloudflare.1
+
+  http:
+    method: GET
+    url: "https://api.cloudflare.com/client/v4/user/tokens/verify"
+    auth:
+      type: bearer
+      secret_group: "token"
+    headers:
+      - name: "Accept"
+        value: "application/json"
+
+    success_codes: [200]
+    failure_codes: [401, 403]
+
+- name: cloudflare-ca-key
+  rule_ids:
+    - kingfisher.cloudflare.2
+
+  http:
+    method: GET
+    url: "https://api.cloudflare.com/client/v4/certificates?per_page=1"
+    auth:
+      type: header
+      secret_group: "token"
+      header_name: "X-Auth-User-Service-Key"
+    headers:
+      - name: "Content-Type"
+        value: "application/json"
+
+    success_codes: [200]
+    failure_codes: [401, 403]

--- a/pkg/validator/validators/deepgram.yaml
+++ b/pkg/validator/validators/deepgram.yaml
@@ -1,0 +1,17 @@
+validators:
+
+- name: deepgram-api-key
+  rule_ids:
+    - kingfisher.deepgram.1
+
+  http:
+    method: GET
+    url: "https://api.deepgram.com/v1/projects"
+    auth:
+      type: header
+      secret_group: "token"
+      header_name: "Authorization"
+      header_prefix: "Token "
+
+    success_codes: [200]
+    failure_codes: [401, 403]

--- a/pkg/validator/validators/deepseek.yaml
+++ b/pkg/validator/validators/deepseek.yaml
@@ -1,0 +1,18 @@
+validators:
+
+- name: deepseek-api-key
+  rule_ids:
+    - kingfisher.deepseek.1
+
+  http:
+    method: GET
+    url: "https://api.deepseek.com/models"
+    auth:
+      type: bearer
+      secret_group: "secret"
+    headers:
+      - name: "Accept"
+        value: "application/json"
+
+    success_codes: [200]
+    failure_codes: [401, 403]

--- a/pkg/validator/validators/fastly.yaml
+++ b/pkg/validator/validators/fastly.yaml
@@ -1,0 +1,16 @@
+validators:
+
+- name: fastly-api-token
+  rule_ids:
+    - kingfisher.fastly.1
+
+  http:
+    method: GET
+    url: "https://api.fastly.com/current_user"
+    auth:
+      type: header
+      secret_group: "1"
+      header_name: "Fastly-Key"
+
+    success_codes: [200]
+    failure_codes: [401, 403]

--- a/pkg/validator/validators/ngrok.yaml
+++ b/pkg/validator/validators/ngrok.yaml
@@ -1,0 +1,18 @@
+validators:
+
+- name: ngrok-api-key
+  rule_ids:
+    - kingfisher.ngrok.1
+
+  http:
+    method: GET
+    url: "https://api.ngrok.com/endpoints"
+    auth:
+      type: bearer
+      secret_group: "1"
+    headers:
+      - name: "ngrok-version"
+        value: "2"
+
+    success_codes: [200]
+    failure_codes: [401, 403]

--- a/pkg/validator/validators/openrouter.yaml
+++ b/pkg/validator/validators/openrouter.yaml
@@ -1,0 +1,18 @@
+validators:
+
+- name: openrouter-api-key
+  rule_ids:
+    - kingfisher.openrouter.1
+
+  http:
+    method: GET
+    url: "https://openrouter.ai/api/v1/key"
+    auth:
+      type: bearer
+      secret_group: "1"
+    headers:
+      - name: "Accept"
+        value: "application/json"
+
+    success_codes: [200]
+    failure_codes: [401, 403]

--- a/pkg/validator/validators/shodan.yaml
+++ b/pkg/validator/validators/shodan.yaml
@@ -1,0 +1,16 @@
+validators:
+
+- name: shodan-api-key
+  rule_ids:
+    - kingfisher.shodan.1
+
+  http:
+    method: GET
+    url: "https://api.shodan.io/api-info"
+    auth:
+      type: query
+      secret_group: "1"
+      query_param: "key"
+
+    success_codes: [200]
+    failure_codes: [401, 403]

--- a/pkg/validator/validators/travisci.yaml
+++ b/pkg/validator/validators/travisci.yaml
@@ -1,0 +1,22 @@
+validators:
+
+- name: travisci-token
+  rule_ids:
+    - kingfisher.travisci.1
+
+  http:
+    method: GET
+    url: "https://api.travis-ci.com/repos?limit=1"
+    auth:
+      type: header
+      secret_group: "1"
+      header_name: "Authorization"
+      header_prefix: "token "
+    headers:
+      - name: "Accept"
+        value: "application/vnd.travis-ci.3+json"
+      - name: "Travis-API-Version"
+        value: "3"
+
+    success_codes: [200]
+    failure_codes: [401, 403]


### PR DESCRIPTION
## Summary
- Add Supabase Management Token validator (kingfisher.supabase.1)
- Add Monday.com API Key validator (kingfisher.monday.1)
- Add Doppler token validators for all 6 token types (np.doppler.1-6)
- Add Fly.io API Token validator (kingfisher.flyio.1)
- Add DigitalOcean token validators for 3 token types (np.digitalocean.1-3)
- Add PostHog Personal API Key validator (kingfisher.posthog.2)
- Add Resend API Key validator (kingfisher.resend.api_key.1)
- Add Postmark API Token validator (np.postmark.1)
- Add LaunchDarkly Access Token validator (kingfisher.launchdarkly.1)
- Add Segment Public API Token validator (np.segment.1)
- Add Codecov Access Token validator (kingfisher.codecov.1)
- Add Figma Personal Access Token validator (np.figma.1)
- Add Together.ai API Key validator (kingfisher.together.1)
- Add Voyage AI API Key validator (kingfisher.voyageai.api_key)
- Add xAI (Grok) API Key validator (kingfisher.xai.1)
- Add OpsGenie API Key validator (kingfisher.opsgenie.1)
- Add PagerDuty API Key validator (kingfisher.pagerduty.1)

## Test plan
- [x] Verify validators load correctly with `titus rules list`
- [x] Test with sample secrets to ensure validation works