### PR TITLE
fix(validator): support positional capture groups in secret extraction

### DIFF
--- a/pkg/validator/http.go
+++ b/pkg/validator/http.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/praetorian-inc/titus/pkg/types"
@@ -92,22 +93,29 @@ func (v *HTTPValidator) extractSecret(match *types.Match) (string, error) {
 		return "", fmt.Errorf("secret_group not specified in validator config")
 	}
 
-	// Look up the named capture group
-	if match.NamedGroups == nil {
-		return "", fmt.Errorf("no named capture groups in match (regex pattern needs (?P<%s>...) syntax)", groupName)
-	}
-
-	value, ok := match.NamedGroups[groupName]
-	if !ok {
-		// List available groups for debugging
-		available := make([]string, 0, len(match.NamedGroups))
-		for name := range match.NamedGroups {
-			available = append(available, name)
+	// Try named capture groups first
+	if match.NamedGroups != nil {
+		if value, ok := match.NamedGroups[groupName]; ok {
+			return string(value), nil
 		}
-		return "", fmt.Errorf("named group %q not found (available: %v)", groupName, available)
 	}
 
-	return string(value), nil
+	// Fall back to positional capture groups for numeric secret_group values
+	if idx, err := strconv.Atoi(groupName); err == nil {
+		// secret_group "1" = Groups[0] (1-based index)
+		zeroIdx := idx - 1
+		if zeroIdx >= 0 && zeroIdx < len(match.Groups) {
+			return string(match.Groups[zeroIdx]), nil
+		}
+		return "", fmt.Errorf("positional group %d out of range (have %d groups)", idx, len(match.Groups))
+	}
+
+	// List available groups for debugging
+	available := make([]string, 0, len(match.NamedGroups))
+	for name := range match.NamedGroups {
+		available = append(available, name)
+	}
+	return "", fmt.Errorf("named group %q not found (available: %v)", groupName, available)
 }
 
 func (v *HTTPValidator) applyAuth(req *http.Request, secret string) error {


### PR DESCRIPTION
## Summary

- `extractSecret()` in the HTTP validator only checked `NamedGroups` (map) when resolving `secret_group` values
- Rules using unnamed positional capture groups (`(...)` syntax) populate the `Groups` slice instead
- A numeric `secret_group` like `"1"` was never found in `NamedGroups`, causing validation to silently return "undetermined"

## Fix

When `secret_group` is numeric and not found in `NamedGroups`, fall back to the positional `Groups` slice using 1-based indexing. Named groups are still checked first, preserving existing behavior.

## Impact

**46 validator entries across 35 YAML files** are affected, including:
digitalocean, gitlab, npm, doppler, heroku, linear, pulumi, supabase, openrouter,
postman, sentry, snyk, figma, tailscale, ngrok, posthog, fastly, resend, monday,
togetherai, launchdarkly, vercel, xai, netlify, pagerduty, newrelic, shodan,
intercom, opsgenie, notion, flyio, travisci, voyageai, postmark, segment, and others.

### Before (main)
```
np.digitalocean.2     undetermined    named group "1" not found (available: [])
np.doppler.1          undetermined    named group "1" not found (available: [])
np.gitlab.2           undetermined    named group "1" not found (available: [])
np.heroku.1           undetermined    named group "1" not found (available: [])
kingfisher.linear.1   undetermined    named group "1" not found (available: [])
np.npm.1              undetermined    named group "1" not found (available: [])
```

### After (this PR)
```
np.digitalocean.2     invalid         HTTP 401 - credentials rejected
np.doppler.1          invalid         HTTP 401 - credentials rejected
np.gitlab.2           invalid         HTTP 401 - credentials rejected
np.heroku.1           invalid         HTTP 401 - credentials rejected
kingfisher.linear.1   invalid         HTTP 401 - credentials rejected
np.npm.1              invalid         HTTP 401 - credentials rejected
```

## Test plan

- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] `go test ./pkg/validator/` — all pass
- [x] `go test ./pkg/rule/` — all pass
- [x] End-to-end: 9 validators tested with fake tokens, all correctly hit APIs and returned 401