### PR TITLE
feat: scan GitHub/GitLab repos without API token

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,14 @@ titus scan path/to/file.txt
 # Scan a directory for leaked credentials
 titus scan path/to/directory
 
+# Scan a public GitHub repository (no token needed)
+titus scan github.com/org/repo
+
+# Scan a public GitLab project (no token needed)
+titus scan gitlab.com/namespace/project
+
 # Scan git history for secrets in past commits
 titus scan --git path/to/repo
-
-# Scan a GitHub repository via API (no clone required)
-titus github owner/repo --token $GITHUB_TOKEN
 
 # Validate detected secrets against source APIs
 titus scan path/to/code --validate
@@ -63,6 +66,37 @@ titus scan path/to/code --validate
 Results are written to a datastore (`titus.ds` by default) and printed to the console.
 
 ## Scanning Options
+
+### GitHub & GitLab Scanning
+
+Scan public repositories directly by URL — no API token required:
+
+```bash
+# Scan a GitHub repository
+titus scan github.com/kubernetes/kubernetes
+
+# Scan a GitLab project
+titus scan gitlab.com/gitlab-org/cli
+
+# Full URLs work too
+titus scan https://github.com/org/repo
+titus scan https://gitlab.com/namespace/project.git
+```
+
+For organization-wide or user-wide scanning, use the dedicated subcommands:
+
+```bash
+# Scan all repos in a GitHub org
+titus github --org kubernetes --token $GITHUB_TOKEN
+
+# Scan all projects in a GitLab group
+titus gitlab scan --group mygroup --token $GITLAB_TOKEN
+
+# Scan a single repo with git history (finds deleted secrets)
+titus github owner/repo --git
+```
+
+Tokens are optional for public repositories. Set `GITHUB_TOKEN` or `GITLAB_TOKEN` (or use `--token`) for private repository access and higher API rate limits.
 
 ### Viewing Scan Results
 

--- a/cmd/titus/github_test.go
+++ b/cmd/titus/github_test.go
@@ -2,7 +2,43 @@ package main
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestGitHubCommand_Exists(t *testing.T) {
+	cmd, _, err := rootCmd.Find([]string{"github"})
+	require.NoError(t, err)
+	assert.Equal(t, "github", cmd.Name())
+}
+
+func TestGitHubCommand_NoCloneFlag(t *testing.T) {
+	cmd, _, err := rootCmd.Find([]string{"github"})
+	require.NoError(t, err)
+
+	flag := cmd.Flags().Lookup("no-clone")
+	require.NotNil(t, flag, "--no-clone flag should exist")
+	assert.Equal(t, "false", flag.DefValue)
+}
+
+func TestGitHubCommand_GitFlag(t *testing.T) {
+	cmd, _, err := rootCmd.Find([]string{"github"})
+	require.NoError(t, err)
+
+	flag := cmd.Flags().Lookup("git")
+	require.NotNil(t, flag, "--git flag should exist")
+	assert.Equal(t, "false", flag.DefValue)
+}
+
+func TestGitHubCommand_TokenOptional(t *testing.T) {
+	cmd, _, err := rootCmd.Find([]string{"github"})
+	require.NoError(t, err)
+
+	flag := cmd.Flags().Lookup("token")
+	require.NotNil(t, flag, "--token flag should exist")
+	assert.Equal(t, "", flag.DefValue, "token should have empty default (optional)")
+}
 
 func TestSplitOwnerRepo(t *testing.T) {
 	tests := []struct {

--- a/cmd/titus/gitlab.go
+++ b/cmd/titus/gitlab.go
@@ -19,89 +19,79 @@ var (
 	gitlabBaseURL      string
 	gitlabOutputPath   string
 	gitlabOutputFormat string
+	gitlabNoClone      bool
+	gitlabGit          bool
 )
 
 var gitlabCmd = &cobra.Command{
-	Use:   "gitlab",
-	Short: "Scan GitLab projects via API",
-	Long:  "Enumerate and scan GitLab projects without cloning",
+	Use:   "gitlab [namespace/project]",
+	Short: "Scan GitLab projects",
+	Long: `Scan GitLab projects by cloning and scanning locally.
+No API token needed for public projects.
+Use --token or GITLAB_TOKEN for private projects and higher rate limits.
+Use --git to scan full git history (slower but finds deleted secrets).`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runGitLabScan,
 }
 
 var gitlabScanCmd = &cobra.Command{
 	Use:   "scan [namespace/project]",
 	Short: "Scan GitLab project or group",
-	Long:  "Scan a single project, all projects in a group, or all projects for a user",
-	Args:  cobra.MaximumNArgs(1),
-	RunE:  runGitLabScan,
+	Long: `Scan a single project, all projects in a group, or all projects for a user.
+Projects are cloned and scanned for current files by default.
+No API token needed for public projects.
+Use --git to also scan full git history.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runGitLabScan,
 }
 
 func init() {
-	gitlabScanCmd.Flags().StringVar(&gitlabToken, "token", "", "GitLab token (or use GITLAB_TOKEN env)")
+	gitlabScanCmd.Flags().StringVar(&gitlabToken, "token", "", "GitLab token (or GITLAB_TOKEN env; optional for public projects)")
 	gitlabScanCmd.Flags().StringVar(&gitlabGroup, "group", "", "Scan all projects in group")
 	gitlabScanCmd.Flags().StringVar(&gitlabUser, "user", "", "Scan all projects for user")
 	gitlabScanCmd.Flags().StringVar(&gitlabBaseURL, "url", "", "GitLab base URL (default: gitlab.com)")
 	gitlabScanCmd.Flags().StringVar(&gitlabOutputPath, "output", "titus.db", "Output database path")
 	gitlabScanCmd.Flags().StringVar(&gitlabOutputFormat, "format", "human", "Output format: json, human")
+	gitlabScanCmd.Flags().BoolVar(&gitlabNoClone, "no-clone", false, "Fetch files via API instead of cloning (requires token, no git history)")
+	gitlabScanCmd.Flags().BoolVar(&gitlabGit, "git", false, "Scan full git history (slower; default scans only current files)")
+
+	gitlabCmd.Flags().StringVar(&gitlabToken, "token", "", "GitLab token (or GITLAB_TOKEN env; optional for public projects)")
+	gitlabCmd.Flags().StringVar(&gitlabGroup, "group", "", "Scan all projects in group")
+	gitlabCmd.Flags().StringVar(&gitlabUser, "user", "", "Scan all projects for user")
+	gitlabCmd.Flags().StringVar(&gitlabBaseURL, "url", "", "GitLab base URL (default: gitlab.com)")
+	gitlabCmd.Flags().StringVar(&gitlabOutputPath, "output", "titus.db", "Output database path")
+	gitlabCmd.Flags().StringVar(&gitlabOutputFormat, "format", "human", "Output format: json, human")
+	gitlabCmd.Flags().BoolVar(&gitlabNoClone, "no-clone", false, "Fetch files via API instead of cloning (requires token, no git history)")
+	gitlabCmd.Flags().BoolVar(&gitlabGit, "git", false, "Scan full git history (slower; default scans only current files)")
 
 	gitlabCmd.AddCommand(gitlabScanCmd)
 }
 
 func runGitLabScan(cmd *cobra.Command, args []string) error {
-	// Get token from flag or environment
 	token := gitlabToken
 	if token == "" {
 		token = os.Getenv("GITLAB_TOKEN")
 	}
-	if token == "" {
-		return fmt.Errorf("GitLab token required: use --token or GITLAB_TOKEN env")
+
+	if gitlabNoClone && token == "" {
+		return fmt.Errorf("--no-clone requires a GitLab token: use --token or GITLAB_TOKEN")
 	}
 
-	// Parse project path if provided
+	if token == "" {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Note: No GitLab token provided. Using unauthenticated access (public projects only).\n")
+		fmt.Fprintf(cmd.ErrOrStderr(), "Set GITLAB_TOKEN or use --token for private project access.\n\n")
+	}
+
 	var project string
 	if len(args) > 0 {
 		project = args[0]
 	}
 
-	// Validate input
 	if project == "" && gitlabGroup == "" && gitlabUser == "" {
 		return fmt.Errorf("must specify namespace/project, --group, or --user")
 	}
 
-	// Load rules
-	rules, err := loadRules("", "", "")
-	if err != nil {
-		return fmt.Errorf("loading rules: %w", err)
-	}
-
-	// Create rule map for finding ID computation
-	ruleMap := make(map[string]*types.Rule)
-	for _, r := range rules {
-		ruleMap[r.ID] = r
-	}
-
-	// Create matcher
-	m, err := matcher.New(matcher.Config{Rules: rules})
-	if err != nil {
-		return fmt.Errorf("creating matcher: %w", err)
-	}
-	defer m.Close()
-
-	// Create store
-	s, err := store.New(store.Config{Path: gitlabOutputPath})
-	if err != nil {
-		return fmt.Errorf("creating store: %w", err)
-	}
-	defer s.Close()
-
-	// Store rules for foreign key constraints
-	for _, r := range rules {
-		if err := s.AddRule(r); err != nil {
-			return fmt.Errorf("storing rule: %w", err)
-		}
-	}
-
-	// Create GitLab enumerator
-	enumerator, err := enum.NewGitLabEnumerator(enum.GitLabConfig{
+	glEnum, err := enum.NewGitLabEnumerator(enum.GitLabConfig{
 		Token:   token,
 		BaseURL: gitlabBaseURL,
 		Project: project,
@@ -112,32 +102,75 @@ func runGitLabScan(cmd *cobra.Command, args []string) error {
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("creating enumerator: %w", err)
+		return fmt.Errorf("creating GitLab client: %w", err)
 	}
 
-	// Scan
+	rules, err := loadRules("", "", "")
+	if err != nil {
+		return fmt.Errorf("loading rules: %w", err)
+	}
+
+	ruleMap := make(map[string]*types.Rule)
+	for _, r := range rules {
+		ruleMap[r.ID] = r
+	}
+
+	m, err := matcher.New(matcher.Config{Rules: rules})
+	if err != nil {
+		return fmt.Errorf("creating matcher: %w", err)
+	}
+	defer m.Close()
+
+	s, err := store.New(store.Config{Path: gitlabOutputPath})
+	if err != nil {
+		return fmt.Errorf("creating store: %w", err)
+	}
+	defer s.Close()
+
+	for _, r := range rules {
+		if err := s.AddRule(r); err != nil {
+			return fmt.Errorf("storing rule: %w", err)
+		}
+	}
+
 	ctx := context.Background()
+	var enumerator enum.Enumerator
+
+	if gitlabNoClone {
+		enumerator = glEnum
+	} else {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Enumerating projects...\n")
+		projects, err := glEnum.ListProjectURLs(ctx)
+		if err != nil {
+			return fmt.Errorf("listing projects: %w", err)
+		}
+
+		fmt.Fprintf(cmd.ErrOrStderr(), "Found %d projects to scan\n\n", len(projects))
+
+		cloneEnum := enum.NewCloneEnumerator(projects, enum.Config{
+			MaxFileSize: 10 * 1024 * 1024,
+		})
+		cloneEnum.Git = gitlabGit
+		enumerator = cloneEnum
+	}
+
 	matchCount := 0
 	findingCount := 0
 
 	err = enumerator.Enumerate(ctx, func(content []byte, blobID types.BlobID, prov types.Provenance) error {
-		// Store blob
 		if err := s.AddBlob(blobID, int64(len(content))); err != nil {
 			return fmt.Errorf("storing blob: %w", err)
 		}
 
-		// Store provenance
 		if err := s.AddProvenance(blobID, prov); err != nil {
 			return fmt.Errorf("storing provenance: %w", err)
 		}
 
-		// Match content
 		matches, err := m.MatchWithBlobID(content, blobID)
 		if err != nil {
 			return fmt.Errorf("matching content: %w", err)
 		}
 
-		// Compute line/column for each match
 		for _, match := range matches {
 			startLine, startCol := types.ComputeLineColumn(content, int(match.Location.Offset.Start))
 			endLine, endCol := types.ComputeLineColumn(content, int(match.Location.Offset.End))
@@ -147,7 +180,6 @@ func runGitLabScan(cmd *cobra.Command, args []string) error {
 			match.Location.Source.End.Column = endCol
 		}
 
-		// Store matches and findings
 		for _, match := range matches {
 			matchCount++
 
@@ -155,7 +187,6 @@ func runGitLabScan(cmd *cobra.Command, args []string) error {
 				return fmt.Errorf("storing match: %w", err)
 			}
 
-			// Create finding (deduplicated by finding ID)
 			rule, ok := ruleMap[match.RuleID]
 			if !ok {
 				return fmt.Errorf("rule not found: %s", match.RuleID)
@@ -189,5 +220,17 @@ func runGitLabScan(cmd *cobra.Command, args []string) error {
 	fmt.Fprintf(cmd.OutOrStdout(), "GitLab scan complete: %d matches, %d findings\n", matchCount, findingCount)
 	fmt.Fprintf(cmd.OutOrStdout(), "Results stored in: %s\n", gitlabOutputPath)
 
-	return nil
+	if gitlabOutputFormat == "json" {
+		matches, err := s.GetAllMatches()
+		if err != nil {
+			return fmt.Errorf("retrieving matches: %w", err)
+		}
+		return outputMatches(cmd, matches)
+	}
+
+	findings, err := s.GetFindings()
+	if err != nil {
+		return fmt.Errorf("retrieving findings: %w", err)
+	}
+	return outputFindings(cmd, findings)
 }

--- a/cmd/titus/gitlab_test.go
+++ b/cmd/titus/gitlab_test.go
@@ -2,7 +2,28 @@ package main
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestGitLabScanCommand_NoCloneFlag(t *testing.T) {
+	cmd, _, err := rootCmd.Find([]string{"gitlab", "scan"})
+	require.NoError(t, err)
+
+	flag := cmd.Flags().Lookup("no-clone")
+	require.NotNil(t, flag, "--no-clone flag should exist")
+	assert.Equal(t, "false", flag.DefValue)
+}
+
+func TestGitLabScanCommand_TokenOptional(t *testing.T) {
+	cmd, _, err := rootCmd.Find([]string{"gitlab", "scan"})
+	require.NoError(t, err)
+
+	flag := cmd.Flags().Lookup("token")
+	require.NotNil(t, flag, "--token flag should exist")
+	assert.Equal(t, "", flag.DefValue, "token should have empty default (optional)")
+}
 
 func TestGitLabCmd_Exists(t *testing.T) {
 	// Verify gitlab command exists
@@ -13,8 +34,9 @@ func TestGitLabCmd_Exists(t *testing.T) {
 
 func TestGitLabCmd_Use(t *testing.T) {
 	// Verify command use string
-	if gitlabCmd.Use != "gitlab" {
-		t.Errorf("expected Use='gitlab', got %q", gitlabCmd.Use)
+	expected := "gitlab [namespace/project]"
+	if gitlabCmd.Use != expected {
+		t.Errorf("expected Use=%q, got %q", expected, gitlabCmd.Use)
 	}
 }
 
@@ -85,4 +107,13 @@ func TestGitLabCmd_HasScanSubcommand(t *testing.T) {
 	if !found {
 		t.Error("gitlab command does not have 'scan' subcommand")
 	}
+}
+
+func TestGitLabScanCommand_GitFlag(t *testing.T) {
+	cmd, _, err := rootCmd.Find([]string{"gitlab", "scan"})
+	require.NoError(t, err)
+
+	flag := cmd.Flags().Lookup("git")
+	require.NotNil(t, flag, "--git flag should exist")
+	assert.Equal(t, "false", flag.DefValue)
 }

--- a/pkg/enum/clone.go
+++ b/pkg/enum/clone.go
@@ -1,0 +1,118 @@
+package enum
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+)
+
+// RepoInfo holds basic repository information for clone-based scanning.
+type RepoInfo struct {
+	Name          string // Full name (e.g., "kubernetes/kubernetes")
+	CloneURL      string // HTTPS clone URL
+	DefaultBranch string
+}
+
+// CloneEnumerator clones repositories and scans them.
+// By default it does a full clone and filesystem scan.
+// Set Git=true to do a full clone with git history scanning.
+type CloneEnumerator struct {
+	repos  []RepoInfo
+	config Config
+	Git    bool // false = full clone + filesystem scan, true = full clone + git history (thorough)
+	Depth  int  // override clone depth (0 = automatic: full clone for filesystem mode, unlimited for git mode)
+}
+
+// NewCloneEnumerator creates a new clone-based enumerator.
+func NewCloneEnumerator(repos []RepoInfo, config Config) *CloneEnumerator {
+	return &CloneEnumerator{repos: repos, config: config}
+}
+
+// Enumerate clones each repository, scans it, and cleans up.
+func (e *CloneEnumerator) Enumerate(ctx context.Context, callback func(content []byte, blobID types.BlobID, prov types.Provenance) error) error {
+	for _, repo := range e.repos {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		if err := e.cloneAndScan(ctx, repo, callback); err != nil {
+			// Log error and continue to next repo
+			fmt.Fprintf(os.Stderr, "warning: skipping %s: %v\n", repo.Name, err)
+			continue
+		}
+	}
+	return nil
+}
+
+func (e *CloneEnumerator) cloneAndScan(ctx context.Context, repo RepoInfo, callback func(content []byte, blobID types.BlobID, prov types.Provenance) error) error {
+	tmpDir, err := os.MkdirTemp("", "titus-clone-*")
+	if err != nil {
+		return fmt.Errorf("creating temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	clonePath := filepath.Join(tmpDir, "repo")
+
+	// Determine effective clone depth
+	depth := e.Depth
+
+	// Build clone args
+	cloneArgs := []string{"-c", "http.postBuffer=524288000", "clone", "--quiet"}
+	if e.Git && depth == 0 {
+		// Full history: bare clone for efficiency (no working tree needed)
+		cloneArgs = append(cloneArgs, "--bare")
+	}
+	if depth > 0 {
+		cloneArgs = append(cloneArgs, "--depth", strconv.Itoa(depth))
+	}
+	cloneArgs = append(cloneArgs, repo.CloneURL, clonePath)
+
+	fmt.Fprintf(os.Stderr, "Cloning %s...\n", repo.Name)
+	cmd := exec.CommandContext(ctx, "git", cloneArgs...)
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("cloning %s: %w", repo.Name, err)
+	}
+
+	cloneConfig := e.config
+	cloneConfig.Root = clonePath
+
+	if e.Git {
+		// Git history mode: walk all commits
+		gitEnum := NewGitEnumerator(cloneConfig)
+		if depth == 0 {
+			gitEnum.WalkAll = true
+		}
+		return gitEnum.Enumerate(ctx, func(content []byte, blobID types.BlobID, prov types.Provenance) error {
+			if gp, ok := prov.(types.GitProvenance); ok {
+				gp.RepoPath = repo.Name
+				return callback(content, blobID, gp)
+			}
+			return callback(content, blobID, prov)
+		})
+	}
+
+	// Filesystem mode (default): fast scan of working tree
+	return NewFilesystemEnumerator(cloneConfig).Enumerate(ctx, func(content []byte, blobID types.BlobID, prov types.Provenance) error {
+		// Rewrite file provenance to include repo name
+		if fp, ok := prov.(types.FileProvenance); ok {
+			// Convert absolute temp path to repo-relative path
+			relPath, err := filepath.Rel(clonePath, fp.FilePath)
+			if err != nil {
+				relPath = fp.FilePath
+			}
+			return callback(content, blobID, types.GitProvenance{
+				RepoPath: repo.Name,
+				BlobPath: relPath,
+			})
+		}
+		return callback(content, blobID, prov)
+	})
+}

--- a/pkg/enum/clone_test.go
+++ b/pkg/enum/clone_test.go
@@ -1,0 +1,144 @@
+package enum
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCloneEnumerator_EmptyRepos(t *testing.T) {
+	e := NewCloneEnumerator(nil, Config{})
+	var count int
+	err := e.Enumerate(context.Background(), func(content []byte, blobID types.BlobID, prov types.Provenance) error {
+		count++
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+}
+
+func TestCloneEnumerator_InvalidURL(t *testing.T) {
+	repos := []RepoInfo{
+		{Name: "invalid/repo", CloneURL: "https://github.com/nonexistent-user-xyz123/nonexistent-repo-xyz123.git"},
+	}
+	e := NewCloneEnumerator(repos, Config{MaxFileSize: 10 * 1024 * 1024})
+
+	var count int
+	err := e.Enumerate(context.Background(), func(content []byte, blobID types.BlobID, prov types.Provenance) error {
+		count++
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+}
+
+func TestCloneEnumerator_LocalRepo(t *testing.T) {
+	tmpDir := t.TempDir()
+	repoDir := filepath.Join(tmpDir, "test-repo")
+	require.NoError(t, os.MkdirAll(repoDir, 0o755))
+
+	cmds := [][]string{
+		{"git", "init", repoDir},
+		{"git", "-C", repoDir, "config", "user.email", "test@test.com"},
+		{"git", "-C", repoDir, "config", "user.name", "Test"},
+	}
+	for _, args := range cmds {
+		cmd := exec.Command(args[0], args[1:]...)
+		require.NoError(t, cmd.Run(), "failed running: %v", args)
+	}
+
+	testFile := filepath.Join(repoDir, "secret.txt")
+	require.NoError(t, os.WriteFile(testFile, []byte("this is a test file with content"), 0o644))
+
+	cmd := exec.Command("git", "-C", repoDir, "add", ".")
+	require.NoError(t, cmd.Run())
+	cmd = exec.Command("git", "-C", repoDir, "commit", "-m", "initial commit")
+	require.NoError(t, cmd.Run())
+
+	repos := []RepoInfo{
+		{Name: "test/repo", CloneURL: "file://" + repoDir},
+	}
+	e := NewCloneEnumerator(repos, Config{MaxFileSize: 10 * 1024 * 1024})
+
+	var blobs []string
+	var provenances []types.Provenance
+	err := e.Enumerate(context.Background(), func(content []byte, blobID types.BlobID, prov types.Provenance) error {
+		blobs = append(blobs, string(content))
+		provenances = append(provenances, prov)
+		return nil
+	})
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, len(blobs), 1, "should enumerate at least one blob")
+
+	for _, prov := range provenances {
+		gp, ok := prov.(types.GitProvenance)
+		if ok {
+			assert.Equal(t, "test/repo", gp.RepoPath, "provenance should use repo name, not temp path")
+		}
+	}
+}
+
+func TestCloneEnumerator_GitMode(t *testing.T) {
+	tmpDir := t.TempDir()
+	repoDir := filepath.Join(tmpDir, "test-repo")
+	require.NoError(t, os.MkdirAll(repoDir, 0o755))
+
+	cmds := [][]string{
+		{"git", "init", repoDir},
+		{"git", "-C", repoDir, "config", "user.email", "test@test.com"},
+		{"git", "-C", repoDir, "config", "user.name", "Test"},
+	}
+	for _, args := range cmds {
+		cmd := exec.Command(args[0], args[1:]...)
+		require.NoError(t, cmd.Run(), "failed running: %v", args)
+	}
+
+	testFile := filepath.Join(repoDir, "secret.txt")
+	require.NoError(t, os.WriteFile(testFile, []byte("this is a test file"), 0o644))
+
+	cmd := exec.Command("git", "-C", repoDir, "add", ".")
+	require.NoError(t, cmd.Run())
+	cmd = exec.Command("git", "-C", repoDir, "commit", "-m", "initial commit")
+	require.NoError(t, cmd.Run())
+
+	repos := []RepoInfo{
+		{Name: "test/repo", CloneURL: "file://" + repoDir},
+	}
+	e := NewCloneEnumerator(repos, Config{MaxFileSize: 10 * 1024 * 1024})
+	e.Git = true
+
+	var blobs []string
+	err := e.Enumerate(context.Background(), func(content []byte, blobID types.BlobID, prov types.Provenance) error {
+		blobs = append(blobs, string(content))
+		// In git mode, provenance should be GitProvenance
+		gp, ok := prov.(types.GitProvenance)
+		assert.True(t, ok, "git mode should produce GitProvenance")
+		if ok {
+			assert.Equal(t, "test/repo", gp.RepoPath)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, len(blobs), 1)
+}
+
+func TestCloneEnumerator_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	repos := []RepoInfo{
+		{Name: "test/repo", CloneURL: "https://github.com/octocat/Hello-World.git"},
+	}
+	e := NewCloneEnumerator(repos, Config{})
+
+	err := e.Enumerate(ctx, func(content []byte, blobID types.BlobID, prov types.Provenance) error {
+		return nil
+	})
+	assert.ErrorIs(t, err, context.Canceled)
+}

--- a/pkg/enum/github_test.go
+++ b/pkg/enum/github_test.go
@@ -48,17 +48,20 @@ func TestGitHubEnumerator_Interface(t *testing.T) {
 	var _ Enumerator = enumerator
 }
 
-// TestGitHubEnumerator_RequiresToken tests that token is required.
-func TestGitHubEnumerator_RequiresToken(t *testing.T) {
+// TestGitHubEnumerator_TokenOptional tests that token is optional (unauthenticated access allowed).
+func TestGitHubEnumerator_TokenOptional(t *testing.T) {
 	config := GitHubConfig{
 		Token: "",
 		Owner: "owner",
 		Repo:  "repo",
 	}
 
-	_, err := NewGitHubEnumerator(config)
-	if err == nil {
-		t.Fatal("expected error when token is empty, got nil")
+	enumerator, err := NewGitHubEnumerator(config)
+	if err != nil {
+		t.Fatalf("expected no error with empty token, got: %v", err)
+	}
+	if enumerator == nil {
+		t.Fatal("expected non-nil enumerator")
 	}
 }
 

--- a/pkg/enum/gitlab.go
+++ b/pkg/enum/gitlab.go
@@ -27,10 +27,6 @@ type GitLabEnumerator struct {
 
 // NewGitLabEnumerator creates a new GitLab enumerator.
 func NewGitLabEnumerator(cfg GitLabConfig) (*GitLabEnumerator, error) {
-	if cfg.Token == "" {
-		return nil, fmt.Errorf("GitLab token is required")
-	}
-
 	if cfg.Project == "" && cfg.Group == "" && cfg.User == "" {
 		return nil, fmt.Errorf("must specify project, group, or user")
 	}
@@ -134,6 +130,24 @@ func (e *GitLabEnumerator) listProjects(ctx context.Context) ([]*gitlab.Project,
 	}
 
 	return nil, fmt.Errorf("must specify project, group, or user")
+}
+
+// ListProjectURLs returns clone URLs for projects matching the configuration.
+func (e *GitLabEnumerator) ListProjectURLs(ctx context.Context) ([]RepoInfo, error) {
+	projects, err := e.listProjects(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var urls []RepoInfo
+	for _, p := range projects {
+		urls = append(urls, RepoInfo{
+			Name:          p.PathWithNamespace,
+			CloneURL:      p.HTTPURLToRepo,
+			DefaultBranch: p.DefaultBranch,
+		})
+	}
+	return urls, nil
 }
 
 // enumerateProject walks a single project's file tree.

--- a/pkg/enum/gitlab_test.go
+++ b/pkg/enum/gitlab_test.go
@@ -7,18 +7,21 @@ import (
 	"github.com/praetorian-inc/titus/pkg/types"
 )
 
-func TestGitLabEnumerator_RequiresToken(t *testing.T) {
-	// Test that GitLabEnumerator requires a token
-	_, err := NewGitLabEnumerator(GitLabConfig{
-		Token: "",
+func TestGitLabEnumerator_TokenOptional(t *testing.T) {
+	// Test that GitLabEnumerator allows empty token (unauthenticated access)
+	enumerator, err := NewGitLabEnumerator(GitLabConfig{
+		Token:   "",
 		Project: "owner/project",
 		Config: Config{
 			MaxFileSize: 10 * 1024 * 1024,
 		},
 	})
 
-	if err == nil {
-		t.Error("expected error when token is empty, got nil")
+	if err != nil {
+		t.Errorf("expected no error with empty token, got: %v", err)
+	}
+	if enumerator == nil {
+		t.Error("expected non-nil enumerator")
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds clone-based scanning for GitHub and GitLab repositories, eliminating the requirement for an API token when scanning public repos. Repos are cloned via the git CLI and scanned using the existing filesystem enumerator.

- **Closes #74** — scan repos/users/orgs like NoseyParker, without needing a token
- **Fixes #73** — `titus scan gitlab.com/gitlab-org/gitlab` now works (clones via git CLI instead of go-git, avoiding OOM on large repos)

## What Changed

### Smart URL routing in `titus scan`
```bash
# These all work now — no token needed for public repos
titus scan github.com/kubernetes/kubernetes
titus scan https://github.com/org/repo
titus scan gitlab.com/gitlab-org/gitlab
titus scan https://gitlab.com/namespace/project.git
```

The `scan` command detects `github.com` and `gitlab.com` URLs and automatically clones + scans them. Filesystem paths continue to work as before.

### Token-optional GitHub/GitLab subcommands
```bash
# Org/group-wide scanning (token optional for public)
titus github --org kubernetes
titus gitlab scan --group mygroup

# Single repo (both forms work now)
titus github owner/repo
titus gitlab namespace/project    # NEW — previously required `titus gitlab scan`
```

### New flags
| Flag | Description |
|------|-------------|
| `--no-clone` | Legacy API-only mode (requires token, fetches files via API) |
| `--git` | Scan full git history via go-git (slower, finds deleted secrets) |

### Files changed (12 files, +847/-113)
- `pkg/enum/clone.go` — **NEW**: `CloneEnumerator` clones repos via `git clone` and delegates to `FilesystemEnumerator`
- `pkg/enum/github.go` — Token optional, added `ListRepoURLs()` for clone-based scanning
- `pkg/enum/gitlab.go` — Token optional, added `ListProjectURLs()` for clone-based scanning
- `cmd/titus/scan.go` — URL detection with `parseRepoURL()`, routes to `runRepoScan()` for remote repos
- `cmd/titus/github.go` — Token optional with warnings, `--no-clone`/`--git` flags
- `cmd/titus/gitlab.go` — Same pattern as github.go, added `RunE` to top-level command for UX consistency
- `README.md` — Updated Quick Start and new "GitHub & GitLab Scanning" section

## Scan Metrics

Tested on Apple Silicon (M3 Max), no API token, Vectorscan-accelerated:

### kubernetes/kubernetes (GitHub)

| Metric | Value |
|--------|-------|
| Repo size | 1.5 GB |
| Total wall clock | **58s** |
| Clone time | ~54s |
| Scan time | ~4s |
| Blobs scanned | 27,366 |
| Data scanned | 247 MB |
| Scan throughput | 4.4 MB/s |
| Matches | 1,496 |
| Unique findings | 354 |
| Top rules | PEM keys (99), private keys (98), generic secrets (35), LinkedIn tokens (25) |

### gitlab-org/gitlab (GitLab)

| Metric | Value |
|--------|-------|
| Repo size | 3.9 GB |
| Total wall clock | **3m 33s** |
| Clone time | ~3m 6s |
| Scan time | ~27s |
| Blobs scanned | 88,723 |
| Data scanned | 500 MB |
| Scan throughput | 2.4 MB/s |
| Matches | 13,500 |
| Unique findings | 701 |
| Top rules | URI credentials (130), generic passwords (124), Mattermost URLs (36), LinkedIn tokens (28) |

**Key insight:** Clone time dominates (~93% for k8s, ~87% for gitlab). The actual scan is fast — 4s for k8s, 27s for gitlab. This is a fundamental improvement over the previous go-git approach which caused OOM on large repos like gitlab-org/gitlab (#73).

### Comparison with issue #73
The reporter's original scan of gitlab-org/gitlab crashed after 2m09s with full CPU utilization (go-git OOM). This PR completes the same scan in 3m33s with clean output and 701 findings.

## Test Plan

- [x] All unit tests pass (`go test ./...` — 13 packages)
- [x] `titus scan github.com/kubernetes/kubernetes` — 58s, 354 findings
- [x] `titus scan gitlab.com/gitlab-org/gitlab` — 3m33s, 701 findings
- [x] `titus scan github.com/praetorian-inc/titus` — 13s (URL format smoke test)
- [x] `titus scan https://github.com/praetorian-inc/titus` — works (https prefix)
- [x] `titus scan https://gitlab.com/gitlab-org/cli` — works (GitLab https prefix)
- [x] `titus scan ./local/path` — existing filesystem scanning unchanged
- [x] Token warnings display correctly when no token provided
- [x] `--no-clone` requires token (errors with helpful message if missing)
- [x] `titus gitlab namespace/project` now works directly (UX parity with github)