### PR TITLE
refactor: move cross-rule dedup into matcher chain for all consumers

### DIFF
--- a/cmd/titus/scan.go
+++ b/cmd/titus/scan.go
@@ -154,13 +154,10 @@ func runScan(cmd *cobra.Command, args []string) error {
 	// Initialize validation engine (nil if validation disabled)
 	validationEngine := initValidationEngine()
 
-	// Cross-rule dedup: suppress redundant matches from different rules
-	// detecting the same secret in the same blob
-	canValidate := func(ruleID string) bool { return false }
+	// Wire validator awareness into the matcher's built-in deduplicator
 	if validationEngine != nil {
-		canValidate = validationEngine.CanValidate
+		matcher.SetCanValidate(m, validationEngine.CanValidate)
 	}
-	crossRuleDedup := matcher.NewCrossRuleDeduplicator(ruleMap, canValidate)
 
 	// Create enumerator
 	enumerator, err := createEnumerator(target, scanGit)
@@ -284,9 +281,6 @@ func runScan(cmd *cobra.Command, args []string) error {
 					match.Location.Source.End.Line = endLine
 					match.Location.Source.End.Column = endCol
 				}
-
-				// Cross-rule dedup before validation to avoid wasted API calls
-				matches = crossRuleDedup.Deduplicate(matches)
 
 				validateMatches(ctx, validationEngine, matches, verbose)
 				matchCount.Add(int64(len(matches)))
@@ -633,11 +627,10 @@ func runRepoScan(cmd *cobra.Command, rt repoTarget) error {
 
 	validationEngine := initValidationEngine()
 
-	canValidate := func(ruleID string) bool { return false }
+	// Wire validator awareness into the matcher's built-in deduplicator
 	if validationEngine != nil {
-		canValidate = validationEngine.CanValidate
+		matcher.SetCanValidate(m, validationEngine.CanValidate)
 	}
-	crossRuleDedup := matcher.NewCrossRuleDeduplicator(ruleMap, canValidate)
 
 	ctx := context.Background()
 	var matchCount atomic.Int64
@@ -751,9 +744,6 @@ func runRepoScan(cmd *cobra.Command, rt repoTarget) error {
 					match.Location.Source.End.Line = endLine
 					match.Location.Source.End.Column = endCol
 				}
-
-				// Cross-rule dedup before validation to avoid wasted API calls
-				matches = crossRuleDedup.Deduplicate(matches)
 
 				validateMatches(ctx, validationEngine, matches, verbose)
 				matchCount.Add(int64(len(matches)))

--- a/pkg/matcher/crossrule.go
+++ b/pkg/matcher/crossrule.go
@@ -27,6 +27,12 @@ func NewCrossRuleDeduplicator(
 	}
 }
 
+// SetCanValidate updates the validator awareness function after construction.
+// Passing nil disables validator-based scoring (all rules treated equally).
+func (d *CrossRuleDeduplicator) SetCanValidate(fn func(ruleID string) bool) {
+	d.canValidate = fn
+}
+
 // Deduplicate takes all matches from a single blob and returns only the
 // non-redundant subset. Matches are clustered by shared captured group values,
 // then for each cluster the most informative match is kept.

--- a/pkg/matcher/dedup_matcher.go
+++ b/pkg/matcher/dedup_matcher.go
@@ -1,0 +1,50 @@
+package matcher
+
+import "github.com/praetorian-inc/titus/pkg/types"
+
+// dedupMatcher wraps a Matcher and applies cross-rule deduplication
+// to suppress redundant matches from different rules detecting the same secret.
+type dedupMatcher struct {
+	inner Matcher
+	dedup *CrossRuleDeduplicator
+}
+
+// newDedupMatcher wraps a matcher with cross-rule deduplication.
+func newDedupMatcher(inner Matcher, rules []*types.Rule) *dedupMatcher {
+	ruleMap := make(map[string]*types.Rule, len(rules))
+	for _, r := range rules {
+		ruleMap[r.ID] = r
+	}
+	return &dedupMatcher{
+		inner: inner,
+		dedup: NewCrossRuleDeduplicator(ruleMap, nil),
+	}
+}
+
+func (d *dedupMatcher) Match(content []byte) ([]*types.Match, error) {
+	matches, err := d.inner.Match(content)
+	if err != nil {
+		return nil, err
+	}
+	return d.dedup.Deduplicate(matches), nil
+}
+
+func (d *dedupMatcher) MatchWithBlobID(content []byte, blobID types.BlobID) ([]*types.Match, error) {
+	matches, err := d.inner.MatchWithBlobID(content, blobID)
+	if err != nil {
+		return nil, err
+	}
+	return d.dedup.Deduplicate(matches), nil
+}
+
+func (d *dedupMatcher) Close() error {
+	return d.inner.Close()
+}
+
+// SetCanValidate upgrades the deduplicator in a matcher chain with validator awareness.
+// If the matcher doesn't contain a dedupMatcher, this is a no-op.
+func SetCanValidate(m Matcher, fn func(ruleID string) bool) {
+	if dm, ok := m.(*dedupMatcher); ok {
+		dm.dedup.SetCanValidate(fn)
+	}
+}

--- a/pkg/matcher/matcher_default.go
+++ b/pkg/matcher/matcher_default.go
@@ -12,5 +12,6 @@ func New(cfg Config) (Matcher, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newFilteringMatcher(inner, cfg.Rules), nil
+	filtered := newFilteringMatcher(inner, cfg.Rules)
+	return newDedupMatcher(filtered, cfg.Rules), nil
 }

--- a/pkg/matcher/matcher_vectorscan.go
+++ b/pkg/matcher/matcher_vectorscan.go
@@ -17,5 +17,6 @@ func New(cfg Config) (Matcher, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newFilteringMatcher(inner, cfg.Rules), nil
+	filtered := newFilteringMatcher(inner, cfg.Rules)
+	return newDedupMatcher(filtered, cfg.Rules), nil
 }

--- a/pkg/matcher/matcher_wasm.go
+++ b/pkg/matcher/matcher_wasm.go
@@ -8,5 +8,6 @@ func New(cfg Config) (Matcher, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newFilteringMatcher(inner, cfg.Rules), nil
+	filtered := newFilteringMatcher(inner, cfg.Rules)
+	return newDedupMatcher(filtered, cfg.Rules), nil
 }

--- a/pkg/scanner/core.go
+++ b/pkg/scanner/core.go
@@ -142,6 +142,14 @@ func (c *Core) Close() {
 	}
 }
 
+// SetCanValidate upgrades the deduplicator with validator awareness. Call this
+// after NewCore() when a validation engine is available so the deduplicator can
+// prefer rules that have validators during cross-rule tie-breaking.
+// Passing nil reverts to treating all rules as having no validator.
+func (c *Core) SetCanValidate(fn func(ruleID string) bool) {
+	matcher.SetCanValidate(c.matcher, fn)
+}
+
 // GetBuiltinRules returns the built-in rules (cached)
 func GetBuiltinRules() ([]*types.Rule, error) {
 	return loadBuiltinRulesCached()

--- a/pkg/scanner/core_test.go
+++ b/pkg/scanner/core_test.go
@@ -1,0 +1,164 @@
+//go:build !wasm
+
+package scanner
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildRulesJSON encodes a slice of rules to JSON for use with NewCore.
+func buildRulesJSON(rules []*types.Rule) string {
+	b, err := json.Marshal(rules)
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}
+
+// TestCore_Scan_DeduplicatesCrossRuleMatches verifies that Scan applies
+// cross-rule deduplication before returning results.
+//
+// Both rules capture the same AWS access key. The combo rule also captures
+// the credential suffix, giving it two capture groups. Dedup clusters them
+// by the shared key value and keeps only the more informative combo match.
+func TestCore_Scan_DeduplicatesCrossRuleMatches(t *testing.T) {
+	rules := []*types.Rule{
+		{
+			ID:      "rule.key_only",
+			Name:    "Key Only",
+			Pattern: `(AKIA[A-Z0-9]{16})`,
+		},
+		{
+			ID:      "rule.key_and_secret",
+			Name:    "Key and Secret",
+			Pattern: `(AKIA[A-Z0-9]{16}).*([A-Za-z0-9/+=]{10})`,
+		},
+	}
+
+	core, err := NewCore(buildRulesJSON(rules), nil)
+	require.NoError(t, err)
+	defer core.Close()
+
+	content := "aws_access_key=AKIAZ52KNG5GARBXTEST credential=wJalrXUtnFE"
+	result, err := core.Scan(content, "test")
+	require.NoError(t, err)
+
+	// Dedup clusters by shared group value "AKIAZ52KNG5GARBXTEST"
+	// rule.key_and_secret has more groups so it wins
+	require.Len(t, result.Matches, 1)
+	assert.Equal(t, "rule.key_and_secret", result.Matches[0].RuleID)
+}
+
+// TestCore_Scan_PreservesIndependentMatches verifies that Scan does not
+// suppress matches for different secrets (no shared capture group values).
+func TestCore_Scan_PreservesIndependentMatches(t *testing.T) {
+	rules := []*types.Rule{
+		{
+			ID:      "rule.aws",
+			Name:    "AWS Key",
+			Pattern: `(AKIA[A-Z0-9]{16})`,
+		},
+		{
+			ID:      "rule.stripe",
+			Name:    "Stripe Key",
+			Pattern: `(sk_live_[a-z0-9]{10})`,
+		},
+	}
+
+	core, err := NewCore(buildRulesJSON(rules), nil)
+	require.NoError(t, err)
+	defer core.Close()
+
+	// Content with two different secrets — neither should be suppressed
+	result, err := core.Scan("aws=AKIAZ52KNG5GARBXTEST stripe=sk_live_abcdef0123", "test")
+	require.NoError(t, err)
+
+	assert.Len(t, result.Matches, 2)
+}
+
+// TestCore_ScanBatch_DeduplicatesPerItem verifies that ScanBatch applies
+// dedup independently to each scanned item.
+func TestCore_ScanBatch_DeduplicatesPerItem(t *testing.T) {
+	rules := []*types.Rule{
+		{
+			ID:      "rule.key_only",
+			Name:    "Key Only",
+			Pattern: `(AKIA[A-Z0-9]{16})`,
+		},
+		{
+			ID:      "rule.key_and_secret",
+			Name:    "Key and Secret",
+			Pattern: `(AKIA[A-Z0-9]{16}).*([A-Za-z0-9/+=]{10})`,
+		},
+	}
+
+	core, err := NewCore(buildRulesJSON(rules), nil)
+	require.NoError(t, err)
+	defer core.Close()
+
+	items := []ContentItem{
+		{Source: "file1", Content: "aws_access_key=AKIAZ52KNG5GARBXTEST credential=wJalrXUtnFE"},
+		{Source: "file2", Content: "aws_access_key=AKIAAAAAAAAAAAAATEST credential=BBBBBBBBBB"},
+	}
+
+	batchResult, err := core.ScanBatch(items)
+	require.NoError(t, err)
+
+	require.Len(t, batchResult.Results, 2)
+	// Each item: two rules match same AWS key, dedup keeps only the combo rule
+	assert.Len(t, batchResult.Results[0].Matches, 1)
+	assert.Equal(t, "rule.key_and_secret", batchResult.Results[0].Matches[0].RuleID)
+	assert.Len(t, batchResult.Results[1].Matches, 1)
+	assert.Equal(t, "rule.key_and_secret", batchResult.Results[1].Matches[0].RuleID)
+	// Total reflects deduplicated counts: 1 per item
+	assert.Equal(t, 2, batchResult.Total)
+}
+
+// TestCore_SetCanValidate_PreferValidatedRule verifies that after calling
+// SetCanValidate, the deduplicator uses validator awareness to break ties.
+//
+// rule.many_groups has two capture groups; rule.has_validator has one group
+// but is declared as having a validator. Without SetCanValidate the
+// many-groups rule wins on group count. After SetCanValidate the validated
+// rule should win because validator presence outranks group count.
+func TestCore_SetCanValidate_PreferValidatedRule(t *testing.T) {
+	rules := []*types.Rule{
+		{
+			ID:      "rule.many_groups",
+			Name:    "Many Groups",
+			Pattern: `(AKIA[A-Z0-9]{16}).*([A-Za-z0-9/+=]{10})`,
+		},
+		{
+			ID:      "rule.has_validator",
+			Name:    "Has Validator",
+			Pattern: `(AKIA[A-Z0-9]{16})`,
+		},
+	}
+
+	core, err := NewCore(buildRulesJSON(rules), nil)
+	require.NoError(t, err)
+	defer core.Close()
+
+	content := "aws_access_key=AKIAZ52KNG5GARBXTEST credential=wJalrXUtnFE"
+
+	// Without SetCanValidate: rule.many_groups wins due to more capture groups
+	result, err := core.Scan(content, "test")
+	require.NoError(t, err)
+	require.Len(t, result.Matches, 1)
+	assert.Equal(t, "rule.many_groups", result.Matches[0].RuleID)
+
+	// After SetCanValidate: rule.has_validator should win (validator beats group count)
+	core.SetCanValidate(func(ruleID string) bool {
+		return ruleID == "rule.has_validator"
+	})
+
+	result, err = core.Scan(content, "test")
+	require.NoError(t, err)
+	require.Len(t, result.Matches, 1)
+	assert.Equal(t, "rule.has_validator", result.Matches[0].RuleID)
+}


### PR DESCRIPTION
## Context

PR #127 added cross-rule deduplication to suppress redundant matches when multiple rules detect the same credential. However, it was wired only into the CLI (`cmd/titus/scan.go`). Library consumers — most importantly Guard, which imports `scanner.Core` — did not get dedup and continued receiving 3-4 redundant matches per credential.

## What changed

Moved the dedup from the CLI into the `matcher.New()` chain as a `dedupMatcher` decorator, following the existing `filteringMatcher` pattern:

```
inner (regexp/vectorscan) → filteringMatcher → dedupMatcher
```

Now **every consumer** of `matcher.New()` gets dedup automatically — CLI, `scanner.Core`, Guard, browser extension, and any future integration.

## Changes

| File | Change |
|------|--------|
| `pkg/matcher/dedup_matcher.go` (new, 51 lines) | Decorator that applies `CrossRuleDeduplicator.Deduplicate()` after each `Match()` call |
| `pkg/matcher/crossrule.go` (+6 lines) | Added `SetCanValidate()` method for post-construction validator upgrade |
| `pkg/matcher/matcher_default.go` | Chain: inner → filtering → **dedup** |
| `pkg/matcher/matcher_vectorscan.go` | Same chain update |
| `pkg/matcher/matcher_wasm.go` | Same chain update |
| `pkg/scanner/core.go` (+8 lines) | `SetCanValidate()` passthrough so Guard can wire validator awareness |
| `cmd/titus/scan.go` (-17 lines) | Removed manual dedup setup from `runScan` and `runRepoScan`; replaced with `matcher.SetCanValidate()` |
| `pkg/scanner/core_test.go` (new, 164 lines) | 4 tests: cross-rule dedup through Core, independent match preservation, batch dedup, SetCanValidate scoring |

## Compared to PR #127

| | PR #127 | This PR |
|---|---|---|
| **Where dedup runs** | CLI only (`cmd/titus/scan.go`) | Matcher chain (all consumers) |
| **Guard gets dedup** | No | Yes |
| **Browser ext gets dedup** | No | Yes |
| **Dedup code locations** | 2 (runScan + runRepoScan) | 1 (dedupMatcher) |
| **Lines added** | +430 (new feature) | +238 net (+255/-17 refactor) |

## Before / After

Verified the same test repos from #127. Results are identical — confirming the matcher-level dedup produces the same output as the CLI-level dedup from #127, with no regressions:

| Repo | Without dedup | With dedup (#127 and this PR) |
|------|---------------|-------------------------------|
| [secret-test-alpha](https://github.com/aashish-dedup-test/secret-test-alpha) | 3 matches | 1 match |
| [secret-test-beta](https://github.com/aashish-dedup-test/secret-test-beta) | 4 matches | 1 match |
| [secret-test-gamma](https://github.com/aashish-dedup-test/secret-test-gamma) | 13 matches | 7 matches |

## Test plan

- [x] `go vet ./...` — clean
- [x] `go test -race ./pkg/matcher/... ./pkg/scanner/...` — pass
- [x] `go build ./...` — clean
- [x] Before/after scans on alpha, beta, gamma repos match PR #127 results exactly