### PR TITLE
audit: iterable rule and validator (LAB-1277)

### DIFF
--- a/pkg/rule/rules/iterable.yml
+++ b/pkg/rule/rules/iterable.yml
@@ -3,6 +3,16 @@ rules:
 - name: Iterable API Key
   id: np.iterable.1
 
+  # Key format evidence:
+  #   - Census/Fivetran docs state 32 characters
+  #   - Segment docs show a real key that is 34 characters (42f187310705012194bd0bd694905664ae)
+  #   - No SDK performs format validation; keys are treated as opaque strings
+  #   - No major scanner (TruffleHog, Gitleaks, GitHub) has an Iterable-specific detector
+  #   - Character set appears lowercase hex from the single documented example,
+  #     but kept as full alphanumeric [a-z0-9] + (?i) since we cannot verify from one sample
+  #   - Length range {32,36} covers both documented lengths with small buffer
+  #   - Previous regex [A-Za-z0-9]{32,64} was overly broad, matching 40-64 char strings
+  #     that have no evidence of being valid Iterable keys
   pattern: |
     (?xi)
     (?:iterable)
@@ -11,7 +21,7 @@ rules:
     (?:.|[\n\r]){0,16}?
     \b
     (?P<key>
-      [A-Za-z0-9]{32,64}
+      [a-z0-9]{32,36}
     )
     \b
 
@@ -25,14 +35,17 @@ rules:
   - secret
 
   examples:
-  - "ITERABLE_API_KEY=a3B8f29E4d1C6a0578e23D9f41b6C8e2"
-  - 'iterable_api_key: "E7d2A1f849c3B05d6e81F2a794c3D5b09f4B2d7E"'
-  - "export ITERABLE_KEY=9f4B2d7E1a3c8056d2E7f1b94A6c3d80"
+  - "ITERABLE_API_KEY=a3b8f29e4d1c6a0578e23d9f41b6c8e2"
+  # 34-char key sourced from Segment Iterable destination docs
+  - 'iterable_api_key: "42f187310705012194bd0bd694905664ae"'
+  - "export ITERABLE_KEY=9F4B2D7E1A3C8056D2E7F1B94A6C3D80"
+  - "ITERABLE_SECRET=e7d2a1f849c3b05d6e81f2a794c3d5b0ab"
 
   negative_examples:
   - "ITERABLE_API_KEY=abcdef1234"
   - "iterable_api_key=your-key-here"
-  - "ITERABLE_API_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+  - "ITERABLE_API_KEY=00000000000000000000000000000000"
+  - "iterable_api_key=a3b8f29e4d1c6a05"
 
   description: |
     Iterable API Key used for marketing automation platform access.
@@ -42,3 +55,4 @@ rules:
 
   references:
   - https://api.iterable.com/api/docs
+  - https://support.iterable.com/hc/en-us/articles/360043464871-API-Keys

--- a/pkg/validator/validators/iterable.yaml
+++ b/pkg/validator/validators/iterable.yaml
@@ -1,16 +1,31 @@
 # pkg/validator/validators/iterable.yaml
-# Iterable uses a custom header Api_Key for authentication
-# Validation uses the export endpoint with minimal data to confirm key validity
+#
+# Auth: Iterable uses a custom header "Api-Key" (case-insensitive, Api_Key also works).
+#       Docs: https://support.iterable.com/hc/en-us/articles/360043464871-API-Keys
+#
+# Endpoint: GET /api/channels — lightweight read-only endpoint returning message channels.
+#           Used by Workato and Airbyte as their connection test endpoint.
+#           Previous endpoint (/api/export/data.json) was heavier and subject to
+#           stricter org-wide rate limits (4 req/min).
+#
+# Regions: Iterable has US (api.iterable.com) and EU (api.eu.iterable.com) data centers.
+#          A key created in one region returns 401 on the other.
+#          This validator only checks the US endpoint. EU keys will return StatusInvalid
+#          (false negative). A Go-based validator with multi-region fallback could fix this
+#          if EU false negatives become a problem.
+#
+# Failure codes: 401 = invalid key (BadApiKey), 403 = valid key but insufficient permissions.
+#                Without 403 in failure_codes, restricted keys would return StatusUndetermined.
 validators:
   - name: iterable-api-key
     rule_ids:
       - np.iterable.1
     http:
       method: GET
-      url: "https://api.iterable.com/api/export/data.json?dataTypeName=emailSend&range=Today&onlyFields=List.empty"
+      url: "https://api.iterable.com/api/channels"
       auth:
         type: header
         secret_group: "key"
-        header_name: "Api_Key"
+        header_name: "Api-Key"
       success_codes: [200]
-      failure_codes: [401]
+      failure_codes: [401, 403]


### PR DESCRIPTION
## Summary
- **Rule** (`iterable.yml`): Tighten key length from `{32,64}` to `{32,36}` based on documented evidence (Census/Fivetran say 32 chars, Segment docs show a real 34-char key). Keep full alphanumeric charset since hex-only cannot be verified from a single sample. Replace fabricated examples with real documented key format.
- **Validator** (`iterable.yaml`): Switch from heavy `/api/export/data.json` to lightweight `GET /api/channels` (industry-standard connection test used by Workato/Airbyte). Add 403 to failure codes (was missing, causing restricted keys to return `StatusUndetermined`). Use canonical `Api-Key` header name.

## Research
- Only one publicly documented real Iterable key exists (34-char lowercase hex from Segment docs)
- No major scanner (TruffleHog, Gitleaks, GitHub Secret Scanning) has an Iterable-specific detector
- No Iterable SDK validates key format — all treat it as an opaque string
- Iterable has US and EU data centers; this validator only checks US (documented in comments)

## Test plan
- [x] `go test ./...` — all 14 packages pass
- [x] Manual test: real 34-char Segment docs key matches in both OLD and NEW
- [x] Manual test: 32, 34, 36 char keys all match (no regression)
- [x] Manual test: JSON, YAML, JS file formats all detect keys
- [x] Manual test: 40-char and 64-char strings rejected by NEW (false positive reduction)
- [x] Manual test: negative cases (short, placeholder, low-entropy) same behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)