### PR TITLE
fix: disable vectorscan build tag when CGO is disabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,11 @@ LDFLAGS := -ldflags "-s -w -X main.version=$(VERSION)"
 CGO_ENABLED ?= 1
 GO_TAGS ?= vectorscan
 
+# Clear vectorscan tag when CGO is disabled (vectorscan requires CGO)
+ifeq ($(CGO_ENABLED),0)
+  GO_TAGS :=
+endif
+
 # Build -tags flag (empty when GO_TAGS is empty to avoid bare "-tags" argument)
 ifneq ($(GO_TAGS),)
   TAGS_FLAG := -tags $(GO_TAGS)


### PR DESCRIPTION
When `CGO_ENABLED=0` was passed to make build, the `GO_TAGS` variable still defaulted to `"vectorscan"`, causing the build to fail. Vectorscan/Hyperscan requires CGO since it wraps a C library.

Add a conditional to clear `GO_TAGS` when `CGO_ENABLED=0`, ensuring the pure-Go fallback matcher is used instead.