### PR TITLE
feat: add mandrill API key validator (LAB-573)

### DIFF
--- a/pkg/rule/rules/mandrill.yml
+++ b/pkg/rule/rules/mandrill.yml
@@ -1,16 +1,24 @@
 rules:
+  # Matches Mandrill (Mailchimp Transactional) API keys.
+  # Key format: 22 characters from [A-Za-z0-9_-] — Base64url-safe alphabet.
+  # Evidence:
+  #   - TruffleHog detector (ID 577) uses \b([A-Za-z0-9_-]{22})\b with keyword "mandrill"
+  #   - Mandrill docs show example key "taqnVL1P5AJrM4oU4opSqQ" (22 chars, mixed case + digits)
+  #   - Keys are opaque tokens; no prefix or checksum structure
+  #   - Auth: POST JSON body {"key": "..."} to mandrillapp.com/api/1.0/
+  #   - Invalid keys return HTTP 500 with {"status":"error","code":-1,"name":"Invalid_Key"}
   - name: Mandrill API Key
     id: kingfisher.mandrill.1
     pattern: |
-      (?xi)                   
-      \b                     
+      (?xi)
+      \b
       mandrill
       (?:.|[\n\r]){0,32}?
       (?:SECRET|PRIVATE|ACCESS|KEY|TOKEN)
       (?:.|[\n\r]){0,32}?
-      \b                     
-      (                      
-        (?:[0-9A-Z_-]{11}){2}
+      \b
+      (?P<key>
+        [0-9A-Z_-]{22}
       )
     pattern_requirements:
       min_digits: 2
@@ -23,19 +31,3 @@ rules:
     categories:
       - api
       - identifier
-    validation:
-      type: Http
-      content:
-        request:
-          method: POST
-          headers:
-            Content-Type: application/json
-          body: |
-            { "key": "{{ TOKEN }}" }
-          url: https://mandrillapp.com/api/1.0/users/ping.json
-          response_matcher:
-            - report_response: true
-            - type: StatusMatch
-              status: [200]
-            - type: WordMatch
-              words: ['"PONG!"']

--- a/pkg/validator/validators/mandrill.yaml
+++ b/pkg/validator/validators/mandrill.yaml
@@ -1,0 +1,24 @@
+# Mandrill (Mailchimp Transactional) API key validator.
+# Auth: Mandrill authenticates via JSON POST body (not headers).
+# Endpoint: POST /api/1.0/users/ping2.json — lightweight auth check.
+#   - ping2.json returns {"PING":"PONG!"} on 200 for valid keys.
+#   - ping.json (v1) also works but requires email/password for some accounts.
+#   - Invalid keys return HTTP 500 with {"status":"error","code":-1,"name":"Invalid_Key"}.
+#     This is unusual — most APIs use 401. Mandrill uses 500 for all API errors.
+# Ref: https://mailchimp.com/developer/transactional/api/users/ping-2/
+validators:
+  - name: mandrill-api-key
+    rule_ids:
+      - kingfisher.mandrill.1
+    http:
+      method: POST
+      url: "https://mandrillapp.com/api/1.0/users/ping2.json"
+      auth:
+        type: none
+        secret_group: "key"
+      headers:
+        - name: Content-Type
+          value: application/json
+      body: '{"key": "{{key}}"}'
+      success_codes: [200]
+      failure_codes: [500]


### PR DESCRIPTION
## Summary
- Added YAML-based validator for Mandrill (Mailchimp Transactional) API keys using `POST /api/1.0/users/ping2.json`
- Fixed rule regex to use named capture group `(?P<key>...)` required by the validator system
- Simplified equivalent regex pattern and removed dead legacy `validation:` block
- Mandrill authenticates via JSON POST body `{"key": "..."}` (not headers) — validator uses auth type `none` with body template substitution
- Invalid keys return HTTP 500 (not 401) — this is Mandrill's documented behavior for all API errors

## Changes
| File | Change |
|------|--------|
| `pkg/rule/rules/mandrill.yml` | Named capture group, simplified regex, removed dead validation block, added evidence comments |
| `pkg/validator/validators/mandrill.yaml` | New YAML validator — POST ping2.json, body auth, 200=valid, 500=invalid |

## Evidence
- Key format: `[A-Za-z0-9_-]{22}` — Base64url-safe alphabet, 22 chars
- TruffleHog detector (ID 577) uses same pattern
- Docs example key: `taqnVL1P5AJrM4oU4opSqQ`
- `ping2.json` returns `{"PING":"PONG!"}` on success, `{"status":"error","code":-1,"name":"Invalid_Key"}` on failure (HTTP 500)

## Test plan
- [x] All existing tests pass (`go test ./...` — 14 packages)
- [x] YAML validator loads via embedded filesystem
- [x] Manual side-by-side comparison (5 test files): zero regressions vs main
- [ ] Review regex named group extraction in real scan output

🤖 Generated with [Claude Code](https://claude.com/claude-code)