### PR TITLE
feat(validator): unified snippet context search for AWS credentials

### DIFF
--- a/pkg/validator/aws.go
+++ b/pkg/validator/aws.go
@@ -15,8 +15,16 @@ import (
 
 // Pre-compiled patterns for extracting AWS credentials from snippet context.
 var (
-	awsSecretKeyPattern    = regexp.MustCompile(`AWS_SECRET_ACCESS_KEY[=:"\s]+([A-Za-z0-9/+=]{40})`)
-	awsSessionTokenPattern = regexp.MustCompile(`AWS_SESSION_TOKEN[=:"\s]+([A-Za-z0-9/+=]+)`)
+	awsAccessKeyIDPatterns = []*regexp.Regexp{
+		regexp.MustCompile(`(?i)AWS_ACCESS_KEY_ID[=:"\s]+((?:A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16})`),
+		regexp.MustCompile(`\b((?:A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16})\b`),
+	}
+	awsSecretKeyPatterns = []*regexp.Regexp{
+		regexp.MustCompile(`(?i)AWS_SECRET_ACCESS_KEY[=:"\s]+([A-Za-z0-9/+=]{40})`),
+	}
+	awsSessionTokenPatterns = []*regexp.Regexp{
+		regexp.MustCompile(`(?i)AWS_SESSION_TOKEN[=:"\s]+([A-Za-z0-9/+=]+)`),
+	}
 )
 
 // STSClient interface for STS operations (allows mocking in tests).
@@ -47,7 +55,7 @@ func (v *AWSValidator) Name() string {
 // CanValidate returns true for AWS-related rule IDs.
 func (v *AWSValidator) CanValidate(ruleID string) bool {
 	switch ruleID {
-	case "np.aws.1", "np.aws.2", "np.aws.6":
+	case "np.aws.1", "np.aws.2", "np.aws.4", "np.aws.6":
 		return true
 	default:
 		return false
@@ -112,77 +120,57 @@ func (v *AWSValidator) Validate(ctx context.Context, match *types.Match) (*types
 	return result, nil
 }
 
-// extractCredentials extracts AWS credentials from match based on rule ID.
-// Returns error for partial credentials (np.aws.1, np.aws.2) when not found in snippet.
-//
-// Expected named capture groups:
-//   - key_id: AWS access key ID (e.g., AKIAIOSFODNN7EXAMPLE)
-//   - secret_key: AWS secret access key
-//   - session_token: (optional) AWS session token for temporary credentials
+// extractCredentials extracts AWS credentials from match using a unified flow.
+// First extracts from NamedGroups, then fills gaps by searching snippet context.
+// Returns error only if key_id or secret_key is still missing after both steps.
 func (v *AWSValidator) extractCredentials(match *types.Match) (keyID, secret, sessionToken string, err error) {
-	switch match.RuleID {
-	case "np.aws.6":
-		// np.aws.6 captures both key_id and secret_key
-		if match.NamedGroups == nil {
-			return "", "", "", fmt.Errorf("np.aws.6 requires named capture groups (key_id, secret_key)")
+	// Step 1: Extract whatever is available from NamedGroups.
+	if match.NamedGroups != nil {
+		if b, ok := match.NamedGroups["key_id"]; ok {
+			keyID = string(b)
 		}
-
-		keyIDBytes, hasKeyID := match.NamedGroups["key_id"]
-		secretBytes, hasSecret := match.NamedGroups["secret_key"]
-
-		if !hasKeyID || !hasSecret {
-			return "", "", "", fmt.Errorf("np.aws.6 requires named groups 'key_id' and 'secret_key' (found: %v)", keysOf(match.NamedGroups))
+		if b, ok := match.NamedGroups["secret_key"]; ok {
+			secret = string(b)
 		}
-
-		// Check for optional session token
-		if tokenBytes, ok := match.NamedGroups["session_token"]; ok {
-			sessionToken = string(tokenBytes)
+		if b, ok := match.NamedGroups["session_token"]; ok {
+			sessionToken = string(b)
 		}
-
-		return string(keyIDBytes), string(secretBytes), sessionToken, nil
-
-	case "np.aws.1":
-		// np.aws.1 captures access key ID - check snippet for secret key
-		if match.NamedGroups == nil {
-			return "", "", "", fmt.Errorf("np.aws.1 requires named capture group 'key_id'")
-		}
-
-		keyIDBytes, hasKeyID := match.NamedGroups["key_id"]
-		if !hasKeyID {
-			return "", "", "", fmt.Errorf("np.aws.1 requires named group 'key_id' (found: %v)", keysOf(match.NamedGroups))
-		}
-		keyID = string(keyIDBytes)
-
-		// Look for AWS_SECRET_ACCESS_KEY in snippet.After
-		secretMatches := awsSecretKeyPattern.FindSubmatch(match.Snippet.After)
-		if len(secretMatches) < 2 {
-			// Secret not found in snippet
-			return "", "", "", fmt.Errorf("partial credentials: np.aws.1 only contains access key ID")
-		}
-		secret = string(secretMatches[1])
-
-		// Look for AWS_SESSION_TOKEN in snippet.After (optional)
-		tokenMatches := awsSessionTokenPattern.FindSubmatch(match.Snippet.After)
-		if len(tokenMatches) >= 2 {
-			sessionToken = string(tokenMatches[1])
-		}
-
-		return keyID, secret, sessionToken, nil
-
-	case "np.aws.2":
-		// np.aws.2 only captures secret - cannot validate
-		return "", "", "", fmt.Errorf("partial credentials: np.aws.2 only contains secret key")
-
-	default:
-		return "", "", "", fmt.Errorf("unsupported rule ID: %s", match.RuleID)
 	}
+
+	// Step 2: Search snippet context for anything still missing.
+	if keyID == "" {
+		keyID = searchSnippet(match.Snippet, awsAccessKeyIDPatterns)
+	}
+	if secret == "" {
+		secret = searchSnippet(match.Snippet, awsSecretKeyPatterns)
+	}
+	if sessionToken == "" {
+		sessionToken = searchSnippet(match.Snippet, awsSessionTokenPatterns)
+	}
+
+	// Step 3: Require at least key_id and secret.
+	if keyID == "" || secret == "" {
+		return "", "", "", fmt.Errorf("partial credentials: need both key_id and secret_key")
+	}
+
+	return keyID, secret, sessionToken, nil
 }
 
-// keysOf returns the keys of a map as a slice (for error messages).
-func keysOf(m map[string][]byte) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
+// searchSnippet searches all three snippet parts (Before, Matching, After) against
+// a list of patterns, returning the first captured group match.
+func searchSnippet(snippet types.Snippet, patterns []*regexp.Regexp) string {
+	snippetParts := [][]byte{
+		snippet.Before,
+		snippet.Matching,
+		snippet.After,
 	}
-	return keys
+
+	for _, pattern := range patterns {
+		for _, part := range snippetParts {
+			if matches := pattern.FindSubmatch(part); len(matches) >= 2 {
+				return string(matches[1])
+			}
+		}
+	}
+	return ""
 }

--- a/pkg/validator/aws_snippet_test.go
+++ b/pkg/validator/aws_snippet_test.go
@@ -82,6 +82,156 @@ func TestAWSValidator_ExtractCredentials_AWS1_NoSnippetSecret(t *testing.T) {
 	assert.Empty(t, sessionToken)
 }
 
+// TestAWSValidator_ExtractCredentials_AWS1_SecretInBefore tests finding secret in snippet.Before
+func TestAWSValidator_ExtractCredentials_AWS1_SecretInBefore(t *testing.T) {
+	v := NewAWSValidator()
+
+	match := &types.Match{
+		RuleID: "np.aws.1",
+		NamedGroups: map[string][]byte{
+			"key_id": []byte("AKIAIOSFODNN7EXAMPLE"),
+		},
+		Snippet: types.Snippet{
+			Before:   []byte("export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\nexport AWS_ACCESS_KEY_ID="),
+			Matching: []byte("AKIAIOSFODNN7EXAMPLE"),
+			After:    []byte("\n"),
+		},
+	}
+
+	keyID, secret, _, err := v.extractCredentials(match)
+	assert.NoError(t, err)
+	assert.Equal(t, "AKIAIOSFODNN7EXAMPLE", keyID)
+	assert.Equal(t, "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", secret)
+}
+
+// TestAWSValidator_ExtractCredentials_AWS2_KeyIDInBefore tests np.aws.2 finding access key in Before
+func TestAWSValidator_ExtractCredentials_AWS2_KeyIDInBefore(t *testing.T) {
+	v := NewAWSValidator()
+
+	match := &types.Match{
+		RuleID: "np.aws.2",
+		NamedGroups: map[string][]byte{
+			"secret_key": []byte("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"),
+		},
+		Snippet: types.Snippet{
+			Before:   []byte("export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE\nexport AWS_SECRET_ACCESS_KEY="),
+			Matching: []byte("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"),
+		},
+	}
+
+	keyID, secret, _, err := v.extractCredentials(match)
+	assert.NoError(t, err)
+	assert.Equal(t, "AKIAIOSFODNN7EXAMPLE", keyID)
+	assert.Equal(t, "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", secret)
+}
+
+// TestAWSValidator_ExtractCredentials_AWS2_KeyIDInAfter tests np.aws.2 finding access key in After
+func TestAWSValidator_ExtractCredentials_AWS2_KeyIDInAfter(t *testing.T) {
+	v := NewAWSValidator()
+
+	match := &types.Match{
+		RuleID: "np.aws.2",
+		NamedGroups: map[string][]byte{
+			"secret_key": []byte("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"),
+		},
+		Snippet: types.Snippet{
+			Matching: []byte("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"),
+			After:    []byte("\nexport AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE\n"),
+		},
+	}
+
+	keyID, secret, _, err := v.extractCredentials(match)
+	assert.NoError(t, err)
+	assert.Equal(t, "AKIAIOSFODNN7EXAMPLE", keyID)
+	assert.Equal(t, "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", secret)
+}
+
+// TestAWSValidator_ExtractCredentials_AWS2_WithSessionToken tests np.aws.2 with session token in snippet
+func TestAWSValidator_ExtractCredentials_AWS2_WithSessionToken(t *testing.T) {
+	v := NewAWSValidator()
+
+	match := &types.Match{
+		RuleID: "np.aws.2",
+		NamedGroups: map[string][]byte{
+			"secret_key": []byte("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"),
+		},
+		Snippet: types.Snippet{
+			Before:   []byte("export AWS_ACCESS_KEY_ID=ASIAIOSFODNN7EXAMPLE\nexport AWS_SECRET_ACCESS_KEY="),
+			Matching: []byte("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"),
+			After:    []byte("\nexport AWS_SESSION_TOKEN=FwoGZXIvYXdzEBQaDMk"),
+		},
+	}
+
+	keyID, secret, sessionToken, err := v.extractCredentials(match)
+	assert.NoError(t, err)
+	assert.Equal(t, "ASIAIOSFODNN7EXAMPLE", keyID)
+	assert.Equal(t, "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", secret)
+	assert.Equal(t, "FwoGZXIvYXdzEBQaDMk", sessionToken)
+}
+
+// TestAWSValidator_ExtractCredentials_AWS2_BareKeyID tests np.aws.2 finding bare access key (no label)
+func TestAWSValidator_ExtractCredentials_AWS2_BareKeyID(t *testing.T) {
+	v := NewAWSValidator()
+
+	match := &types.Match{
+		RuleID: "np.aws.2",
+		NamedGroups: map[string][]byte{
+			"secret_key": []byte("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"),
+		},
+		Snippet: types.Snippet{
+			Before:   []byte("key: AKIAIOSFODNN7EXAMPLE\nsecret: "),
+			Matching: []byte("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"),
+		},
+	}
+
+	keyID, secret, _, err := v.extractCredentials(match)
+	assert.NoError(t, err)
+	assert.Equal(t, "AKIAIOSFODNN7EXAMPLE", keyID)
+	assert.Equal(t, "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", secret)
+}
+
+// TestAWSValidator_ExtractCredentials_AWS6_FallbackToSnippet tests np.aws.6 falling back to snippet
+func TestAWSValidator_ExtractCredentials_AWS6_FallbackToSnippet(t *testing.T) {
+	v := NewAWSValidator()
+
+	// np.aws.6 with only key_id in named groups, secret in snippet
+	match := &types.Match{
+		RuleID: "np.aws.6",
+		NamedGroups: map[string][]byte{
+			"key_id": []byte("AKIAIOSFODNN7EXAMPLE"),
+		},
+		Snippet: types.Snippet{
+			After: []byte("\nAWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"),
+		},
+	}
+
+	keyID, secret, _, err := v.extractCredentials(match)
+	assert.NoError(t, err)
+	assert.Equal(t, "AKIAIOSFODNN7EXAMPLE", keyID)
+	assert.Equal(t, "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", secret)
+}
+
+// TestAWSValidator_ExtractCredentials_AWS4_FromSnippet tests np.aws.4 finding key_id + secret in snippet
+func TestAWSValidator_ExtractCredentials_AWS4_FromSnippet(t *testing.T) {
+	v := NewAWSValidator()
+
+	match := &types.Match{
+		RuleID: "np.aws.4",
+		NamedGroups: map[string][]byte{
+			"session_token": []byte("FwoGZXIvYXdzEBQaDMk"),
+		},
+		Snippet: types.Snippet{
+			Before: []byte("export AWS_ACCESS_KEY_ID=ASIAIOSFODNN7EXAMPLE\nexport AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\nexport AWS_SESSION_TOKEN="),
+		},
+	}
+
+	keyID, secret, sessionToken, err := v.extractCredentials(match)
+	assert.NoError(t, err)
+	assert.Equal(t, "ASIAIOSFODNN7EXAMPLE", keyID)
+	assert.Equal(t, "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", secret)
+	assert.Equal(t, "FwoGZXIvYXdzEBQaDMk", sessionToken)
+}
+
 // TestAWSValidator_Validate_AWS1_WithSessionToken tests validation with session token
 func TestAWSValidator_Validate_AWS1_WithSessionToken(t *testing.T) {
 	mock := &mockSTSClient{
@@ -111,4 +261,34 @@ func TestAWSValidator_Validate_AWS1_WithSessionToken(t *testing.T) {
 	assert.Equal(t, types.StatusValid, result.Status)
 	assert.Equal(t, 1.0, result.Confidence)
 	assert.Contains(t, result.Message, "123456789012")
+}
+
+// TestAWSValidator_Validate_AWS2_WithSnippet tests end-to-end validation for np.aws.2 with mock STS
+func TestAWSValidator_Validate_AWS2_WithSnippet(t *testing.T) {
+	mock := &mockSTSClient{
+		callerIdentity: &sts.GetCallerIdentityOutput{
+			Account: aws.String("987654321098"),
+			Arn:     aws.String("arn:aws:iam::987654321098:user/leaked-user"),
+			UserId:  aws.String("AIDAEXAMPLE2"),
+		},
+	}
+
+	v := NewAWSValidatorWithClient(mock)
+
+	match := &types.Match{
+		RuleID: "np.aws.2",
+		NamedGroups: map[string][]byte{
+			"secret_key": []byte("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"),
+		},
+		Snippet: types.Snippet{
+			Before:   []byte("export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE\nexport AWS_SECRET_ACCESS_KEY="),
+			Matching: []byte("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"),
+		},
+	}
+
+	result, err := v.Validate(context.Background(), match)
+	assert.NoError(t, err)
+	assert.Equal(t, types.StatusValid, result.Status)
+	assert.Equal(t, 1.0, result.Confidence)
+	assert.Contains(t, result.Message, "987654321098")
 }

--- a/pkg/validator/aws_test.go
+++ b/pkg/validator/aws_test.go
@@ -23,6 +23,7 @@ func TestAWSValidator_CanValidate(t *testing.T) {
 	// AWS rules it can potentially handle
 	assert.True(t, v.CanValidate("np.aws.1"))
 	assert.True(t, v.CanValidate("np.aws.2"))
+	assert.True(t, v.CanValidate("np.aws.4"))
 	assert.True(t, v.CanValidate("np.aws.6"))
 
 	// Non-AWS rules


### PR DESCRIPTION
## Summary
- Replaced per-rule switch statement in `extractCredentials` with a unified flow: extract from NamedGroups first, then fill gaps by searching all snippet parts (Before, Matching, After)
- Fixed **np.aws.2** — now searches snippet for access key ID (previously always returned "partial credentials")
- Fixed **np.aws.1** — now searches all snippet parts for secret key (previously only searched After)
- Fixed **np.aws.6** — falls back to snippet when a named group is missing (previously failed immediately)
- Added **np.aws.4** support — session token rule can now validate when key_id + secret are found in snippet context
- Added `searchSnippet` helper following the same pattern as branchio/amplitude/twilio validators
- Removed unused `keysOf` helper

## Test plan
- [x] All 22 existing + new AWS tests pass (`go test ./pkg/validator/ -run TestAWS -v`)
- [ ] Verify np.aws.2 extracts key_id from snippet Before and After
- [ ] Verify np.aws.1 finds secret in snippet Before (not just After)
- [ ] Verify np.aws.6 falls back to snippet when one named group is missing
- [ ] Verify np.aws.4 finds key_id + secret in snippet context
- [ ] End-to-end validation test for np.aws.2 with mock STS client

🤖 Generated with [Claude Code](https://claude.com/claude-code)