### PR TITLE
feat(validator): add validators for sonarqube, sonarcloud, honeycomb, typeform, eventbrite

### DIFF
--- a/pkg/validator/validators/eventbrite.yaml
+++ b/pkg/validator/validators/eventbrite.yaml
@@ -1,0 +1,15 @@
+validators:
+  - name: eventbrite-api-key
+    rule_ids:
+      - kingfisher.eventbrite.1
+    http:
+      method: GET
+      url: https://www.eventbriteapi.com/v3/users/me/organizations/
+      auth:
+        type: bearer
+        secret_group: "1"
+      headers:
+        - name: Accept
+          value: application/json
+      success_codes: [200]
+      failure_codes: [401, 403]

--- a/pkg/validator/validators/honeycomb.yaml
+++ b/pkg/validator/validators/honeycomb.yaml
@@ -1,0 +1,16 @@
+validators:
+  - name: honeycomb-api-key
+    rule_ids:
+      - kingfisher.honeycomb.1
+    http:
+      method: GET
+      url: https://api.honeycomb.io/1/auth
+      auth:
+        type: header
+        secret_group: "1"
+        header_name: X-Honeycomb-Team
+      headers:
+        - name: Accept
+          value: application/json
+      success_codes: [200]
+      failure_codes: [401, 403]

--- a/pkg/validator/validators/sonarcloud.yaml
+++ b/pkg/validator/validators/sonarcloud.yaml
@@ -1,0 +1,15 @@
+validators:
+  - name: sonarcloud-token
+    rule_ids:
+      - kingfisher.sonarcloud.1
+    http:
+      method: GET
+      url: https://sonarcloud.io/api/user_tokens/search
+      auth:
+        type: bearer
+        secret_group: "1"
+      headers:
+        - name: Accept
+          value: application/json
+      success_codes: [200]
+      failure_codes: [401, 403]

--- a/pkg/validator/validators/sonarqube.yaml
+++ b/pkg/validator/validators/sonarqube.yaml
@@ -1,0 +1,15 @@
+validators:
+  - name: sonarqube-token
+    rule_ids:
+      - np.sonarqube.1
+    http:
+      method: GET
+      url: https://sonarcloud.io/api/user_tokens/search
+      auth:
+        type: bearer
+        secret_group: "1"
+      headers:
+        - name: Accept
+          value: application/json
+      success_codes: [200]
+      failure_codes: [401, 403]

--- a/pkg/validator/validators/typeform.yaml
+++ b/pkg/validator/validators/typeform.yaml
@@ -1,0 +1,15 @@
+validators:
+  - name: typeform-api-token
+    rule_ids:
+      - kingfisher.typeform.1
+    http:
+      method: GET
+      url: https://api.typeform.com/forms
+      auth:
+        type: bearer
+        secret_group: "1"
+      headers:
+        - name: Accept
+          value: application/json
+      success_codes: [200]
+      failure_codes: [401, 403]


### PR DESCRIPTION
## Summary

Adds 5 YAML-only validators for Tier 2 services:

- **sonarqube** (`np.sonarqube.1`) — Bearer auth, `sonarcloud.io/api/user_tokens/search`
- **sonarcloud** (`kingfisher.sonarcloud.1`) — Bearer auth, `sonarcloud.io/api/user_tokens/search`
- **honeycomb** (`kingfisher.honeycomb.1`) — `X-Honeycomb-Team` header, `api.honeycomb.io/1/auth`
- **typeform** (`kingfisher.typeform.1`) — Bearer auth, `api.typeform.com/forms`
- **eventbrite** (`kingfisher.eventbrite.1`) — Bearer auth, `eventbriteapi.com/v3/users/me/organizations/`

No Go code changes — validators auto-register via `//go:embed`.

## Validation results

| Service | Detection | Validation | Method |
|---------|-----------|-----------|--------|
| honeycomb | rule match | HTTP 200 (valid) / 401 (invalid) | GitHub scan |
| eventbrite | rule match | HTTP 200 (valid) / 401 (invalid) | GitHub scan |
| sonarcloud | rule match | HTTP 401 (invalid, revoked token) | GitHub scan |
| sonarqube | rule match | HTTP 401 (invalid) | Fake token test |
| typeform | rule match | HTTP 403 (invalid) | Fake token test |

## Test plan

- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] `go test ./pkg/validator/` — all pass
- [x] `go test ./pkg/rule/` — all pass
- [x] End-to-end: all 5 validators verified via `titus scan --validate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)