### PR TITLE
feat(validator): add Mailjet API key validators

### DIFF
--- a/pkg/validator/validators/mailjet.yaml
+++ b/pkg/validator/validators/mailjet.yaml
@@ -1,0 +1,31 @@
+validators:
+  - name: mailjet-sms-api-key
+    rule_ids:
+      - kingfisher.mailjet.1
+    http:
+      method: GET
+      url: https://api.mailjet.com/v4/sms/count
+      auth:
+        type: bearer
+        secret_group: "1"
+      headers:
+        - name: Accept
+          value: "application/vnd.mailjetsms+json; version=3"
+      success_codes: [200]
+      failure_codes: [401, 403]
+
+  - name: mailjet-email-basic-auth
+    rule_ids:
+      - kingfisher.mailjet.2
+    http:
+      method: GET
+      url: "https://api.mailjet.com/v3/REST/apikey?Limit=1"
+      auth:
+        type: api_key
+        secret_group: "1"
+        key_prefix: "Basic "
+      headers:
+        - name: Accept
+          value: application/json
+      success_codes: [200]
+      failure_codes: [401, 403]


### PR DESCRIPTION
## Summary
- Adds YAML HTTP validators for `kingfisher.mailjet.1` and `kingfisher.mailjet.2` rules
- SMS API: Validates via `GET https://api.mailjet.com/v4/sms/count` with Bearer token auth
- Email API: Validates via `GET https://api.mailjet.com/v3/REST/apikey?Limit=1` with pre-encoded Basic auth
- Returns 200 for valid keys, 401/403 for invalid

## Changes
- `pkg/validator/validators/mailjet.yaml` — New validator file (2 validators)

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./pkg/validator/` passes
- [x] End-to-end: `titus scan --validate --rules-include mailjet` correctly validates test keys as invalid (HTTP 401) for both SMS and Email rules