### PR TITLE
Add response body validation to YAML HTTPValidator

### DIFF
--- a/pkg/validator/http.go
+++ b/pkg/validator/http.go
@@ -81,10 +81,21 @@ func (v *HTTPValidator) Validate(ctx context.Context, match *types.Match) (*type
 	if err != nil {
 		return types.NewValidationResult(types.StatusUndetermined, 0, fmt.Sprintf("request failed: %v", err)), nil
 	}
-	defer func() { io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
+	defer resp.Body.Close()
 
-	// Check response code
-	return v.evaluateResponse(resp.StatusCode), nil
+	// Read response body if needed for body-based validation
+	var respBody []byte
+	if v.def.HTTP.SuccessBodyContains != "" || v.def.HTTP.FailureBodyContains != "" {
+		respBody, err = io.ReadAll(resp.Body)
+		if err != nil {
+			return types.NewValidationResult(types.StatusUndetermined, 0, fmt.Sprintf("failed to read response body: %v", err)), nil
+		}
+	} else {
+		io.Copy(io.Discard, resp.Body)
+	}
+
+	// Check response code and body
+	return v.evaluateResponse(resp.StatusCode, respBody), nil
 }
 
 func (v *HTTPValidator) extractSecret(match *types.Match) (string, error) {
@@ -166,10 +177,25 @@ func (v *HTTPValidator) applyAuth(req *http.Request, secret string) error {
 	return nil
 }
 
-func (v *HTTPValidator) evaluateResponse(statusCode int) *types.ValidationResult {
+func (v *HTTPValidator) evaluateResponse(statusCode int, body []byte) *types.ValidationResult {
+	bodyStr := string(body)
+
+	// Check failure body first (takes precedence over success codes)
+	if v.def.HTTP.FailureBodyContains != "" && strings.Contains(bodyStr, v.def.HTTP.FailureBodyContains) {
+		return types.NewValidationResult(types.StatusInvalid, 1.0, fmt.Sprintf("HTTP %d - response body indicates invalid credentials", statusCode))
+	}
+
 	// Check success codes
 	for _, code := range v.def.HTTP.SuccessCodes {
 		if statusCode == code {
+			// If success_body_contains is specified, also check the body
+			if v.def.HTTP.SuccessBodyContains != "" {
+				if strings.Contains(bodyStr, v.def.HTTP.SuccessBodyContains) {
+					return types.NewValidationResult(types.StatusValid, 1.0, fmt.Sprintf("HTTP %d - credentials accepted", statusCode))
+				}
+				// Status code matched but body didn't - treat as invalid
+				return types.NewValidationResult(types.StatusInvalid, 1.0, fmt.Sprintf("HTTP %d - response body indicates invalid credentials", statusCode))
+			}
 			return types.NewValidationResult(types.StatusValid, 1.0, fmt.Sprintf("HTTP %d - credentials accepted", statusCode))
 		}
 	}

--- a/pkg/validator/http_test.go
+++ b/pkg/validator/http_test.go
@@ -537,3 +537,114 @@ func TestHTTPValidator_Validate_None_EmptyAuthType(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, types.StatusValid, result.Status)
 }
+
+func TestHTTPValidator_Validate_SuccessBodyContains_Valid(t *testing.T) {
+	// Slack-style API: returns 200 with ok:true/false in body
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true,"team":"T123"}`))
+	}))
+	defer server.Close()
+
+	def := ValidatorDef{
+		Name:    "slack-token",
+		RuleIDs: []string{"np.slack.4"},
+		HTTP: HTTPDef{
+			Method: "POST",
+			URL:    server.URL,
+			Auth: AuthDef{
+				Type:        "bearer",
+				SecretGroup: "token",
+			},
+			SuccessCodes:        []int{200},
+			FailureCodes:        []int{},
+			SuccessBodyContains: `"ok":true`,
+		},
+	}
+
+	v := NewHTTPValidator(def, nil)
+	match := &types.Match{
+		RuleID: "np.slack.4",
+		NamedGroups: map[string][]byte{
+			"token": []byte("xoxp-valid-token"),
+		},
+	}
+
+	result, err := v.Validate(context.Background(), match)
+	assert.NoError(t, err)
+	assert.Equal(t, types.StatusValid, result.Status)
+}
+
+func TestHTTPValidator_Validate_SuccessBodyContains_Invalid(t *testing.T) {
+	// Slack-style API: returns 200 with ok:false for invalid tokens
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":false,"error":"invalid_auth"}`))
+	}))
+	defer server.Close()
+
+	def := ValidatorDef{
+		Name:    "slack-token",
+		RuleIDs: []string{"np.slack.4"},
+		HTTP: HTTPDef{
+			Method: "POST",
+			URL:    server.URL,
+			Auth: AuthDef{
+				Type:        "bearer",
+				SecretGroup: "token",
+			},
+			SuccessCodes:        []int{200},
+			FailureCodes:        []int{},
+			SuccessBodyContains: `"ok":true`,
+		},
+	}
+
+	v := NewHTTPValidator(def, nil)
+	match := &types.Match{
+		RuleID: "np.slack.4",
+		NamedGroups: map[string][]byte{
+			"token": []byte("xoxp-invalid-token"),
+		},
+	}
+
+	result, err := v.Validate(context.Background(), match)
+	assert.NoError(t, err)
+	assert.Equal(t, types.StatusInvalid, result.Status)
+}
+
+func TestHTTPValidator_Validate_FailureBodyContains(t *testing.T) {
+	// API that returns 200 but with error in body
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"status":"error","message":"unauthorized"}`))
+	}))
+	defer server.Close()
+
+	def := ValidatorDef{
+		Name:    "api-token",
+		RuleIDs: []string{"np.test.1"},
+		HTTP: HTTPDef{
+			Method: "GET",
+			URL:    server.URL,
+			Auth: AuthDef{
+				Type:        "bearer",
+				SecretGroup: "token",
+			},
+			SuccessCodes:        []int{200},
+			FailureCodes:        []int{},
+			FailureBodyContains: `"status":"error"`,
+		},
+	}
+
+	v := NewHTTPValidator(def, nil)
+	match := &types.Match{
+		RuleID: "np.test.1",
+		NamedGroups: map[string][]byte{
+			"token": []byte("bad-token"),
+		},
+	}
+
+	result, err := v.Validate(context.Background(), match)
+	assert.NoError(t, err)
+	assert.Equal(t, types.StatusInvalid, result.Status)
+}

--- a/pkg/validator/validators/slack.yaml
+++ b/pkg/validator/validators/slack.yaml
@@ -29,8 +29,9 @@ validators:
       auth:
         type: bearer
         secret_group: "token"  # Matches (?P<token>...) in rule regex
-      success_codes: [200]  # 200 with ok=true in JSON response
-      failure_codes: []  # 200 with ok=false indicates invalid (check response body for error field)
+      success_codes: [200]
+      failure_codes: []
+      success_body_contains: '"ok":true'  # Slack returns 200 with ok:true/false in body
 
   - name: slack-user-token
     rule_ids:
@@ -43,6 +44,7 @@ validators:
         secret_group: "token"
       success_codes: [200]
       failure_codes: []
+      success_body_contains: '"ok":true'
 
   - name: slack-app-token
     rule_ids:
@@ -55,6 +57,7 @@ validators:
         secret_group: "token"
       success_codes: [200]
       failure_codes: []
+      success_body_contains: '"ok":true'
 
   - name: slack-legacy-bot-token
     rule_ids:
@@ -67,3 +70,4 @@ validators:
         secret_group: "token"
       success_codes: [200]
       failure_codes: []
+      success_body_contains: '"ok":true'

--- a/pkg/validator/yaml.go
+++ b/pkg/validator/yaml.go
@@ -21,13 +21,15 @@ type ValidatorDef struct {
 
 // HTTPDef defines HTTP request configuration.
 type HTTPDef struct {
-	Method       string   `yaml:"method"`
-	URL          string   `yaml:"url"`
-	Auth         AuthDef  `yaml:"auth"`
-	Headers      []Header `yaml:"headers,omitempty"`
-	Body         string   `yaml:"body,omitempty"` // Static request body for POST/PUT
-	SuccessCodes []int    `yaml:"success_codes"`
-	FailureCodes []int    `yaml:"failure_codes"`
+	Method              string   `yaml:"method"`
+	URL                 string   `yaml:"url"`
+	Auth                AuthDef  `yaml:"auth"`
+	Headers             []Header `yaml:"headers,omitempty"`
+	Body                string   `yaml:"body,omitempty"` // Static request body for POST/PUT
+	SuccessCodes        []int    `yaml:"success_codes"`
+	FailureCodes        []int    `yaml:"failure_codes"`
+	SuccessBodyContains string   `yaml:"success_body_contains,omitempty"` // Response body must contain this string for success
+	FailureBodyContains string   `yaml:"failure_body_contains,omitempty"` // Response body containing this string indicates failure
 }
 
 // AuthDef defines authentication configuration.


### PR DESCRIPTION
## Summary
- Add `success_body_contains` and `failure_body_contains` fields to YAML HTTPValidator
- Fix Slack token validators to check `ok:true` in response body
- Slack API returns HTTP 200 for both valid/invalid tokens, using JSON body for status

## Problem
Slack validators marked all tokens as valid because they only checked HTTP status codes. Slack's `auth.test` endpoint always returns 200, with `ok:true/false` in the JSON body.

## Test plan
- [x] Unit tests for body validation (3 new tests)
- [x] Verified dummy token `xoxp-123456789012-...` now correctly marked invalid
- [x] All existing HTTPValidator tests pass