### PR TITLE
feat(validator): add Sourcegraph access token validator

### DIFF
--- a/pkg/validator/validators/sourcegraph.yaml
+++ b/pkg/validator/validators/sourcegraph.yaml
@@ -1,0 +1,19 @@
+validators:
+  - name: sourcegraph-access-token
+    rule_ids:
+      - np.sourcegraph.1
+    http:
+      method: POST
+      url: https://sourcegraph.com/.api/graphql
+      auth:
+        type: api_key
+        secret_group: "1"
+        key_prefix: "token "
+      headers:
+        - name: Content-Type
+          value: application/json
+        - name: Accept
+          value: application/json
+      body: '{"query":"{ currentUser { username } }"}'
+      success_codes: [200]
+      failure_codes: [401, 403]


### PR DESCRIPTION
## Summary
- Adds YAML HTTP validator for `np.sourcegraph.1` rule
- Validates via `POST https://sourcegraph.com/.api/graphql` with `{"query":"{ currentUser { username } }"}` body
- Uses `Authorization: token <secret>` header (Sourcegraph's custom auth format)
- Returns 200 for valid tokens, 401/403 for invalid

## Changes
- `pkg/validator/validators/sourcegraph.yaml` — New validator file

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./pkg/validator/` passes
- [x] End-to-end: `titus scan --validate --rules-include sourcegraph` correctly validates test tokens as invalid (HTTP 401)