### PR TITLE
fix: enforce min_entropy and pattern_requirements post-match filtering

### DIFF
--- a/pkg/matcher/entropy.go
+++ b/pkg/matcher/entropy.go
@@ -1,0 +1,24 @@
+package matcher
+
+import "math"
+
+// shannonEntropy calculates Shannon entropy in bits per byte for the given data.
+func shannonEntropy(data []byte) float64 {
+	if len(data) == 0 {
+		return 0
+	}
+	var counts [256]int
+	for _, b := range data {
+		counts[b]++
+	}
+	length := float64(len(data))
+	entropy := 0.0
+	for _, count := range counts {
+		if count == 0 {
+			continue
+		}
+		p := float64(count) / length
+		entropy -= p * math.Log2(p)
+	}
+	return entropy
+}

--- a/pkg/matcher/entropy_test.go
+++ b/pkg/matcher/entropy_test.go
@@ -1,0 +1,49 @@
+package matcher
+
+import (
+	"math"
+	"testing"
+)
+
+func TestShannonEntropy_Empty(t *testing.T) {
+	got := shannonEntropy(nil)
+	if got != 0 {
+		t.Errorf("expected 0 for nil, got %f", got)
+	}
+	got = shannonEntropy([]byte{})
+	if got != 0 {
+		t.Errorf("expected 0 for empty, got %f", got)
+	}
+}
+
+func TestShannonEntropy_SingleByteRepeated(t *testing.T) {
+	// All same byte → entropy 0
+	got := shannonEntropy([]byte("aaaaaaa"))
+	if got != 0 {
+		t.Errorf("expected 0 for repeated single char, got %f", got)
+	}
+}
+
+func TestShannonEntropy_TwoEqualSymbols(t *testing.T) {
+	// "ab" — 2 equally probable symbols → entropy 1.0
+	got := shannonEntropy([]byte("ab"))
+	if math.Abs(got-1.0) > 1e-9 {
+		t.Errorf("expected 1.0 for 'ab', got %f", got)
+	}
+}
+
+func TestShannonEntropy_FourEqualSymbols(t *testing.T) {
+	// "abcd" — 4 equally probable symbols → entropy 2.0
+	got := shannonEntropy([]byte("abcd"))
+	if math.Abs(got-2.0) > 1e-9 {
+		t.Errorf("expected 2.0 for 'abcd', got %f", got)
+	}
+}
+
+func TestShannonEntropy_HighEntropy(t *testing.T) {
+	// Random-looking 32-byte string — should be well above 3.0
+	got := shannonEntropy([]byte("aB3$xY9!mN2@kL7#pQ1%vR4^wS6&zT8*"))
+	if got < 3.0 {
+		t.Errorf("expected high entropy (>3.0) for mixed chars, got %f", got)
+	}
+}

--- a/pkg/matcher/filtering_matcher.go
+++ b/pkg/matcher/filtering_matcher.go
@@ -1,0 +1,39 @@
+package matcher
+
+import "github.com/praetorian-inc/titus/pkg/types"
+
+// filteringMatcher wraps a Matcher and applies post-match filtering
+// based on min_entropy and pattern_requirements from rule definitions.
+type filteringMatcher struct {
+	inner Matcher
+	rules map[string]*types.Rule
+}
+
+// newFilteringMatcher wraps a matcher with post-match filtering.
+func newFilteringMatcher(inner Matcher, rules []*types.Rule) *filteringMatcher {
+	ruleMap := make(map[string]*types.Rule, len(rules))
+	for _, r := range rules {
+		ruleMap[r.ID] = r
+	}
+	return &filteringMatcher{inner: inner, rules: ruleMap}
+}
+
+func (f *filteringMatcher) Match(content []byte) ([]*types.Match, error) {
+	matches, err := f.inner.Match(content)
+	if err != nil {
+		return nil, err
+	}
+	return filterMatches(matches, f.rules), nil
+}
+
+func (f *filteringMatcher) MatchWithBlobID(content []byte, blobID types.BlobID) ([]*types.Match, error) {
+	matches, err := f.inner.MatchWithBlobID(content, blobID)
+	if err != nil {
+		return nil, err
+	}
+	return filterMatches(matches, f.rules), nil
+}
+
+func (f *filteringMatcher) Close() error {
+	return f.inner.Close()
+}

--- a/pkg/matcher/matcher_default.go
+++ b/pkg/matcher/matcher_default.go
@@ -8,5 +8,9 @@ package matcher
 // - High detection accuracy: finds 20% more secrets than NoseyParker v0.24.0
 // - Performance: comparable on small files, sufficient for most use cases
 func New(cfg Config) (Matcher, error) {
-	return NewPortableRegexp(cfg.Rules, cfg.ContextLines)
+	inner, err := NewPortableRegexp(cfg.Rules, cfg.ContextLines)
+	if err != nil {
+		return nil, err
+	}
+	return newFilteringMatcher(inner, cfg.Rules), nil
 }

--- a/pkg/matcher/matcher_vectorscan.go
+++ b/pkg/matcher/matcher_vectorscan.go
@@ -13,5 +13,9 @@ package matcher
 // - CGO is enabled
 // - The "vectorscan" build tag is specified
 func New(cfg Config) (Matcher, error) {
-	return NewVectorscan(cfg.Rules, cfg.ContextLines)
+	inner, err := NewVectorscan(cfg.Rules, cfg.ContextLines)
+	if err != nil {
+		return nil, err
+	}
+	return newFilteringMatcher(inner, cfg.Rules), nil
 }

--- a/pkg/matcher/matcher_wasm.go
+++ b/pkg/matcher/matcher_wasm.go
@@ -4,5 +4,9 @@ package matcher
 
 // New creates a regexp-based matcher for WASM builds.
 func New(cfg Config) (Matcher, error) {
-	return NewRegexp(cfg.Rules, cfg.ContextLines)
+	inner, err := NewRegexp(cfg.Rules, cfg.ContextLines)
+	if err != nil {
+		return nil, err
+	}
+	return newFilteringMatcher(inner, cfg.Rules), nil
 }

--- a/pkg/matcher/postfilter.go
+++ b/pkg/matcher/postfilter.go
@@ -1,0 +1,135 @@
+package matcher
+
+import (
+	"strings"
+	"unicode"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+)
+
+// defaultSpecialChars is the set of characters considered "special" when
+// evaluating min_special_chars requirements.
+const defaultSpecialChars = "!@#$%^&*()_+-=[]{}|;:'\",.<>?/\\`~"
+
+// findSecretCapture selects which capture group represents the secret value.
+// Priority (matching Kingfisher):
+//  1. Named capture called "TOKEN" (case-insensitive)
+//  2. First named capture in NamedGroups
+//  3. Groups[1] (first positional capture)
+//  4. Groups[0] (full match)
+func findSecretCapture(m *types.Match) []byte {
+	// 1. Named capture called "TOKEN" (case-insensitive)
+	for k, v := range m.NamedGroups {
+		if strings.EqualFold(k, "token") {
+			return v
+		}
+	}
+
+	// 2. First named capture in NamedGroups (map iteration order is random,
+	//    but we just need any named group when TOKEN isn't present)
+	for _, v := range m.NamedGroups {
+		return v
+	}
+
+	// 3. Groups[1] (first positional capture)
+	if len(m.Groups) > 1 {
+		return m.Groups[1]
+	}
+
+	// 4. Groups[0] (full match)
+	if len(m.Groups) > 0 {
+		return m.Groups[0]
+	}
+
+	return nil
+}
+
+// passesEntropyCheck returns true if minEntropy is 0 (disabled) or the
+// calculated entropy of secretBytes is strictly greater than minEntropy.
+// Matches with entropy <= minEntropy are rejected (Kingfisher behavior).
+func passesEntropyCheck(secretBytes []byte, minEntropy float64) bool {
+	if minEntropy == 0 {
+		return true
+	}
+	return shannonEntropy(secretBytes) > minEntropy
+}
+
+// passesPatternRequirements checks character-class and content constraints.
+func passesPatternRequirements(text []byte, reqs *types.PatternRequirements) bool {
+	if reqs == nil {
+		return true
+	}
+
+	// Check ignore_if_contains (case-insensitive substring match)
+	lower := strings.ToLower(string(text))
+	for _, sub := range reqs.IgnoreIfContains {
+		if strings.Contains(lower, strings.ToLower(sub)) {
+			return false
+		}
+	}
+
+	// Character class counts
+	var digits, uppercase, lowercase, special int
+	specialChars := reqs.SpecialChars
+	if specialChars == "" {
+		specialChars = defaultSpecialChars
+	}
+
+	for _, r := range string(text) {
+		switch {
+		case unicode.IsDigit(r):
+			digits++
+		case unicode.IsUpper(r):
+			uppercase++
+		case unicode.IsLower(r):
+			lowercase++
+		case strings.ContainsRune(specialChars, r):
+			special++
+		}
+	}
+
+	if digits < reqs.MinDigits {
+		return false
+	}
+	if uppercase < reqs.MinUppercase {
+		return false
+	}
+	if lowercase < reqs.MinLowercase {
+		return false
+	}
+	if special < reqs.MinSpecialChars {
+		return false
+	}
+
+	return true
+}
+
+// filterMatches iterates matches, looks up each rule, applies entropy and
+// pattern_requirements checks, and returns only the passing matches.
+func filterMatches(matches []*types.Match, rules map[string]*types.Rule) []*types.Match {
+	if len(matches) == 0 {
+		return matches
+	}
+
+	out := matches[:0:len(matches)]
+	for _, m := range matches {
+		rule, ok := rules[m.RuleID]
+		if !ok {
+			// Unknown rule — pass through (no filtering possible)
+			out = append(out, m)
+			continue
+		}
+
+		secret := findSecretCapture(m)
+
+		if !passesEntropyCheck(secret, rule.MinEntropy) {
+			continue
+		}
+		if !passesPatternRequirements(secret, rule.PatternRequirements) {
+			continue
+		}
+
+		out = append(out, m)
+	}
+	return out
+}

--- a/pkg/matcher/postfilter_test.go
+++ b/pkg/matcher/postfilter_test.go
@@ -1,0 +1,256 @@
+package matcher
+
+import (
+	"testing"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+)
+
+// --- findSecretCapture tests ---
+
+func TestFindSecretCapture_TokenNamed(t *testing.T) {
+	m := &types.Match{
+		NamedGroups: map[string][]byte{
+			"TOKEN": []byte("secret123"),
+			"other": []byte("noise"),
+		},
+	}
+	got := findSecretCapture(m)
+	if string(got) != "secret123" {
+		t.Errorf("expected 'secret123', got %q", got)
+	}
+}
+
+func TestFindSecretCapture_TokenCaseInsensitive(t *testing.T) {
+	m := &types.Match{
+		NamedGroups: map[string][]byte{
+			"token": []byte("lowtoken"),
+		},
+	}
+	got := findSecretCapture(m)
+	if string(got) != "lowtoken" {
+		t.Errorf("expected 'lowtoken', got %q", got)
+	}
+}
+
+func TestFindSecretCapture_FirstNamedGroup(t *testing.T) {
+	m := &types.Match{
+		NamedGroups: map[string][]byte{
+			"key": []byte("keyvalue"),
+		},
+	}
+	got := findSecretCapture(m)
+	if string(got) != "keyvalue" {
+		t.Errorf("expected 'keyvalue', got %q", got)
+	}
+}
+
+func TestFindSecretCapture_Groups1(t *testing.T) {
+	m := &types.Match{
+		Groups: [][]byte{[]byte("full"), []byte("capture1")},
+	}
+	got := findSecretCapture(m)
+	if string(got) != "capture1" {
+		t.Errorf("expected 'capture1', got %q", got)
+	}
+}
+
+func TestFindSecretCapture_Groups0Fallback(t *testing.T) {
+	m := &types.Match{
+		Groups: [][]byte{[]byte("fullmatch")},
+	}
+	got := findSecretCapture(m)
+	if string(got) != "fullmatch" {
+		t.Errorf("expected 'fullmatch', got %q", got)
+	}
+}
+
+func TestFindSecretCapture_NoGroups(t *testing.T) {
+	m := &types.Match{}
+	got := findSecretCapture(m)
+	if got != nil {
+		t.Errorf("expected nil, got %q", got)
+	}
+}
+
+// --- passesEntropyCheck tests ---
+
+func TestPassesEntropyCheck_ZeroThreshold(t *testing.T) {
+	// Zero threshold means no check — everything passes
+	if !passesEntropyCheck([]byte("aaaa"), 0) {
+		t.Error("expected pass for zero threshold")
+	}
+}
+
+func TestPassesEntropyCheck_HighEntropyPasses(t *testing.T) {
+	// High-entropy secret passes a low threshold
+	secret := []byte("aB3$xY9!mN2@kL7#")
+	if !passesEntropyCheck(secret, 2.0) {
+		t.Error("expected high-entropy secret to pass threshold 2.0")
+	}
+}
+
+func TestPassesEntropyCheck_LowEntropyRejected(t *testing.T) {
+	// Repeated chars → entropy 0, should be rejected
+	if passesEntropyCheck([]byte("aaaaaaa"), 1.0) {
+		t.Error("expected low-entropy secret to be rejected")
+	}
+}
+
+func TestPassesEntropyCheck_ExactEqualsRejects(t *testing.T) {
+	// "ab" has entropy exactly 1.0 — <= 1.0 should reject
+	if passesEntropyCheck([]byte("ab"), 1.0) {
+		t.Error("expected entropy == threshold to be rejected")
+	}
+}
+
+// --- passesPatternRequirements tests ---
+
+func TestPassesPatternRequirements_Nil(t *testing.T) {
+	if !passesPatternRequirements([]byte("anything"), nil) {
+		t.Error("expected nil requirements to pass")
+	}
+}
+
+func TestPassesPatternRequirements_MinDigits(t *testing.T) {
+	reqs := &types.PatternRequirements{MinDigits: 3}
+	if passesPatternRequirements([]byte("ab12"), reqs) {
+		t.Error("expected fail: only 2 digits")
+	}
+	if !passesPatternRequirements([]byte("abc123"), reqs) {
+		t.Error("expected pass: 3 digits")
+	}
+}
+
+func TestPassesPatternRequirements_MinUppercase(t *testing.T) {
+	reqs := &types.PatternRequirements{MinUppercase: 2}
+	if passesPatternRequirements([]byte("Abcd"), reqs) {
+		t.Error("expected fail: only 1 uppercase")
+	}
+	if !passesPatternRequirements([]byte("ABcd"), reqs) {
+		t.Error("expected pass: 2 uppercase")
+	}
+}
+
+func TestPassesPatternRequirements_MinLowercase(t *testing.T) {
+	reqs := &types.PatternRequirements{MinLowercase: 3}
+	if passesPatternRequirements([]byte("ABCd"), reqs) {
+		t.Error("expected fail: only 1 lowercase")
+	}
+	if !passesPatternRequirements([]byte("ABCdef"), reqs) {
+		t.Error("expected pass: 3 lowercase")
+	}
+}
+
+func TestPassesPatternRequirements_IgnoreIfContains(t *testing.T) {
+	reqs := &types.PatternRequirements{
+		IgnoreIfContains: []string{"EXAMPLE", "test"},
+	}
+	// Case-insensitive: "example" should match "EXAMPLE"
+	if passesPatternRequirements([]byte("sk_live_example_key"), reqs) {
+		t.Error("expected fail: contains 'example'")
+	}
+	if passesPatternRequirements([]byte("sk_live_TEST_key"), reqs) {
+		t.Error("expected fail: contains 'test' (case-insensitive)")
+	}
+	if !passesPatternRequirements([]byte("sk_live_realkey123"), reqs) {
+		t.Error("expected pass: no ignored substrings")
+	}
+}
+
+func TestPassesPatternRequirements_MinSpecialChars(t *testing.T) {
+	reqs := &types.PatternRequirements{MinSpecialChars: 2}
+	if passesPatternRequirements([]byte("abc!def"), reqs) {
+		t.Error("expected fail: only 1 special char")
+	}
+	if !passesPatternRequirements([]byte("abc!def@"), reqs) {
+		t.Error("expected pass: 2 special chars")
+	}
+}
+
+func TestPassesPatternRequirements_CustomSpecialChars(t *testing.T) {
+	reqs := &types.PatternRequirements{
+		MinSpecialChars: 1,
+		SpecialChars:    "-_",
+	}
+	if passesPatternRequirements([]byte("abc!def"), reqs) {
+		t.Error("expected fail: '!' not in custom special chars")
+	}
+	if !passesPatternRequirements([]byte("abc_def"), reqs) {
+		t.Error("expected pass: '_' is in custom special chars")
+	}
+}
+
+// --- filterMatches tests ---
+
+func TestFilterMatches_Empty(t *testing.T) {
+	result := filterMatches(nil, map[string]*types.Rule{})
+	if result != nil {
+		t.Error("expected nil for nil input")
+	}
+}
+
+func TestFilterMatches_PassesWhenNoRule(t *testing.T) {
+	matches := []*types.Match{
+		{RuleID: "unknown.rule", Groups: [][]byte{[]byte("val")}},
+	}
+	result := filterMatches(matches, map[string]*types.Rule{})
+	if len(result) != 1 {
+		t.Errorf("expected match to pass through when rule not found, got %d", len(result))
+	}
+}
+
+func TestFilterMatches_EntropyFiltering(t *testing.T) {
+	rules := map[string]*types.Rule{
+		"np.test.1": {
+			ID:         "np.test.1",
+			MinEntropy: 3.0,
+		},
+	}
+	matches := []*types.Match{
+		{
+			RuleID: "np.test.1",
+			Groups: [][]byte{[]byte("full"), []byte("aaaaaaa")}, // low entropy
+		},
+		{
+			RuleID: "np.test.1",
+			Groups: [][]byte{[]byte("full"), []byte("aB3$xY9!mN2@kL7#pQ1z")}, // high entropy
+		},
+	}
+	result := filterMatches(matches, rules)
+	if len(result) != 1 {
+		t.Errorf("expected 1 match after entropy filtering, got %d", len(result))
+	}
+}
+
+func TestFilterMatches_PatternRequirementsFiltering(t *testing.T) {
+	rules := map[string]*types.Rule{
+		"np.test.2": {
+			ID: "np.test.2",
+			PatternRequirements: &types.PatternRequirements{
+				IgnoreIfContains: []string{"example"},
+			},
+		},
+	}
+	matches := []*types.Match{
+		{
+			RuleID: "np.test.2",
+			NamedGroups: map[string][]byte{
+				"token": []byte("sk_live_EXAMPLE_key"),
+			},
+		},
+		{
+			RuleID: "np.test.2",
+			NamedGroups: map[string][]byte{
+				"token": []byte("sk_live_realkey12345"),
+			},
+		},
+	}
+	result := filterMatches(matches, rules)
+	if len(result) != 1 {
+		t.Errorf("expected 1 match after pattern requirements filtering, got %d", len(result))
+	}
+	if string(result[0].NamedGroups["token"]) != "sk_live_realkey12345" {
+		t.Errorf("unexpected match content: %q", result[0].NamedGroups["token"])
+	}
+}

--- a/pkg/rule/loader.go
+++ b/pkg/rule/loader.go
@@ -168,6 +168,17 @@ func convertYAMLRule(yr yamlRule) *types.Rule {
 		NegativeExamples: yr.NegativeExamples,
 		References:       yr.References,
 		Categories:       yr.Categories,
+		MinEntropy:       yr.MinEntropy,
+	}
+	if yr.PatternRequirements != nil {
+		r.PatternRequirements = &types.PatternRequirements{
+			MinDigits:        yr.PatternRequirements.MinDigits,
+			MinUppercase:     yr.PatternRequirements.MinUppercase,
+			MinLowercase:     yr.PatternRequirements.MinLowercase,
+			MinSpecialChars:  yr.PatternRequirements.MinSpecialChars,
+			SpecialChars:     yr.PatternRequirements.SpecialChars,
+			IgnoreIfContains: yr.PatternRequirements.IgnoreIfContains,
+		}
 	}
 	r.StructuralID = r.ComputeStructuralID()
 	return r

--- a/pkg/rule/loader_test.go
+++ b/pkg/rule/loader_test.go
@@ -332,3 +332,78 @@ func TestRoundTrip(t *testing.T) {
 		t.Error("expected StructuralID to be computed")
 	}
 }
+
+func TestLoadRule_WithMinEntropy(t *testing.T) {
+	loader := NewLoader()
+
+	yaml := `rules:
+  - name: Test Rule With Entropy
+    id: np.test.entropy.1
+    pattern: 'test[A-Z0-9]{16}'
+    min_entropy: 3.5
+`
+	rule, err := loader.LoadRule([]byte(yaml))
+	if err != nil {
+		t.Fatalf("LoadRule failed: %v", err)
+	}
+	if rule.MinEntropy != 3.5 {
+		t.Errorf("expected MinEntropy 3.5, got %f", rule.MinEntropy)
+	}
+}
+
+func TestLoadRule_WithPatternRequirements(t *testing.T) {
+	loader := NewLoader()
+
+	yaml := `rules:
+  - name: Test Rule With Requirements
+    id: np.test.req.1
+    pattern: 'sk_live_[A-Za-z0-9]{24}'
+    pattern_requirements:
+      min_digits: 2
+      min_uppercase: 1
+      min_lowercase: 3
+      min_special_chars: 0
+      ignore_if_contains:
+        - EXAMPLE
+        - test
+`
+	rule, err := loader.LoadRule([]byte(yaml))
+	if err != nil {
+		t.Fatalf("LoadRule failed: %v", err)
+	}
+	if rule.PatternRequirements == nil {
+		t.Fatal("expected PatternRequirements to be non-nil")
+	}
+	if rule.PatternRequirements.MinDigits != 2 {
+		t.Errorf("expected MinDigits 2, got %d", rule.PatternRequirements.MinDigits)
+	}
+	if rule.PatternRequirements.MinUppercase != 1 {
+		t.Errorf("expected MinUppercase 1, got %d", rule.PatternRequirements.MinUppercase)
+	}
+	if rule.PatternRequirements.MinLowercase != 3 {
+		t.Errorf("expected MinLowercase 3, got %d", rule.PatternRequirements.MinLowercase)
+	}
+	if len(rule.PatternRequirements.IgnoreIfContains) != 2 {
+		t.Errorf("expected 2 IgnoreIfContains entries, got %d", len(rule.PatternRequirements.IgnoreIfContains))
+	}
+}
+
+func TestLoadRule_NoPatternRequirements(t *testing.T) {
+	loader := NewLoader()
+
+	yaml := `rules:
+  - name: Simple Rule
+    id: np.test.simple.1
+    pattern: 'simple[A-Z0-9]+'
+`
+	rule, err := loader.LoadRule([]byte(yaml))
+	if err != nil {
+		t.Fatalf("LoadRule failed: %v", err)
+	}
+	if rule.MinEntropy != 0 {
+		t.Errorf("expected MinEntropy 0 (unset), got %f", rule.MinEntropy)
+	}
+	if rule.PatternRequirements != nil {
+		t.Error("expected PatternRequirements to be nil for rule without requirements")
+	}
+}

--- a/pkg/rule/yaml.go
+++ b/pkg/rule/yaml.go
@@ -1,16 +1,28 @@
 package rule
 
+// yamlPatternRequirements is the intermediate struct for parsing pattern requirements.
+type yamlPatternRequirements struct {
+	MinDigits        int      `yaml:"min_digits,omitempty"`
+	MinUppercase     int      `yaml:"min_uppercase,omitempty"`
+	MinLowercase     int      `yaml:"min_lowercase,omitempty"`
+	MinSpecialChars  int      `yaml:"min_special_chars,omitempty"`
+	SpecialChars     string   `yaml:"special_chars,omitempty"`
+	IgnoreIfContains []string `yaml:"ignore_if_contains,omitempty"`
+}
+
 // yamlRule is the intermediate struct for parsing NoseyParker YAML rule format.
 // Maps YAML fields to types.Rule structure.
 type yamlRule struct {
-	Name             string   `yaml:"name"`
-	ID               string   `yaml:"id"`
-	Pattern          string   `yaml:"pattern"`
-	Description      string   `yaml:"description,omitempty"`
-	Examples         []string `yaml:"examples,omitempty"`
-	NegativeExamples []string `yaml:"negative_examples,omitempty"`
-	References       []string `yaml:"references,omitempty"`
-	Categories       []string `yaml:"categories,omitempty"`
+	Name                string                   `yaml:"name"`
+	ID                  string                   `yaml:"id"`
+	Pattern             string                   `yaml:"pattern"`
+	Description         string                   `yaml:"description,omitempty"`
+	Examples            []string                 `yaml:"examples,omitempty"`
+	NegativeExamples    []string                 `yaml:"negative_examples,omitempty"`
+	References          []string                 `yaml:"references,omitempty"`
+	Categories          []string                 `yaml:"categories,omitempty"`
+	MinEntropy          float64                  `yaml:"min_entropy,omitempty"`
+	PatternRequirements *yamlPatternRequirements `yaml:"pattern_requirements,omitempty"`
 }
 
 // yamlRulesFile represents the top-level structure of a rules YAML file.

--- a/pkg/types/rule.go
+++ b/pkg/types/rule.go
@@ -6,6 +6,17 @@ import (
 	"regexp"
 )
 
+// PatternRequirements specifies minimum character-class counts that a captured
+// value must satisfy. Reduces false positives for patterns matching generic strings.
+type PatternRequirements struct {
+	MinDigits        int      `json:"min_digits,omitempty"`
+	MinUppercase     int      `json:"min_uppercase,omitempty"`
+	MinLowercase     int      `json:"min_lowercase,omitempty"`
+	MinSpecialChars  int      `json:"min_special_chars,omitempty"`
+	SpecialChars     string   `json:"special_chars,omitempty"`
+	IgnoreIfContains []string `json:"ignore_if_contains,omitempty"`
+}
+
 // Rule is a detection rule with pattern and metadata.
 type Rule struct {
 	ID               string   // e.g., "np.aws.1"
@@ -18,6 +29,15 @@ type Rule struct {
 	References       []string // documentation URLs
 	Categories       []string // classification tags
 	Keywords         []string // keywords for Aho-Corasick prefiltering
+
+	// MinEntropy is the minimum Shannon entropy (bits/char) the secret capture
+	// group must have. Matches with entropy <= MinEntropy are rejected.
+	// A value of 0 disables the entropy check.
+	MinEntropy float64
+
+	// PatternRequirements specifies character-class and content constraints
+	// for the captured value. nil means no requirements.
+	PatternRequirements *PatternRequirements
 }
 
 // namedGroupRe matches named capture groups like (?P<name>...) and replaces


### PR DESCRIPTION
## Summary
- The YAML rule parser loaded `min_entropy` and `pattern_requirements` fields but the matcher never applied them, silently ignoring filtering guards on 263+ rules
- Adds a `filteringMatcher` decorator wrapping all matcher implementations (default, vectorscan, wasm) with post-match entropy and pattern_requirements checks
- Matches Kingfisher's `filter_match` behavior: entropy on secret capture group (TOKEN > first named > group 1 > group 0), `<=` threshold rejects

## Changes
- `pkg/types/rule.go` — Add `PatternRequirements` struct, `MinEntropy` and `PatternRequirements` fields to `Rule`
- `pkg/rule/yaml.go` — Add YAML deserialization for `min_entropy` and `pattern_requirements`
- `pkg/rule/loader.go` — Map new fields in `convertYAMLRule()`
- `pkg/matcher/entropy.go` — Shannon entropy calculation
- `pkg/matcher/postfilter.go` — `findSecretCapture`, `passesEntropyCheck`, `passesPatternRequirements`, `filterMatches`
- `pkg/matcher/filtering_matcher.go` — Decorator implementing `Matcher` interface
- `pkg/matcher/matcher_default.go`, `matcher_vectorscan.go`, `matcher_wasm.go` — Wrap with `filteringMatcher`

## Validation
Tested against a file with real leaked tokens and crafted bogus tokens across 5 rules (Alibaba, Shodan, MongoDB, Redis, Plaid). A/B comparison against main:
- **Main**: 30 matches (including 16 false positives)
- **This branch**: 14 matches (all false positives correctly filtered)
- Zero regressions — all real tokens still detected
- All 14 packages pass tests

## Test plan
- [x] Unit tests for Shannon entropy calculation
- [x] Unit tests for `findSecretCapture` group priority
- [x] Unit tests for `passesEntropyCheck` and `passesPatternRequirements`
- [x] Unit tests for `filterMatches` integration
- [x] Unit tests for YAML rule loading with new fields
- [x] A/B validation with real and bogus tokens across 5 rule families