### PR TITLE
feat(validator): add MessageBird API token validator

### DIFF
--- a/pkg/validator/validators/messagebird.yaml
+++ b/pkg/validator/validators/messagebird.yaml
@@ -1,0 +1,16 @@
+validators:
+  - name: messagebird-api-token
+    rule_ids:
+      - kingfisher.messagebird.1
+    http:
+      method: GET
+      url: https://rest.messagebird.com/balance
+      auth:
+        type: api_key
+        secret_group: "1"
+        key_prefix: "AccessKey "
+      headers:
+        - name: Accept
+          value: application/json
+      success_codes: [200]
+      failure_codes: [401, 403]


### PR DESCRIPTION
## Summary
- Adds YAML HTTP validator for `kingfisher.messagebird.1` rule
- Validates via `GET https://rest.messagebird.com/balance` with `Authorization: AccessKey <token>`
- Returns 200 for valid keys, 401/403 for invalid

## Changes
- `pkg/validator/validators/messagebird.yaml` — New validator file

## Test plan
- [x] `go test ./pkg/validator/` passes
- [x] `go test ./...` — all 14 packages pass
- [x] End-to-end: `titus scan --validate --rules-include messagebird` correctly validates leaked tokens as invalid (HTTP 401)