### PR TITLE
Add detection rule for GitLab routable personal access tokens

### DIFF
--- a/pkg/rule/rules/gitlab.yml
+++ b/pkg/rule/rules/gitlab.yml
@@ -62,3 +62,18 @@ rules:
       --no-progress-meter \
       -F token=glptt-0d66598d696a02da33fb65e2a041f607c68ea50d \
       -F ref=main
+
+
+- name: GitLab Routable Personal Access Token
+  id: np.gitlab.4
+  pattern: '\b(glpat-[0-9a-zA-Z_-]{27,300}\.[0-9a-z]{2}\.[a-z0-9]{9})(?:\b|$)'
+
+  categories: [api, secret]
+
+  references:
+  - https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html
+  - https://gitlab.com/gitlab-org/gitlab/-/merge_requests/169322
+
+  examples:
+  - 'export GITLAB_TOKEN="glpat-3fZ1p5y4XWcCvMGVlfakeW86MQp1Oml3Ymg0Cw.01.1203afake"'
+  - 'PRIVATE-TOKEN: glpat-AbCdEfGhIjKlMnOpQrStUvWxYz012345.02.a1b2c3d4e'

--- a/pkg/rule/rulesets/default.yml
+++ b/pkg/rule/rulesets/default.yml
@@ -81,6 +81,7 @@ rulesets:
   - np.gitlab.1       # GitLab Runner Registration Token
   - np.gitlab.2       # GitLab Personal Access Token
   - np.gitlab.3       # GitLab Pipeline Trigger Token
+  - np.gitlab.4       # GitLab Routable Personal Access Token
   - np.google.2       # Google OAuth Client Secret (prefixed)
   - np.google.3       # Google OAuth Client Secret
   - np.google.4       # Google OAuth Access Token

--- a/pkg/validator/validators/gitlab.yaml
+++ b/pkg/validator/validators/gitlab.yaml
@@ -7,6 +7,7 @@ validators:
 - name: gitlab-personal-access-token
   rule_ids:
     - np.gitlab.2
+    - np.gitlab.4
 
   http:
     method: GET


### PR DESCRIPTION
## Summary

GitLab's newer routable personal access tokens, issued by default on instances, use an extended format with dot-separated routing segments.

- Add GitLab Routable Personal Access Token rule (np.gitlab.4) for `glpat-{base64url}.{2chars}.{9chars}` pattern
- Add np.gitlab.4 to default ruleset
- Add np.gitlab.4 to existing GitLab PAT validator (validates against `/api/v4/user` endpoint)

## Test plan
- [x] Verified detection against test tokens in both self-hosted and GitLab.com routable PAT formats
- [x] Confirmed no overlap between np.gitlab.2 (classic 20-char PATs) and np.gitlab.4 (routable PATs)
- [x] All existing tests pass
- [x] Validated that existing GitLab PAT validator handles routable tokens correctly

Closes LAB-1411