### PR TITLE
fix: register all Go validators in CLI scan command

### DIFF
--- a/cmd/titus/scan.go
+++ b/cmd/titus/scan.go
@@ -908,26 +908,7 @@ func initValidationEngine() *validator.Engine {
 	if !scanValidate {
 		return nil
 	}
-
-	var validators []validator.Validator
-
-	// Add Go validators (complex multi-credential validation)
-	validators = append(validators, validator.NewAWSValidator())
-	validators = append(validators, validator.NewSauceLabsValidator())
-	validators = append(validators, validator.NewTwilioValidator())
-	validators = append(validators, validator.NewAzureStorageValidator())
-	validators = append(validators, validator.NewPostgresValidator())
-
-	// Add embedded YAML validators
-	embedded, err := validator.LoadEmbeddedValidators()
-	if err != nil {
-		// Log warning but continue
-		fmt.Fprintf(os.Stderr, "warning: failed to load embedded validators: %v\n", err)
-	} else {
-		validators = append(validators, embedded...)
-	}
-
-	return validator.NewEngine(scanValidateWorkers, validators...)
+	return validator.NewDefaultEngine(scanValidateWorkers)
 }
 
 // validateMatches validates matches using the validation engine.

--- a/pkg/validator/engine.go
+++ b/pkg/validator/engine.go
@@ -8,6 +8,35 @@ import (
 	"github.com/praetorian-inc/titus/pkg/types"
 )
 
+// NewDefaultEngine creates a validation engine pre-loaded with all built-in validators.
+// This is the single source of truth for validator registration.
+func NewDefaultEngine(workers int) *Engine {
+	var validators []Validator
+
+	// Go validators (complex multi-credential validation)
+	validators = append(validators, NewAWSValidator())
+	validators = append(validators, NewSauceLabsValidator())
+	validators = append(validators, NewTwilioValidator())
+	validators = append(validators, NewAzureStorageValidator())
+	validators = append(validators, NewPostgresValidator())
+	validators = append(validators, NewBrowserStackValidator())
+	validators = append(validators, NewAmplitudeValidator())
+	validators = append(validators, NewHelpScoutValidator())
+	validators = append(validators, NewCypressValidator())
+	validators = append(validators, NewKeenIOValidator())
+	validators = append(validators, NewBranchIOValidator())
+	validators = append(validators, NewZendeskValidator())
+	validators = append(validators, NewWPEngineValidator())
+
+	// Embedded YAML validators
+	embedded, err := LoadEmbeddedValidators()
+	if err == nil {
+		validators = append(validators, embedded...)
+	}
+
+	return NewEngine(workers, validators...)
+}
+
 // Engine coordinates validation across multiple validators with caching.
 type Engine struct {
 	validators []Validator

--- a/titus.go
+++ b/titus.go
@@ -311,30 +311,7 @@ func (s *Scanner) validateMatches(ctx context.Context, matches []*Match) {
 
 // createValidationEngine creates a validation engine with all available validators.
 func createValidationEngine(workers int) *validator.Engine {
-	var validators []validator.Validator
-
-	// Add Go validators (complex multi-credential validation)
-	validators = append(validators, validator.NewAWSValidator())
-	validators = append(validators, validator.NewSauceLabsValidator())
-	validators = append(validators, validator.NewTwilioValidator())
-	validators = append(validators, validator.NewAzureStorageValidator())
-	validators = append(validators, validator.NewPostgresValidator())
-	validators = append(validators, validator.NewBrowserStackValidator())
-	validators = append(validators, validator.NewAmplitudeValidator())
-	validators = append(validators, validator.NewHelpScoutValidator())
-	validators = append(validators, validator.NewCypressValidator())
-	validators = append(validators, validator.NewKeenIOValidator())
-	validators = append(validators, validator.NewBranchIOValidator())
-	validators = append(validators, validator.NewZendeskValidator())
-	validators = append(validators, validator.NewWPEngineValidator())
-
-	// Add embedded YAML validators
-	embedded, err := validator.LoadEmbeddedValidators()
-	if err == nil {
-		validators = append(validators, embedded...)
-	}
-
-	return validator.NewEngine(workers, validators...)
+	return validator.NewDefaultEngine(workers)
 }
 
 // LoadRulesFromFile loads detection rules from a YAML file.


### PR DESCRIPTION
## Summary
- The CLI `initValidationEngine()` only registered 5 of 13 Go validators, causing BrowserStack, Amplitude, HelpScout, Cypress, KeenIO, BranchIO, Zendesk, and WPEngine to silently return "no validator available" during `titus scan --validate`
- Consolidated validator registration into `validator.NewDefaultEngine()` as the single source of truth, called by both the library API and CLI
- Net reduction of 13 lines — eliminates duplicated registration lists that were already out of sync

## Test plan
- [x] `go build ./...` — clean compilation
- [x] `go test ./pkg/validator/` — all 156 tests pass (154 pass, 2 skip)
- [x] `go test ./...` — full suite passes (14 packages)
- [x] End-to-end: `titus scan <file> --validate --verbose` now shows Cypress validator firing (previously reported "no validator available")