### PR TITLE
fix: apply code review bugfixes across validators, rules, and enums

### DIFF
--- a/pkg/rule/contentful_test.go
+++ b/pkg/rule/contentful_test.go
@@ -11,7 +11,7 @@ import (
 // and has the correct structure for detecting Contentful Delivery API tokens
 func TestContentfulDeliveryToken_RuleExists(t *testing.T) {
 	// Load the contentful.yml file
-	data, err := builtinRulesFS.ReadFile("rules/contentful.yml")
+	data, err := builtinFS.ReadFile("rules/contentful.yml")
 	if err != nil {
 		t.Fatalf("Failed to read contentful.yml: %v", err)
 	}
@@ -73,7 +73,7 @@ func TestContentfulDeliveryToken_RuleExists(t *testing.T) {
 // TestContentfulPersonalAccessToken_RuleExists verifies the kingfisher.contentful.2 rule exists
 func TestContentfulPersonalAccessToken_RuleExists(t *testing.T) {
 	// Load the contentful.yml file
-	data, err := builtinRulesFS.ReadFile("rules/contentful.yml")
+	data, err := builtinFS.ReadFile("rules/contentful.yml")
 	if err != nil {
 		t.Fatalf("Failed to read contentful.yml: %v", err)
 	}
@@ -130,7 +130,7 @@ func TestContentfulPersonalAccessToken_RuleExists(t *testing.T) {
 // TestContentfulDeliveryToken_HasNamedCaptureGroup verifies the pattern has named capture group
 func TestContentfulDeliveryToken_HasNamedCaptureGroup(t *testing.T) {
 	// Load the contentful.yml file
-	data, err := builtinRulesFS.ReadFile("rules/contentful.yml")
+	data, err := builtinFS.ReadFile("rules/contentful.yml")
 	if err != nil {
 		t.Fatalf("Failed to read contentful.yml: %v", err)
 	}
@@ -165,7 +165,7 @@ func TestContentfulDeliveryToken_HasNamedCaptureGroup(t *testing.T) {
 // TestContentfulPersonalAccessToken_HasNamedCaptureGroup verifies the pattern has named capture group
 func TestContentfulPersonalAccessToken_HasNamedCaptureGroup(t *testing.T) {
 	// Load the contentful.yml file
-	data, err := builtinRulesFS.ReadFile("rules/contentful.yml")
+	data, err := builtinFS.ReadFile("rules/contentful.yml")
 	if err != nil {
 		t.Fatalf("Failed to read contentful.yml: %v", err)
 	}
@@ -199,7 +199,7 @@ func TestContentfulPersonalAccessToken_HasNamedCaptureGroup(t *testing.T) {
 // TestContentfulDeliveryToken_PatternHasExamples verifies the delivery rule has examples
 func TestContentfulDeliveryToken_PatternHasExamples(t *testing.T) {
 	// Load the contentful.yml file
-	data, err := builtinRulesFS.ReadFile("rules/contentful.yml")
+	data, err := builtinFS.ReadFile("rules/contentful.yml")
 	if err != nil {
 		t.Fatalf("Failed to read contentful.yml: %v", err)
 	}
@@ -248,7 +248,7 @@ func TestContentfulDeliveryToken_PatternHasExamples(t *testing.T) {
 // TestContentfulPersonalAccessToken_PatternHasExamples verifies the PAT rule has examples
 func TestContentfulPersonalAccessToken_PatternHasExamples(t *testing.T) {
 	// Load the contentful.yml file
-	data, err := builtinRulesFS.ReadFile("rules/contentful.yml")
+	data, err := builtinFS.ReadFile("rules/contentful.yml")
 	if err != nil {
 		t.Fatalf("Failed to read contentful.yml: %v", err)
 	}

--- a/pkg/rule/embed.go
+++ b/pkg/rule/embed.go
@@ -2,14 +2,7 @@ package rule
 
 import "embed"
 
-// builtinRulesFS embeds the built-in rules directory.
-// Contains 189 detection rules ported from NoseyParker.
+// builtinFS embeds the built-in rules and rulesets directories.
 //
-//go:embed rules/*.yml
-var builtinRulesFS embed.FS
-
-// builtinRulesetsFS embeds the built-in rulesets directory.
-// Contains rulesets ported from NoseyParker.
-//
-//go:embed rulesets/*.yml
-var builtinRulesetsFS embed.FS
+//go:embed rules/*.yml rulesets/*.yml
+var builtinFS embed.FS

--- a/pkg/rule/facebook_test.go
+++ b/pkg/rule/facebook_test.go
@@ -11,7 +11,7 @@ import (
 // and has the correct structure for detecting paired Facebook app credentials
 func TestFacebookAppCredentials_RuleExists(t *testing.T) {
 	// Load the facebook.yml file containing all Facebook rules
-	data, err := builtinRulesFS.ReadFile("rules/facebook.yml")
+	data, err := builtinFS.ReadFile("rules/facebook.yml")
 	if err != nil {
 		t.Fatalf("Failed to read facebook.yml: %v", err)
 	}
@@ -88,7 +88,7 @@ func TestFacebookAppCredentials_RuleExists(t *testing.T) {
 // TestFacebookAppCredentials_ExamplesIncluded tests that positive and negative examples are included
 func TestFacebookAppCredentials_ExamplesIncluded(t *testing.T) {
 	// Load the facebook.yml file
-	data, err := builtinRulesFS.ReadFile("rules/facebook.yml")
+	data, err := builtinFS.ReadFile("rules/facebook.yml")
 	if err != nil {
 		t.Fatalf("Failed to read facebook.yml: %v", err)
 	}

--- a/pkg/rule/loader.go
+++ b/pkg/rule/loader.go
@@ -18,7 +18,7 @@ type Loader struct {
 // NewLoader creates a loader with built-in rules from embedded filesystem.
 func NewLoader() *Loader {
 	return &Loader{
-		fs: builtinRulesFS,
+		fs: builtinFS,
 	}
 }
 

--- a/pkg/rule/loader_test.go
+++ b/pkg/rule/loader_test.go
@@ -107,7 +107,7 @@ func TestLoadRuleset_Valid(t *testing.T) {
   - id: rs.aws
     name: AWS Rules
     description: Rules for AWS credential detection
-    rule_ids:
+    include_rule_ids:
       - np.aws.1
       - np.aws.2
 `

--- a/pkg/rule/microsoft_teams_test.go
+++ b/pkg/rule/microsoft_teams_test.go
@@ -15,7 +15,7 @@ import (
 // and has the correct structure
 func TestMicrosoftTeamsWebhook_RuleExists(t *testing.T) {
 	// Load the microsoft_teams.yml file
-	data, err := builtinRulesFS.ReadFile("rules/microsoft_teams.yml")
+	data, err := builtinFS.ReadFile("rules/microsoft_teams.yml")
 	require.NoError(t, err, "Failed to read microsoft_teams.yml")
 
 	// Parse the YAML to get all rules
@@ -60,7 +60,7 @@ func TestMicrosoftTeamsWebhook_RuleExists(t *testing.T) {
 // TestMicrosoftTeamsWebhook_PatternMatches tests that positive examples match
 func TestMicrosoftTeamsWebhook_PatternMatches(t *testing.T) {
 	// Load the microsoft_teams.yml file
-	data, err := builtinRulesFS.ReadFile("rules/microsoft_teams.yml")
+	data, err := builtinFS.ReadFile("rules/microsoft_teams.yml")
 	require.NoError(t, err, "Failed to read microsoft_teams.yml")
 
 	// Parse the YAML
@@ -137,7 +137,7 @@ func TestMicrosoftTeamsWebhook_PatternMatches(t *testing.T) {
 // TestMicrosoftTeamsWebhook_NamedCaptureGroup verifies the webhook capture group extracts full URL
 func TestMicrosoftTeamsWebhook_NamedCaptureGroup(t *testing.T) {
 	// Load the microsoft_teams.yml file
-	data, err := builtinRulesFS.ReadFile("rules/microsoft_teams.yml")
+	data, err := builtinFS.ReadFile("rules/microsoft_teams.yml")
 	require.NoError(t, err, "Failed to read microsoft_teams.yml")
 
 	// Parse the YAML
@@ -197,7 +197,7 @@ func TestMicrosoftTeamsWebhook_NamedCaptureGroup(t *testing.T) {
 // TestKingfisherMicrosoftTeamsWebhook_RuleExists verifies the kingfisher.microsoftteamswebhook.1 rule exists
 func TestKingfisherMicrosoftTeamsWebhook_RuleExists(t *testing.T) {
 	// Load the microsoftteamswebhook.yml file
-	data, err := builtinRulesFS.ReadFile("rules/microsoftteamswebhook.yml")
+	data, err := builtinFS.ReadFile("rules/microsoftteamswebhook.yml")
 	require.NoError(t, err, "Failed to read microsoftteamswebhook.yml")
 
 	// Parse the YAML
@@ -232,7 +232,7 @@ func TestKingfisherMicrosoftTeamsWebhook_RuleExists(t *testing.T) {
 // TestKingfisherMicrosoftTeamsWebhook_PatternMatches tests pattern matching for kingfisher rule
 func TestKingfisherMicrosoftTeamsWebhook_PatternMatches(t *testing.T) {
 	// Load the microsoftteamswebhook.yml file
-	data, err := builtinRulesFS.ReadFile("rules/microsoftteamswebhook.yml")
+	data, err := builtinFS.ReadFile("rules/microsoftteamswebhook.yml")
 	require.NoError(t, err, "Failed to read microsoftteamswebhook.yml")
 
 	// Parse the YAML
@@ -297,7 +297,7 @@ func TestKingfisherMicrosoftTeamsWebhook_PatternMatches(t *testing.T) {
 // TestKingfisherMicrosoftTeamsWebhook_NamedCaptureGroup verifies webhook capture group extracts full URL
 func TestKingfisherMicrosoftTeamsWebhook_NamedCaptureGroup(t *testing.T) {
 	// Load the microsoftteamswebhook.yml file
-	data, err := builtinRulesFS.ReadFile("rules/microsoftteamswebhook.yml")
+	data, err := builtinFS.ReadFile("rules/microsoftteamswebhook.yml")
 	require.NoError(t, err, "Failed to read microsoftteamswebhook.yml")
 
 	// Parse the YAML
@@ -357,7 +357,7 @@ func TestKingfisherMicrosoftTeamsWebhook_NamedCaptureGroup(t *testing.T) {
 // TestMicrosoftTeamsWebhook_ValidationBlock verifies validation YAML structure for np.msteams.1
 func TestMicrosoftTeamsWebhook_ValidationBlock(t *testing.T) {
 	// Load the microsoft_teams.yml file
-	data, err := builtinRulesFS.ReadFile("rules/microsoft_teams.yml")
+	data, err := builtinFS.ReadFile("rules/microsoft_teams.yml")
 	require.NoError(t, err, "Failed to read microsoft_teams.yml")
 
 	// Parse the raw YAML to access validation structure
@@ -449,7 +449,7 @@ func TestMicrosoftTeamsWebhook_ValidationBlock(t *testing.T) {
 // TestKingfisherMicrosoftTeamsWebhook_ValidationBlock verifies validation YAML structure
 func TestKingfisherMicrosoftTeamsWebhook_ValidationBlock(t *testing.T) {
 	// Load the microsoftteamswebhook.yml file
-	data, err := builtinRulesFS.ReadFile("rules/microsoftteamswebhook.yml")
+	data, err := builtinFS.ReadFile("rules/microsoftteamswebhook.yml")
 	require.NoError(t, err, "Failed to read microsoftteamswebhook.yml")
 
 	// Parse the raw YAML to access validation structure

--- a/pkg/rule/yaml.go
+++ b/pkg/rule/yaml.go
@@ -24,7 +24,7 @@ type yamlRuleset struct {
 	ID          string   `yaml:"id"`
 	Name        string   `yaml:"name"`
 	Description string   `yaml:"description,omitempty"`
-	RuleIDs     []string `yaml:"rule_ids"`
+	RuleIDs     []string `yaml:"include_rule_ids"`
 }
 
 // yamlRulesetsFile represents the top-level structure of a rulesets YAML file.

--- a/pkg/scanner/core.go
+++ b/pkg/scanner/core.go
@@ -101,11 +101,6 @@ func (c *Core) Scan(content, source string) (*ScanResult, error) {
 		return nil, err
 	}
 
-	// Store matches
-	for _, match := range matches {
-		c.store.AddMatch(match)
-	}
-
 	return &ScanResult{
 		Source:  source,
 		Matches: matches,
@@ -122,11 +117,6 @@ func (c *Core) ScanBatch(items []ContentItem) (*BatchScanResult, error) {
 		if err != nil {
 			// Skip items that fail to scan
 			continue
-		}
-
-		// Store matches
-		for _, match := range matches {
-			c.store.AddMatch(match)
 		}
 
 		results = append(results, ScanResult{

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -254,6 +254,9 @@ func (s *SQLiteStore) ExecBatch(fn func(Store) error) error {
 }
 
 func (s *SQLiteStore) Close() error {
+	if s.db == nil {
+		return nil
+	}
 	return s.db.Close()
 }
 


### PR DESCRIPTION
## Summary

Applies 11 bugfixes (6 HIGH, 5 MEDIUM severity) identified during code review across 17 files.

### HIGH severity
- **H4/H5**: HTTP validator template substitution now handles all 4 syntax variants (`{{name}}`, `{{ name }}`, `{{.name}}`, `{{ .name }}`) for URL, body, and headers
- **H9**: Ruleset YAML struct tag changed from `rule_ids` to `include_rule_ids` to match actual YAML files
- **H10**: Merged two duplicate `embed.FS` vars into single `builtinFS`
- **H11**: Added truncated tree error for GitHub repos with >100K blobs (prevents silent missed secrets)
- **H12**: Added nil guard in `SQLiteStore.Close()` for transaction-scoped stores
- **H13**: GitHub/GitLab commands now use `ComputeFindingID(rule.StructuralID, match.Groups)` consistent with `scan` command

### MEDIUM severity
- **M2**: Response body drain before close in HTTP/Twilio/SauceLabs validators (prevents connection pool exhaustion)
- **M4**: Base64 multiline newline stripping for GitHub API content decoding
- **M5**: Context propagation to GitLab `listProjects` pagination loops (enables cancellation)
- **M8**: Package-level regexp compilation in AWS/Twilio/SauceLabs validators (eliminates per-call recompilation)
- **M16**: Removed unused `AddMatch` calls in scanner core (prevents unbounded WASM memory growth)

## Test plan

- [x] `GOWORK=off go build ./...` passes (exit 0)
- [x] `GOWORK=off go vet` passes (all packages except pre-existing `enum` test issue)
- [x] `GOWORK=off go test -short` passes (11/11 packages, 0 failures)
- [x] Vectorscan build: `CGO_ENABLED=1 go build -tags vectorscan` passes
- [x] Vectorscan scan of /tmp/kubernetes: 1497 matches across 22 rules
- [x] NoseyParker comparison: all 7 overlapping rules produce identical match counts (no regressions)
- [x] Backend reviewer approved all changes