### PR TITLE
Add context requirement to StabilityAI rule to reduce OpenAI overlap

### DIFF
--- a/pkg/rule/rules/stabilityai.yml
+++ b/pkg/rule/rules/stabilityai.yml
@@ -1,11 +1,15 @@
 rules:
   - name: Stability AI API Key
     id: kingfisher.stabilityai.1
-    pattern: |           
-      (?x)
+    pattern: |
+      (?xi)
+      (?:stability|stable|dreamstudio|stabilityai)
+      (?:.|[\n\r]){0,40}?
+      (?:SECRET|PRIVATE|ACCESS|KEY|TOKEN|API)?
+      (?:.|[\n\r]){0,20}?
       \b
-      (                
-        sk-     
+      (
+        sk-
         [A-Za-z0-9]{48}
       )
       \b
@@ -14,9 +18,10 @@ rules:
     min_entropy: 4.0
     confidence: medium
     examples:
-      - sk-AnmgropvAII5XEoxVPjbnSMG3XhacEwhJlLh8ossXh7K1iLP
-      - sk-gQHyuK4k6Vw2viJRaAnLh6zAULaWtUg40ZHWcYjw7JGutlW6
-      - sk-nwvJypEMFNASJLiPBgNnzJj1xsDwlHChbFRMNwVkzy3e4UJg
+      - stability_api_key = sk-AnmgropvAII5XEoxVPjbnSMG3XhacEwhJlLh8ossXh7K1iLP
+      - STABILITYAI_TOKEN=sk-gQHyuK4k6Vw2viJRaAnLh6zAULaWtUg40ZHWcYjw7JGutlW6
+      - stable_diffusion_key = sk-nwvJypEMFNASJLiPBgNnzJj1xsDwlHChbFRMNwVkzy3e4UJg
+      - dreamstudio_api_key=sk-nwvJypEMFNASJLiPBgNnzJj1xsDwlHChbFRMNwVkzy3e4UJg
     references:
       - https://platform.stability.ai/docs/api-reference#v1-user-account
     validation:


### PR DESCRIPTION
## Summary
- Adds context keywords (stability, stable, dreamstudio, stabilityai) to the StabilityAI rule pattern
- Prevents false positive matches where a plain `sk-{48 chars}` token would match both `np.openai.1` and `kingfisher.stabilityai.1`
- Updated examples to include context keywords

## Problem
Both OpenAI and StabilityAI keys use the same `sk-[48 alphanumeric]` format:
- OpenAI: `sk-mxIt5s1tyfCJyIKHwrqOT4BlbkFJT3VVmv6VdSwB7XXIq1TO`
- StabilityAI: `sk-AnmgropvAII5XEoxVPjbnSMG3XhacEwhJlLh8ossXh7K1iLP`

Without context requirements, a single token would match both rules.

## Solution
Added context requirement to `kingfisher.stabilityai.1` to require one of:
- `stability`
- `stable`
- `dreamstudio`
- `stabilityai`

This follows the pattern used by other `kingfisher.*` rules that require service-specific context.

## Test plan
- [x] StabilityAI key WITH context matches `kingfisher.stabilityai.1`
- [x] Plain `sk-` token WITHOUT context does NOT match `kingfisher.stabilityai.1`
- [x] OpenAI keys still match `np.openai.1`