### PR TITLE
Add GitLab PAT and NPM token validators

### DIFF
--- a/pkg/validator/validators/gitlab.yaml
+++ b/pkg/validator/validators/gitlab.yaml
@@ -1,0 +1,23 @@
+# pkg/validator/validators/gitlab.yaml
+# GitLab Personal Access Token Validator
+# Validates glpat-* tokens against GitLab.com API
+
+validators:
+
+- name: gitlab-personal-access-token
+  rule_ids:
+    - np.gitlab.2
+
+  http:
+    method: GET
+    url: "https://gitlab.com/api/v4/user"
+    auth:
+      type: header
+      secret_group: "1"
+      header_name: "PRIVATE-TOKEN"
+
+    # Success codes indicate valid token
+    success_codes: [200]
+
+    # Failure codes indicate invalid or unauthorized token
+    failure_codes: [401, 403]

--- a/pkg/validator/validators/npm.yaml
+++ b/pkg/validator/validators/npm.yaml
@@ -1,0 +1,22 @@
+# pkg/validator/validators/npm.yaml
+# NPM Access Token Validator
+# Validates npm_* fine-grained tokens against npm registry
+
+validators:
+
+- name: npm-access-token
+  rule_ids:
+    - np.npm.1
+
+  http:
+    method: GET
+    url: "https://registry.npmjs.org/-/npm/v1/user"
+    auth:
+      type: bearer
+      secret_group: "1"
+
+    # Success codes indicate valid token
+    success_codes: [200]
+
+    # Failure codes indicate invalid or unauthorized token
+    failure_codes: [401, 403]


### PR DESCRIPTION
Recreated after history squash for OSS release. See original PR for full context.