### PR TITLE
Route external contrib Linear issues as sub-issues in Backlog

### DIFF
--- a/.github/workflows/external-contribution.yml
+++ b/.github/workflows/external-contribution.yml
@@ -14,6 +14,7 @@ jobs:
         with:
           linear-team-id: ${{ secrets.LINEAR_TEAM_ID }}
           linear-assignee-id: ${{ secrets.LINEAR_ASSIGNEE_ID }}
+          linear-parent-issue-id: ${{ secrets.LINEAR_PARENT_ISSUE_ID }}
           slack-channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
         env:
           ORG_MEMBER_CHECK_PAT: ${{ secrets.ORG_MEMBER_CHECK_PAT }}


### PR DESCRIPTION
## Summary
- Adds `linear-parent-issue-id` input to route external contribution issues as sub-issues under the tool's parent Linear issue
- State defaults to Backlog (no longer Triage)
- Parent issue ID stored as repo-level secret `LINEAR_PARENT_ISSUE_ID`
- Workflow file remains identical across all repos (DRY)

## Test plan
- [ ] Open a test issue from a non-org account to verify sub-issue creation
- [ ] Confirm issue appears in Backlog under the correct parent issue