### PR TITLE
Add context requirement to StabilityAI rule to reduce OpenAI overlap

### DIFF
--- a/pkg/rule/rules/stabilityai.yml
+++ b/pkg/rule/rules/stabilityai.yml
@@ -1,11 +1,15 @@
 rules:
   - name: Stability AI API Key
     id: kingfisher.stabilityai.1
-    pattern: |           
-      (?x)
+    pattern: |
+      (?xi)
+      (?:stability|stable|dreamstudio|stabilityai)
+      (?:.|[\n\r]){0,40}?
+      (?:SECRET|PRIVATE|ACCESS|KEY|TOKEN|API)?
+      (?:.|[\n\r]){0,20}?
       \b
-      (                
-        sk-     
+      (
+        sk-
         [A-Za-z0-9]{48}
       )
       \b
@@ -14,9 +18,10 @@ rules:
     min_entropy: 4.0
     confidence: medium
     examples:
-      - sk-AnmgropvAII5XEoxVPjbnSMG3XhacEwhJlLh8ossXh7K1iLP
-      - sk-gQHyuK4k6Vw2viJRaAnLh6zAULaWtUg40ZHWcYjw7JGutlW6
-      - sk-nwvJypEMFNASJLiPBgNnzJj1xsDwlHChbFRMNwVkzy3e4UJg
+      - stability_api_key = sk-AnmgropvAII5XEoxVPjbnSMG3XhacEwhJlLh8ossXh7K1iLP
+      - STABILITYAI_TOKEN=sk-gQHyuK4k6Vw2viJRaAnLh6zAULaWtUg40ZHWcYjw7JGutlW6
+      - stable_diffusion_key = sk-nwvJypEMFNASJLiPBgNnzJj1xsDwlHChbFRMNwVkzy3e4UJg
+      - dreamstudio_api_key=sk-nwvJypEMFNASJLiPBgNnzJj1xsDwlHChbFRMNwVkzy3e4UJg
     references:
       - https://platform.stability.ai/docs/api-reference#v1-user-account
     validation:


### PR DESCRIPTION
Recreated after history squash for OSS release. See original PR for full context.