### PR TITLE
feat(validator): add Shippo API token validator

### DIFF
--- a/pkg/validator/validators/shippo.yaml
+++ b/pkg/validator/validators/shippo.yaml
@@ -1,0 +1,16 @@
+validators:
+  - name: shippo-api-token
+    rule_ids:
+      - kingfisher.shippo.1
+    http:
+      method: GET
+      url: https://api.goshippo.com/shipments/
+      auth:
+        type: api_key
+        secret_group: "1"
+        key_prefix: "ShippoToken "
+      headers:
+        - name: Accept
+          value: application/json
+      success_codes: [200]
+      failure_codes: [401, 403]


### PR DESCRIPTION
## Summary
- Adds YAML HTTP validator for `kingfisher.shippo.1` rule
- Validates via `GET https://api.goshippo.com/shipments/` with `Authorization: ShippoToken <token>` header
- Returns 200 for valid tokens, 401/403 for invalid

## Changes
- `pkg/validator/validators/shippo.yaml` — New validator file

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./pkg/validator/` passes
- [x] End-to-end: `titus scan --validate --rules-include shippo` correctly validates test tokens as invalid (HTTP 401)