### PR TITLE
Add DeviantArt OAuth client secret detection rule

### DIFF
--- a/pkg/rule/rules/deviantart.yml
+++ b/pkg/rule/rules/deviantart.yml
@@ -37,3 +37,54 @@ rules:
 
     references:
     - https://www.deviantart.com/developers/http/v1/20210526
+
+  - name: DeviantArt OAuth Client Secret
+    id: kingfisher.deviantart.1
+
+    pattern: |
+      (?xi)
+      (?:deviantart|deviant_art|da_)
+      (?:.|\n|\r){0,64}?
+      (?:client[_-]?secret|oauth[_-]?secret)
+      (?:.|\n|\r){0,32}?
+      \b
+      (?P<secret>
+        (?!0123456789abcdef)
+        [0-9a-f]{32}
+      )
+      \b
+
+    examples:
+    - 'deviantart_client_secret = "76b08c69cfb27f26d6161f9ab6d061a1"'
+    - 'DEVIANTART_CLIENT_SECRET=ccd16fd197588957c0bd74939057fa9d'
+    - |
+        deviantart:
+          client_id: "7926"
+          client_secret: "7e9e2374a223c479f70e1bf18874f8c3"
+    - |
+        deviantart() {
+            CLIENT_ID=16531
+            CLIENT_SECRET=68c00f3d0ceab95b0fac638b33a3368e
+        }
+
+    negative_examples:
+    - 'github_client_secret = "76b08c69cfb27f26d6161f9ab6d061a1"'
+    - 'stripe_client_secret = "76b08c69cfb27f26d6161f9ab6d061a1"'
+    - 'deviantart_client_secret = "0123456789abcdef0123456789abcdef"'
+    - 'deviantart_client_secret = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"'
+    - 'deviantart_client_secret = "LMNOPQRSTUVWXYZZZZZZZZ9999999999"'
+
+    description: |
+      DeviantArt OAuth 2.0 client secret used for API authentication.
+      An attacker with this credential and the corresponding client_id can
+      obtain access tokens via the client_credentials grant type, enabling
+      unauthorized API access to DeviantArt resources. Potential impact
+      includes scraping private user data, impersonating applications, and
+      abusing the DeviantArt API on behalf of the registered application.
+
+    references:
+    - https://www.deviantart.com/developers/authentication
+    - https://www.deviantart.com/developers/
+    - https://www.deviantart.com/developers/http/v1/20240701
+
+    categories: [api, secret]

--- a/pkg/validator/validators/deviantart.yaml
+++ b/pkg/validator/validators/deviantart.yaml
@@ -10,6 +10,7 @@ validators:
       url: "https://www.deviantart.com/api/v1/oauth2/placebo"
       auth:
         type: none  # Credentials sent in request body, not auth header
+        secret_group: "token"  # Matches (?P<token>...) in rule regex
       headers:
         - name: Content-Type
           value: application/x-www-form-urlencoded


### PR DESCRIPTION
## Summary
- Add `kingfisher.deviantart.1` rule to detect DeviantArt OAuth client secrets (32-char lowercase hex) alongside existing `np.deviantart.1` access token rule
- Fix missing `secret_group` in existing `np.deviantart.1` validator config (was causing "secret_group not specified" error during `--validate`)
- GitHub validation: 4 unique real credentials found across 70 files (~75% real credential rate)

## Test plan
- [x] `go test ./pkg/rule/... -count=1` passes
- [x] `go test ./pkg/validator/... -count=1` passes
- [x] `titus rules list --include deviantart` shows both rules (`np.deviantart.1`, `kingfisher.deviantart.1`)
- [x] `titus scan <test-file> --validate --rules-include deviantart` returns `invalid` (401) for np.deviantart.1 validator

**Note:** CI failures (`undefined: matcher.New`) are pre-existing on `main` — unrelated to this PR's YAML-only changes.