### PR TITLE
feat: cross-rule redundancy suppression for overlapping secret matches

### DIFF
--- a/cmd/titus/scan.go
+++ b/cmd/titus/scan.go
@@ -154,6 +154,14 @@ func runScan(cmd *cobra.Command, args []string) error {
 	// Initialize validation engine (nil if validation disabled)
 	validationEngine := initValidationEngine()
 
+	// Cross-rule dedup: suppress redundant matches from different rules
+	// detecting the same secret in the same blob
+	canValidate := func(ruleID string) bool { return false }
+	if validationEngine != nil {
+		canValidate = validationEngine.CanValidate
+	}
+	crossRuleDedup := matcher.NewCrossRuleDeduplicator(ruleMap, canValidate)
+
 	// Create enumerator
 	enumerator, err := createEnumerator(target, scanGit)
 	if err != nil {
@@ -276,6 +284,9 @@ func runScan(cmd *cobra.Command, args []string) error {
 					match.Location.Source.End.Line = endLine
 					match.Location.Source.End.Column = endCol
 				}
+
+				// Cross-rule dedup before validation to avoid wasted API calls
+				matches = crossRuleDedup.Deduplicate(matches)
 
 				validateMatches(ctx, validationEngine, matches, verbose)
 				matchCount.Add(int64(len(matches)))
@@ -622,6 +633,12 @@ func runRepoScan(cmd *cobra.Command, rt repoTarget) error {
 
 	validationEngine := initValidationEngine()
 
+	canValidate := func(ruleID string) bool { return false }
+	if validationEngine != nil {
+		canValidate = validationEngine.CanValidate
+	}
+	crossRuleDedup := matcher.NewCrossRuleDeduplicator(ruleMap, canValidate)
+
 	ctx := context.Background()
 	var matchCount atomic.Int64
 	var findingCount atomic.Int64
@@ -734,6 +751,9 @@ func runRepoScan(cmd *cobra.Command, rt repoTarget) error {
 					match.Location.Source.End.Line = endLine
 					match.Location.Source.End.Column = endCol
 				}
+
+				// Cross-rule dedup before validation to avoid wasted API calls
+				matches = crossRuleDedup.Deduplicate(matches)
 
 				validateMatches(ctx, validationEngine, matches, verbose)
 				matchCount.Add(int64(len(matches)))

--- a/pkg/matcher/crossrule.go
+++ b/pkg/matcher/crossrule.go
@@ -1,0 +1,169 @@
+package matcher
+
+import (
+	"github.com/praetorian-inc/titus/pkg/types"
+)
+
+// CrossRuleDeduplicator suppresses redundant matches across different rules
+// within the same blob when they detect the same underlying secret.
+//
+// When multiple rules (e.g., np.aws.1, np.aws.2, np.aws.6) match overlapping
+// credential data in the same file, only the most informative match is kept.
+// Matches are clustered by shared captured group values, then scored.
+type CrossRuleDeduplicator struct {
+	rules       map[string]*types.Rule
+	canValidate func(ruleID string) bool
+}
+
+// NewCrossRuleDeduplicator creates a deduplicator with rule metadata and
+// validator awareness.
+func NewCrossRuleDeduplicator(
+	rules map[string]*types.Rule,
+	canValidate func(ruleID string) bool,
+) *CrossRuleDeduplicator {
+	return &CrossRuleDeduplicator{
+		rules:       rules,
+		canValidate: canValidate,
+	}
+}
+
+// Deduplicate takes all matches from a single blob and returns only the
+// non-redundant subset. Matches are clustered by shared captured group values,
+// then for each cluster the most informative match is kept.
+func (d *CrossRuleDeduplicator) Deduplicate(matches []*types.Match) []*types.Match {
+	if len(matches) <= 1 {
+		return matches
+	}
+
+	clusters := d.clusterBySharedValues(matches)
+
+	result := make([]*types.Match, 0, len(matches))
+	for _, cluster := range clusters {
+		if len(cluster) == 1 {
+			result = append(result, cluster[0])
+			continue
+		}
+		winner := d.pickWinner(cluster)
+		result = append(result, winner)
+	}
+	return result
+}
+
+// clusterBySharedValues groups matches whose captured group values overlap.
+// Uses union-find: if match A and match B share any exact group value,
+// they belong to the same cluster.
+func (d *CrossRuleDeduplicator) clusterBySharedValues(matches []*types.Match) [][]*types.Match {
+	n := len(matches)
+	parent := make([]int, n)
+	for i := range parent {
+		parent[i] = i
+	}
+
+	var find func(int) int
+	find = func(x int) int {
+		for parent[x] != x {
+			parent[x] = parent[parent[x]] // path compression
+			x = parent[x]
+		}
+		return x
+	}
+
+	union := func(a, b int) {
+		ra, rb := find(a), find(b)
+		if ra != rb {
+			parent[ra] = rb
+		}
+	}
+
+	// Map: group value → index of first match that has it
+	valueIndex := make(map[string]int)
+
+	for i, m := range matches {
+		for _, g := range m.Groups {
+			val := string(g)
+			if val == "" {
+				continue
+			}
+			if prev, exists := valueIndex[val]; exists {
+				union(i, prev)
+			} else {
+				valueIndex[val] = i
+			}
+		}
+	}
+
+	// Collect clusters by root
+	clusterMap := make(map[int][]*types.Match)
+	for i, m := range matches {
+		root := find(i)
+		clusterMap[root] = append(clusterMap[root], m)
+	}
+
+	clusters := make([][]*types.Match, 0, len(clusterMap))
+	for _, c := range clusterMap {
+		clusters = append(clusters, c)
+	}
+	return clusters
+}
+
+// pickWinner selects the most informative match from a cluster.
+// Priority: has validator > group count > total captured length > pattern length.
+func (d *CrossRuleDeduplicator) pickWinner(cluster []*types.Match) *types.Match {
+	best := 0
+	bestScore := d.score(cluster[0])
+	for i := 1; i < len(cluster); i++ {
+		s := d.score(cluster[i])
+		if s.Better(bestScore) {
+			best = i
+			bestScore = s
+		}
+	}
+	return cluster[best]
+}
+
+// score computes the ranking criteria for a match.
+func (d *CrossRuleDeduplicator) score(m *types.Match) matchScore {
+	hasValidator := false
+	if d.canValidate != nil {
+		hasValidator = d.canValidate(m.RuleID)
+	}
+
+	groupsLen := 0
+	for _, g := range m.Groups {
+		groupsLen += len(g)
+	}
+
+	patternLen := 0
+	if r, ok := d.rules[m.RuleID]; ok {
+		patternLen = len(r.Pattern)
+	}
+
+	return matchScore{
+		hasValidator: hasValidator,
+		groupCount:   len(m.Groups),
+		groupsLen:    groupsLen,
+		patternLen:   patternLen,
+	}
+}
+
+// matchScore captures the ranking criteria for comparing matches.
+type matchScore struct {
+	hasValidator bool
+	groupCount   int
+	groupsLen    int
+	patternLen   int
+}
+
+// Better returns true if s is ranked higher than other.
+func (s matchScore) Better(other matchScore) bool {
+	if s.hasValidator != other.hasValidator {
+		return s.hasValidator
+	}
+	if s.groupCount != other.groupCount {
+		return s.groupCount > other.groupCount
+	}
+	if s.groupsLen != other.groupsLen {
+		return s.groupsLen > other.groupsLen
+	}
+	return s.patternLen > other.patternLen
+}

--- a/pkg/matcher/crossrule_test.go
+++ b/pkg/matcher/crossrule_test.go
@@ -1,0 +1,241 @@
+package matcher
+
+import (
+	"testing"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeMatch(ruleID string, groups ...string) *types.Match {
+	g := make([][]byte, len(groups))
+	for i, s := range groups {
+		g[i] = []byte(s)
+	}
+	return &types.Match{
+		RuleID: ruleID,
+		Groups: g,
+	}
+}
+
+func makeRules(rules ...struct{ id, pattern string }) map[string]*types.Rule {
+	m := make(map[string]*types.Rule)
+	for _, r := range rules {
+		m[r.id] = &types.Rule{ID: r.id, Pattern: r.pattern}
+	}
+	return m
+}
+
+func TestCrossRule_AWSCombo(t *testing.T) {
+	// np.aws.1 captures key, np.aws.2 captures secret, np.aws.6 captures both.
+	// aws.6 shares group[0] with aws.1 and group[1] with aws.2 → all clustered.
+	// aws.6 wins: most groups (2 > 1).
+	rules := makeRules(
+		struct{ id, pattern string }{"np.aws.1", `AKIA[A-Z0-9]{16}`},
+		struct{ id, pattern string }{"np.aws.2", `aws_secret.*[a-z0-9/+=]{40}`},
+		struct{ id, pattern string }{"np.aws.6", `AKIA[A-Z0-9]{16}.*[A-Za-z0-9/+=]{40}`},
+	)
+
+	// All have validators
+	canValidate := func(ruleID string) bool { return true }
+
+	dedup := NewCrossRuleDeduplicator(rules, canValidate)
+
+	matches := []*types.Match{
+		makeMatch("np.aws.1", "AKIAZ52KNG5GARBXTEST"),
+		makeMatch("np.aws.2", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"),
+		makeMatch("np.aws.6", "AKIAZ52KNG5GARBXTEST", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"),
+	}
+
+	result := dedup.Deduplicate(matches)
+
+	require.Len(t, result, 1)
+	assert.Equal(t, "np.aws.6", result[0].RuleID)
+}
+
+func TestCrossRule_ValidatorWins(t *testing.T) {
+	// RuleA has 2 groups but no validator. RuleB has 1 group but has validator.
+	// They share a group value. Validator priority wins.
+	rules := makeRules(
+		struct{ id, pattern string }{"rule.a", `pattern_a`},
+		struct{ id, pattern string }{"rule.b", `pattern_b`},
+	)
+
+	canValidate := func(ruleID string) bool { return ruleID == "rule.b" }
+
+	dedup := NewCrossRuleDeduplicator(rules, canValidate)
+
+	matches := []*types.Match{
+		makeMatch("rule.a", "SECRET123", "extra_group"),
+		makeMatch("rule.b", "SECRET123"),
+	}
+
+	result := dedup.Deduplicate(matches)
+
+	require.Len(t, result, 1)
+	assert.Equal(t, "rule.b", result[0].RuleID)
+}
+
+func TestCrossRule_NoOverlap_DifferentSecrets(t *testing.T) {
+	// AWS key and Stripe key in same file — no shared group values.
+	rules := makeRules(
+		struct{ id, pattern string }{"np.aws.1", `AKIA[A-Z0-9]{16}`},
+		struct{ id, pattern string }{"np.stripe.1", `sk_live_[a-z0-9]{24}`},
+	)
+
+	dedup := NewCrossRuleDeduplicator(rules, nil)
+
+	matches := []*types.Match{
+		makeMatch("np.aws.1", "AKIAZ52KNG5GARBXTEST"),
+		makeMatch("np.stripe.1", "sk_live_abc123def456ghi789jk"),
+	}
+
+	result := dedup.Deduplicate(matches)
+
+	require.Len(t, result, 2)
+}
+
+func TestCrossRule_TwoDifferentAWSKeys(t *testing.T) {
+	// Two different AWS keys in same file — different values, both survive.
+	rules := makeRules(
+		struct{ id, pattern string }{"np.aws.1", `AKIA[A-Z0-9]{16}`},
+	)
+
+	dedup := NewCrossRuleDeduplicator(rules, nil)
+
+	matches := []*types.Match{
+		makeMatch("np.aws.1", "AKIAZ52KNG5GARBXAAAA"),
+		makeMatch("np.aws.1", "AKIAZ52KNG5GARBXBBBB"),
+	}
+
+	result := dedup.Deduplicate(matches)
+
+	require.Len(t, result, 2)
+}
+
+func TestCrossRule_SingleMatch(t *testing.T) {
+	dedup := NewCrossRuleDeduplicator(nil, nil)
+
+	matches := []*types.Match{
+		makeMatch("np.aws.1", "AKIAZ52KNG5GARBXTEST"),
+	}
+
+	result := dedup.Deduplicate(matches)
+
+	require.Len(t, result, 1)
+	assert.Equal(t, "np.aws.1", result[0].RuleID)
+}
+
+func TestCrossRule_EmptyInput(t *testing.T) {
+	dedup := NewCrossRuleDeduplicator(nil, nil)
+	result := dedup.Deduplicate(nil)
+	assert.Nil(t, result)
+}
+
+func TestCrossRule_EmptyGroups(t *testing.T) {
+	// Matches with empty capture groups should not be clustered together.
+	rules := makeRules(
+		struct{ id, pattern string }{"rule.a", `pattern_a`},
+		struct{ id, pattern string }{"rule.b", `pattern_b`},
+	)
+
+	dedup := NewCrossRuleDeduplicator(rules, nil)
+
+	matches := []*types.Match{
+		makeMatch("rule.a", ""),
+		makeMatch("rule.b", ""),
+	}
+
+	result := dedup.Deduplicate(matches)
+
+	require.Len(t, result, 2)
+}
+
+func TestCrossRule_TransitiveChaining(t *testing.T) {
+	// A shares value with B, B shares value with C, A doesn't share with C directly.
+	// All three should be in one cluster via transitive union.
+	rules := makeRules(
+		struct{ id, pattern string }{"rule.a", `a`},
+		struct{ id, pattern string }{"rule.b", `ab`},
+		struct{ id, pattern string }{"rule.c", `c`},
+	)
+
+	canValidate := func(ruleID string) bool { return ruleID == "rule.b" }
+
+	dedup := NewCrossRuleDeduplicator(rules, canValidate)
+
+	matches := []*types.Match{
+		makeMatch("rule.a", "VALUE_X"),
+		makeMatch("rule.b", "VALUE_X", "VALUE_Y"),
+		makeMatch("rule.c", "VALUE_Y"),
+	}
+
+	result := dedup.Deduplicate(matches)
+
+	require.Len(t, result, 1)
+	assert.Equal(t, "rule.b", result[0].RuleID)
+}
+
+func TestCrossRule_GroupCountTiebreaker(t *testing.T) {
+	// Both have validators, but rule.combo has more groups.
+	rules := makeRules(
+		struct{ id, pattern string }{"rule.single", `pattern_short`},
+		struct{ id, pattern string }{"rule.combo", `pattern_longer`},
+	)
+
+	canValidate := func(ruleID string) bool { return true }
+
+	dedup := NewCrossRuleDeduplicator(rules, canValidate)
+
+	matches := []*types.Match{
+		makeMatch("rule.single", "SECRET123"),
+		makeMatch("rule.combo", "SECRET123", "EXTRA_DATA"),
+	}
+
+	result := dedup.Deduplicate(matches)
+
+	require.Len(t, result, 1)
+	assert.Equal(t, "rule.combo", result[0].RuleID)
+}
+
+func TestCrossRule_PatternLengthTiebreaker(t *testing.T) {
+	// Same validator status, same group count, same captured length.
+	// Longer pattern wins.
+	rules := makeRules(
+		struct{ id, pattern string }{"rule.short", `[a-z]{10}`},
+		struct{ id, pattern string }{"rule.long", `(?:aws_secret_key=)[a-z]{10}`},
+	)
+
+	dedup := NewCrossRuleDeduplicator(rules, nil)
+
+	matches := []*types.Match{
+		makeMatch("rule.short", "abcdefghij"),
+		makeMatch("rule.long", "abcdefghij"),
+	}
+
+	result := dedup.Deduplicate(matches)
+
+	require.Len(t, result, 1)
+	assert.Equal(t, "rule.long", result[0].RuleID)
+}
+
+func TestCrossRule_NilCanValidate(t *testing.T) {
+	// When canValidate is nil (validation disabled), scoring should still work.
+	rules := makeRules(
+		struct{ id, pattern string }{"np.aws.1", `short`},
+		struct{ id, pattern string }{"np.aws.6", `longer_pattern`},
+	)
+
+	dedup := NewCrossRuleDeduplicator(rules, nil)
+
+	matches := []*types.Match{
+		makeMatch("np.aws.1", "AKIAZ52KNG5GARBXTEST"),
+		makeMatch("np.aws.6", "AKIAZ52KNG5GARBXTEST", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"),
+	}
+
+	result := dedup.Deduplicate(matches)
+
+	require.Len(t, result, 1)
+	assert.Equal(t, "np.aws.6", result[0].RuleID)
+}

--- a/pkg/validator/engine.go
+++ b/pkg/validator/engine.go
@@ -90,6 +90,16 @@ func (e *Engine) ValidateMatch(ctx context.Context, match *types.Match) (*types.
 	return types.NewValidationResult(types.StatusUndetermined, 0, "no validator available for this secret type"), nil
 }
 
+// CanValidate reports whether any registered validator can handle the given rule ID.
+func (e *Engine) CanValidate(ruleID string) bool {
+	for _, v := range e.validators {
+		if v.CanValidate(ruleID) {
+			return true
+		}
+	}
+	return false
+}
+
 // extractSecret extracts the secret value from a match for caching purposes.
 // Prefers named group "secret", falls back to matching snippet.
 func extractSecret(match *types.Match) []byte {


### PR DESCRIPTION
## Problem

When multiple rules detect the same credential in a file, each produces a distinct FindingID, creating duplicate downstream findings. For example, an AWS key+secret pair triggers `np.aws.1`, `np.aws.2`, `np.aws.6`, and `np.generic.2` — all detecting the same underlying credential but producing 3-4 separate findings with different structural IDs.

This is a **Titus-level improvement** — the dedup happens before validation and output, benefiting all consumers (Guard, CLI, integrations).

## Industry Context

Every major secret scanner faces this problem. GitHub solves it with value-based dedup and paired credential detection. TruffleHog tried cross-detector dedup but removed it due to false negatives. NoseyParker uses byte-range overlap which is complex and breaks on cross-line credentials. Our approach combines GitHub-style value-based grouping with validator-priority scoring, applied pre-validation to save API calls — simpler than byte-range and handles cross-line credentials naturally.

## Solution

Cross-rule deduplication that clusters matches by shared captured group values (union-find), then keeps only the most informative match per cluster using 4-tier scoring: validator presence > group count > captured byte length > pattern length.

Inserted **before validation** in the pipeline so suppressed matches skip API calls entirely.

## Before / After

### Test 1: [`secret-test-alpha`](https://github.com/aashish-dedup-test/secret-test-alpha) — YAML config with AWS key+secret

**Before** (3 matches):
```
L  6  np.aws.1        groups=1  [AKIAZ52KNG5GARBXTEST]
L  6  np.aws.6        groups=2  [AKIAZ52KNG5GARBXTEST, wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY]
L  7  np.generic.2    groups=1  [wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY]
```

**After** (1 match):
```
L  6  np.aws.6        groups=2  ← WINNER (key+secret, most groups)
```

All three share captured values transitively → single cluster → `np.aws.6` wins.

---

### Test 2: [`secret-test-beta`](https://github.com/aashish-dedup-test/secret-test-beta) — `.env` file with `AWS_ACCESS_KEY_ID=` + `AWS_SECRET_ACCESS_KEY=`

**Before** (4 matches):
```
L  3  np.aws.1        groups=1  [AKIAZ52KNG5GARBXTEST]
L  4  np.aws.2        groups=1  [AWS_SECRET_ACCESS_KEY=wJalr...]
L  3  np.aws.6        groups=2  [AKIAZ52KNG5GARBXTEST, wJalrXUtnFEMI/...]
L  4  np.generic.2    groups=1  [wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY]
```

**After** (1 match):
```
L  3  np.aws.6        groups=2  ← WINNER
```

---

### Test 3: [`secret-test-gamma`](https://github.com/aashish-dedup-test/secret-test-gamma) — Challenge: 2 AWS pairs + Google + Postgres + generic + duplicate locations

**Before** (9 matches):
```
L  7  np.aws.1        groups=1  [AKIAXTESTDEDUPRULE01]              ← AWS pair #1
L 12  np.aws.1        groups=1  [AKIAXTESTDEDUPRULE02]              ← AWS pair #2 (different key)
L  7  np.aws.6        groups=2  [AKIAXTESTDEDUPRULE01, wJalrXUtn...]← AWS pair #1 combo
L 13  np.aws.6        groups=2  [AKIAXTESTDEDUPRULE02, bPxRfiCY...] ← AWS pair #2 combo
L  8  np.generic.2    groups=1  [wJalrXUtnFEMI/K7MDENG/bPxRfi...]   ← generic on pair #1 secret
L 14  np.generic.2    groups=1  [bPxRfiCYANOTHERKEY/wJalrXUtn...]   ← generic on pair #2 secret
L 23  np.generic.2    groups=1  [951bc382db9abad29c...]              ← standalone generic API key
L 30  np.google.1     groups=1  [231545488769-...]                   ← Google OAuth client ID
L 27  np.postgres.1   groups=4  [admin, SuperSecret..., ...]         ← Postgres connection string
```

**After** (5 matches):
```
L  7  np.aws.6        groups=2  ← WINNER pair #1 (absorbed aws.1 + generic.2)
L 13  np.aws.6        groups=2  ← WINNER pair #2 (absorbed aws.1 + generic.2)
L 23  np.generic.2    groups=1  ← survived (standalone, no overlap)
L 30  np.google.1     groups=1  ← survived (independent service)
L 27  np.postgres.1   groups=4  ← survived (independent service)
```

Key observations:
- **Each AWS pair**: 3 matches → 1 match (aws.1 + aws.6 + generic.2 clustered → aws.6 wins)
- **Cross-service secrets preserved**: Google, Postgres, standalone generic — no false suppression
- **Duplicate locations** (same key reused at L18-19): handled by existing within-rule dedup
- **Two independent AWS pairs**: each forms its own cluster (different key values)

## Why cross-service secrets can never be falsely suppressed

Clustering uses **exact string match** on captured group values. Different services have different prefixes (`AKIA...` vs `sk_live_...` vs `xoxb-...` vs `ghp_...`) and unique randomly-generated secret values. Two matches can only cluster if they capture the **exact same literal string**. Verified by `TestCrossRule_NoOverlap_DifferentSecrets` unit test.

## Changes

| File | Change |
|------|--------|
| `pkg/matcher/crossrule.go` (new, 169 lines) | `CrossRuleDeduplicator` with union-find clustering and 4-tier scoring |
| `pkg/matcher/crossrule_test.go` (new, 241 lines) | 11 unit tests: AWS combo, validator priority, transitive chaining, no-overlap, empty groups, tiebreakers |
| `pkg/validator/engine.go` (+10 lines) | Expose `CanValidate(ruleID)` method on Engine |
| `cmd/titus/scan.go` (+20 lines) | Wire deduplicator into `runScan` and `runRepoScan` pipelines |

## Algorithm

1. **Cluster** matches by shared captured group values using union-find (O(n·α(n)))
2. **Score** each match: `hasValidator` > `groupCount` > `totalCapturedBytes` > `patternLength`
3. **Keep** highest-scored match per cluster, suppress the rest

## Test plan

- [x] `go test ./pkg/matcher/...` — 11 unit tests pass
- [x] `go test ./...` — no regressions
- [x] [`secret-test-alpha`](https://github.com/aashish-dedup-test/secret-test-alpha): 3 → 1 match
- [x] [`secret-test-beta`](https://github.com/aashish-dedup-test/secret-test-beta): 4 → 1 match
- [x] [`secret-test-gamma`](https://github.com/aashish-dedup-test/secret-test-gamma): 9 → 5 matches (2 AWS pairs each 3→1, independent services preserved)
- [x] Cross-service secrets (Google, Postgres, generic) all preserved correctly
- [x] Duplicate same-secret at different locations handled by existing within-rule dedup