### PR TITLE
feat(validator): add JumpCloud API key validator

### DIFF
--- a/pkg/validator/validators/jumpcloud.yaml
+++ b/pkg/validator/validators/jumpcloud.yaml
@@ -1,0 +1,16 @@
+validators:
+  - name: jumpcloud-api-key
+    rule_ids:
+      - kingfisher.jumpcloud.1
+    http:
+      method: GET
+      url: "https://console.jumpcloud.com/api/systemusers?limit=1&skip=0"
+      auth:
+        type: header
+        secret_group: "1"
+        header_name: x-api-key
+      headers:
+        - name: Accept
+          value: application/json
+      success_codes: [200]
+      failure_codes: [401, 403]


### PR DESCRIPTION
## Summary
- Adds YAML HTTP validator for `kingfisher.jumpcloud.1` rule
- Validates via `GET https://console.jumpcloud.com/api/systemusers?limit=1&skip=0` with `x-api-key` header
- Returns 200 for valid keys, 401/403 for invalid

## Changes
- `pkg/validator/validators/jumpcloud.yaml` — New validator file

## Test plan
- [x] `go test ./pkg/validator/` passes
- [x] End-to-end: `titus scan --validate --rules-include jumpcloud` correctly validates test keys as invalid (HTTP 401)