### PR TITLE
fix: handle combined regex flags like (?xi) in vectorscan

### DIFF
--- a/pkg/matcher/extended_test.go
+++ b/pkg/matcher/extended_test.go
@@ -85,6 +85,21 @@ test\ pattern    (?# with escaped space )
 			input:    `(?x) (?s) \. .+`,
 			expected: `\..+`,
 		},
+		{
+			name:     "pattern with (?xi) combined flags preserves i",
+			input:    `(?xi) test pattern`,
+			expected: `(?i)testpattern`,
+		},
+		{
+			name:     "pattern with (?xis) multiple flags preserves is",
+			input:    `(?xis) test .+`,
+			expected: `(?is)test.+`,
+		},
+		{
+			name:     "pattern with (?ixm) x in middle preserves im",
+			input:    `(?ixm) test$`,
+			expected: `(?im)test$`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/matcher/vectorscan.go
+++ b/pkg/matcher/vectorscan.go
@@ -330,18 +330,42 @@ func hasExtendedMode(pattern string) bool {
 }
 
 // hasCaseInsensitive checks if pattern uses case-insensitive mode.
+// Detects both (?i) and combined forms like (?xi), (?is), etc.
 func hasCaseInsensitive(pattern string) bool {
-	return strings.Contains(pattern, "(?i)")
+	return hasFlag(pattern, 'i')
 }
 
 // hasDotAll checks if pattern uses dot-all mode.
+// Detects both (?s) and combined forms like (?xs), (?is), etc.
 func hasDotAll(pattern string) bool {
-	return strings.Contains(pattern, "(?s)")
+	return hasFlag(pattern, 's')
 }
 
 // hasMultiline checks if pattern uses multiline mode.
+// Detects both (?m) and combined forms like (?xm), (?im), etc.
 func hasMultiline(pattern string) bool {
-	return strings.Contains(pattern, "(?m)")
+	return hasFlag(pattern, 'm')
+}
+
+// hasFlag checks if a pattern contains the given flag character in any flag group.
+// It searches for (?...) groups anywhere in the pattern and checks if the flag is present.
+func hasFlag(pattern string, flag byte) bool {
+	for i := 0; i < len(pattern)-2; i++ {
+		if pattern[i] == '(' && pattern[i+1] == '?' {
+			// Found a flag group, extract flags until ')'
+			for j := i + 2; j < len(pattern); j++ {
+				c := pattern[j]
+				if c == ')' || c == ':' || c == '!' || c == '=' || c == '<' {
+					// End of flags (or start of non-capturing/lookahead/lookbehind group)
+					break
+				}
+				if c == flag {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 // Match scans content against all loaded rules.


### PR DESCRIPTION
  ## Summary
  - Fixes vectorscan matcher failing to match patterns with combined regex flags like `(?xi)`, `(?xis)`, `(?ixm)`
  - Rules using combined flags (e.g., `kingfisher.recaptcha.1`) now match correctly with vectorscan
  - Snippet output matches now correctly reports `Before`, `Matching`, and `After` when using vectorscan

  ## Test plan
  - [x] Added `TestHasFlag` with 11 test cases for flag detection in combined groups
  - [x] Added `TestVectorscanMatcher_CombinedFlagsCaseInsensitive` end-to-end test
  - [x] Extended `TestStripExtendedMode` with cases for `(?xi)`, `(?xis)`, `(?ixm)`
  - [x] All existing matcher tests pass

  ## Root Cause
  Two functions assumed flags appear in isolation (e.g., `(?i)`) rather than combined (e.g., `(?xi)`):

  1. **`stripExtendedMode()`** checked for literal `(?x)` prefix only
  2. **`hasCaseInsensitive()` etc.** used `strings.Contains(pattern, "(?i)")` which doesn't match `(?xi)`

  For a pattern like `(?xi)recaptcha...`:
  - `stripExtendedMode()` didn't recognize it → pattern unchanged
  - `hasCaseInsensitive()` returned `false` → Hyperscan compiled without `Caseless` flag
  - Match failed because "RECAPTCHA" ≠ "recaptcha"

  ## Changes
  | File | Change |
  |------|--------|
  | `pkg/matcher/extended.go` | `stripExtendedMode()` now extracts flag group, removes only 'x', preserves others |
  | `pkg/matcher/vectorscan.go` | Added `hasFlag()` helper; updated flag detection functions to use it |
  | `pkg/matcher/extended_test.go` | Added 3 test cases for combined flags |
  | `pkg/matcher/vectorscan_test.go` | Added `TestHasFlag` (11 cases) and `TestVectorscanMatcher_CombinedFlagsCaseInsensitive` |