### PR TITLE
Add validators for Groq, Huggingface, and Telegram

### DIFF
--- a/pkg/rule/rules/groq.yml
+++ b/pkg/rule/rules/groq.yml
@@ -21,3 +21,18 @@ rules:
 
   - |
       const apiKey = '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'; // Replace with your actual API key
+
+  validation:
+    type: Http
+    content:
+      request:
+        method: GET
+        url: https://api.groq.com/openai/v1/models
+        headers:
+          Authorization: 'Bearer {{ TOKEN }}'
+          Accept: application/json
+        response_matcher:
+          - report_response: true
+          - type: StatusMatch
+            status:
+              - 200

--- a/pkg/rule/rules/huggingface.yml
+++ b/pkg/rule/rules/huggingface.yml
@@ -12,3 +12,21 @@ rules:
 
   examples:
   - 'HF_TOKEN:"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"'
+
+  validation:
+    type: Http
+    content:
+      request:
+        method: GET
+        url: https://huggingface.co/api/whoami-v2
+        headers:
+          Authorization: 'Bearer {{ TOKEN }}'
+          Accept: application/json
+        response_matcher:
+          - report_response: true
+          - type: StatusMatch
+            status:
+              - 200
+          - type: WordMatch
+            words:
+              - '"name"'

--- a/pkg/rule/rules/telegram.yml
+++ b/pkg/rule/rules/telegram.yml
@@ -20,3 +20,20 @@ rules:
   references:
   - https://core.telegram.org/bots/api
   - https://core.telegram.org/bots/features#botfather
+
+  validation:
+    type: Http
+    content:
+      request:
+        method: GET
+        url: 'https://api.telegram.org/bot{{ TOKEN }}/getMe'
+        headers:
+          Accept: application/json
+        response_matcher:
+          - report_response: true
+          - type: StatusMatch
+            status:
+              - 200
+          - type: WordMatch
+            words:
+              - '"ok":true'


### PR DESCRIPTION
## Summary
- Adds HTTP validation for Groq API Key (np.groq.1)
- Adds HTTP validation for HuggingFace User Access Token (np.huggingface.1)
- Adds HTTP validation for Telegram Bot Token (np.telegram.1)

## Test plan
- [x] Build passes
- [x] Rule loading tests pass
- [ ] Manual validation test with real tokens (optional)