### PR TITLE
feat(validator): add TrueNAS API key detection rule and validator

### DIFF
--- a/pkg/rule/rules/truenas.yml
+++ b/pkg/rule/rules/truenas.yml
@@ -69,7 +69,7 @@ rules:
     (?xi)
     \b(?:truenas|true[_-]nas|tn[_-])
     (?:.|[\n\r]){0,64}?
-    (?:api[_-]?key|api[_-]?token|token|secret|password|auth)
+    (?:api[_-]?key|api[_-]?token|key|token|secret|password|auth)
     (?:.|[\n\r]){0,32}?
     (?P<token>
       \d+-[a-zA-Z0-9]{64}

--- a/pkg/validator/engine.go
+++ b/pkg/validator/engine.go
@@ -30,6 +30,7 @@ func NewDefaultEngine(workers int) *Engine {
 	validators = append(validators, NewWPEngineValidator())
 	validators = append(validators, NewRabbitMQValidator())
 	validators = append(validators, NewMattermostValidator())
+	validators = append(validators, NewTrueNASValidator())
 
 	// Embedded YAML validators
 	embedded, err := LoadEmbeddedValidators()

--- a/pkg/validator/truenas.go
+++ b/pkg/validator/truenas.go
@@ -1,0 +1,172 @@
+// pkg/validator/truenas.go
+package validator
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+)
+
+// Pre-compiled patterns for extracting TrueNAS instance URL from snippet context.
+var truenasURLPatterns = []*regexp.Regexp{
+	// Env var / config style: TRUENAS_URL=https://192.168.1.50
+	regexp.MustCompile(`(?i)(?:TRUENAS_URL|TRUENAS_HOST|TRUE_NAS_URL|TRUE_NAS_HOST|TN_URL|TN_HOST)\s*[=:]\s*["']?(https?://[a-zA-Z0-9._:/-]+?)["'\s]`),
+	// URL in curl commands or code containing truenas-related paths
+	regexp.MustCompile(`(https?://[a-zA-Z0-9._:-]+)/api/v2\.0`),
+	// WebSocket URL (ws:// or wss://) — common for TrueNAS WebSocket API
+	regexp.MustCompile(`wss?://([a-zA-Z0-9._:-]+)(?:/websocket)?`),
+	// URL with truenas in the hostname
+	regexp.MustCompile(`(https?://[a-zA-Z0-9._-]*(?:truenas|true-nas|tn)[a-zA-Z0-9._-]*(?::\d{2,5})?)`),
+	// Generic IP-based URL (common for NAS devices on local networks)
+	regexp.MustCompile(`(https?://\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(?::\d{2,5})?)`),
+}
+
+// TrueNASValidator validates TrueNAS API keys by calling the system info endpoint.
+// TrueNAS is self-hosted, so the validator searches snippet context for the instance URL.
+type TrueNASValidator struct {
+	client *http.Client
+}
+
+// NewTrueNASValidator creates a new TrueNAS API key validator.
+func NewTrueNASValidator() *TrueNASValidator {
+	return &TrueNASValidator{client: http.DefaultClient}
+}
+
+// NewTrueNASValidatorWithClient creates a validator with a custom HTTP client (for testing).
+func NewTrueNASValidatorWithClient(client *http.Client) *TrueNASValidator {
+	return &TrueNASValidator{client: client}
+}
+
+// Name returns the validator name.
+func (v *TrueNASValidator) Name() string {
+	return "truenas"
+}
+
+// CanValidate returns true for TrueNAS rule IDs.
+func (v *TrueNASValidator) CanValidate(ruleID string) bool {
+	switch ruleID {
+	case "np.truenas.1", "np.truenas.2", "np.truenas.3":
+		return true
+	}
+	return false
+}
+
+// Validate checks TrueNAS API key credentials against the system info endpoint.
+func (v *TrueNASValidator) Validate(ctx context.Context, match *types.Match) (*types.ValidationResult, error) {
+	// Extract token from named groups or capture groups
+	token := v.extractToken(match)
+	if token == "" {
+		return types.NewValidationResult(
+			types.StatusUndetermined,
+			0,
+			"token not found in match",
+		), nil
+	}
+
+	// Search snippet context for TrueNAS instance URL
+	baseURL := v.extractURL(match)
+	if baseURL == "" {
+		return types.NewValidationResult(
+			types.StatusUndetermined,
+			0,
+			"partial credentials: found API key but TrueNAS instance URL not in context",
+		), nil
+	}
+
+	// If extracted from a WebSocket URL (ws://host), the result is just the host.
+	// Prepend http:// so we can call the REST API.
+	if !strings.HasPrefix(baseURL, "http://") && !strings.HasPrefix(baseURL, "https://") {
+		baseURL = "http://" + baseURL
+	}
+
+	// Strip trailing slashes and any existing API path
+	baseURL = strings.TrimRight(baseURL, "/")
+	baseURL = strings.TrimSuffix(baseURL, "/api/v2.0")
+
+	// Call system/info endpoint (read-only, lightweight)
+	url := baseURL + "/api/v2.0/system/info"
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return types.NewValidationResult(
+			types.StatusUndetermined,
+			0,
+			fmt.Sprintf("failed to create request: %v", err),
+		), nil
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := v.client.Do(req)
+	if err != nil {
+		return types.NewValidationResult(
+			types.StatusUndetermined,
+			0,
+			fmt.Sprintf("request failed: %v", err),
+		), nil
+	}
+	defer func() { io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return types.NewValidationResult(
+			types.StatusValid,
+			1.0,
+			fmt.Sprintf("valid TrueNAS API key for %s", baseURL),
+		), nil
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return types.NewValidationResult(
+			types.StatusInvalid,
+			1.0,
+			fmt.Sprintf("credentials rejected by %s: HTTP %d", baseURL, resp.StatusCode),
+		), nil
+	default:
+		return types.NewValidationResult(
+			types.StatusUndetermined,
+			0.5,
+			fmt.Sprintf("unexpected status code from %s: HTTP %d", baseURL, resp.StatusCode),
+		), nil
+	}
+}
+
+// extractToken extracts the TrueNAS API key from the match.
+// Checks named groups first (np.truenas.3), then falls back to capture groups (np.truenas.1, np.truenas.2).
+func (v *TrueNASValidator) extractToken(match *types.Match) string {
+	// Try named groups first (np.truenas.3 uses (?P<token>...))
+	if match.NamedGroups != nil {
+		if tokenBytes, ok := match.NamedGroups["token"]; ok && len(tokenBytes) > 0 {
+			return string(tokenBytes)
+		}
+	}
+
+	// Fall back to positional capture groups (np.truenas.1 and np.truenas.2 use unnamed groups)
+	if len(match.Groups) > 0 && len(match.Groups[0]) > 0 {
+		return string(match.Groups[0])
+	}
+
+	return ""
+}
+
+// extractURL searches the snippet context for a TrueNAS instance URL.
+func (v *TrueNASValidator) extractURL(match *types.Match) string {
+	snippetParts := [][]byte{
+		match.Snippet.Before,
+		match.Snippet.Matching,
+		match.Snippet.After,
+	}
+
+	for _, pattern := range truenasURLPatterns {
+		for _, part := range snippetParts {
+			if matches := pattern.FindSubmatch(part); len(matches) >= 2 {
+				return string(matches[1])
+			}
+		}
+	}
+
+	return ""
+}

--- a/pkg/validator/truenas_test.go
+++ b/pkg/validator/truenas_test.go
@@ -1,0 +1,364 @@
+// pkg/validator/truenas_test.go
+package validator
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTrueNASValidator_Name(t *testing.T) {
+	v := NewTrueNASValidator()
+	assert.Equal(t, "truenas", v.Name())
+}
+
+func TestTrueNASValidator_CanValidate(t *testing.T) {
+	v := NewTrueNASValidator()
+	assert.True(t, v.CanValidate("np.truenas.1"))
+	assert.True(t, v.CanValidate("np.truenas.2"))
+	assert.True(t, v.CanValidate("np.truenas.3"))
+	assert.False(t, v.CanValidate("np.github.1"))
+	assert.False(t, v.CanValidate("np.shopify.1"))
+}
+
+func TestTrueNASValidator_ExtractToken_FromNamedGroups(t *testing.T) {
+	v := NewTrueNASValidator()
+
+	match := &types.Match{
+		RuleID: "np.truenas.3",
+		NamedGroups: map[string][]byte{
+			"token": []byte("8-Lp22ov7halMBLUpG97Wg4y7fibQi3CW19VJiZcCu746zgCs0mdDdTCoOcpgEucgu"),
+		},
+	}
+
+	token := v.extractToken(match)
+	assert.Equal(t, "8-Lp22ov7halMBLUpG97Wg4y7fibQi3CW19VJiZcCu746zgCs0mdDdTCoOcpgEucgu", token)
+}
+
+func TestTrueNASValidator_ExtractToken_FromGroups(t *testing.T) {
+	v := NewTrueNASValidator()
+
+	match := &types.Match{
+		RuleID: "np.truenas.1",
+		Groups: [][]byte{
+			[]byte("8-Lp22ov7halMBLUpG97Wg4y7fibQi3CW19VJiZcCu746zgCs0mdDdTCoOcpgEucgu"),
+		},
+	}
+
+	token := v.extractToken(match)
+	assert.Equal(t, "8-Lp22ov7halMBLUpG97Wg4y7fibQi3CW19VJiZcCu746zgCs0mdDdTCoOcpgEucgu", token)
+}
+
+func TestTrueNASValidator_ExtractToken_Missing(t *testing.T) {
+	v := NewTrueNASValidator()
+
+	match := &types.Match{
+		RuleID:      "np.truenas.3",
+		NamedGroups: map[string][]byte{},
+	}
+
+	token := v.extractToken(match)
+	assert.Empty(t, token)
+}
+
+func TestTrueNASValidator_ExtractURL_FromEnvVar(t *testing.T) {
+	v := NewTrueNASValidator()
+
+	match := &types.Match{
+		RuleID: "np.truenas.3",
+		Snippet: types.Snippet{
+			Before:   []byte("TRUENAS_URL=https://192.168.1.50"),
+			Matching: []byte("TRUENAS_API_KEY=8-Lp22ov7halMBLUpG97Wg4y7fibQi3CW19VJiZcCu746zgCs0mdDdTCoOcpgEucgu"),
+			After:    []byte(""),
+		},
+	}
+
+	url := v.extractURL(match)
+	assert.Equal(t, "https://192.168.1.50", url)
+}
+
+func TestTrueNASValidator_ExtractURL_FromHostEnvVar(t *testing.T) {
+	v := NewTrueNASValidator()
+
+	match := &types.Match{
+		RuleID: "np.truenas.3",
+		Snippet: types.Snippet{
+			Before:   []byte("TN_HOST=http://truenas.local:8080 "),
+			Matching: []byte("TN_API_KEY=8-Lp22ov7halMBLUpG97Wg4y7fibQi3CW19VJiZcCu746zgCs0mdDdTCoOcpgEucgu"),
+			After:    []byte(""),
+		},
+	}
+
+	url := v.extractURL(match)
+	assert.Equal(t, "http://truenas.local:8080", url)
+}
+
+func TestTrueNASValidator_ExtractURL_FromAPIPath(t *testing.T) {
+	v := NewTrueNASValidator()
+
+	match := &types.Match{
+		RuleID: "np.truenas.2",
+		Snippet: types.Snippet{
+			Before:   []byte(""),
+			Matching: []byte(`curl -X GET "https://10.0.0.5/api/v2.0/system/info" -H "Authorization: Bearer 8-Lp22ov7halMBLUpG97Wg4y7fibQi3CW19VJiZcCu746zgCs0mdDdTCoOcpgEucgu"`),
+			After:    []byte(""),
+		},
+	}
+
+	url := v.extractURL(match)
+	assert.Equal(t, "https://10.0.0.5", url)
+}
+
+func TestTrueNASValidator_ExtractURL_FromTrueNASHostname(t *testing.T) {
+	v := NewTrueNASValidator()
+
+	match := &types.Match{
+		RuleID: "np.truenas.3",
+		Snippet: types.Snippet{
+			Before:   []byte(""),
+			Matching: []byte("truenas_token=8-Lp22ov7halMBLUpG97Wg4y7fibQi3CW19VJiZcCu746zgCs0mdDdTCoOcpgEucgu"),
+			After:    []byte("server = https://my-truenas.local"),
+		},
+	}
+
+	url := v.extractURL(match)
+	assert.Equal(t, "https://my-truenas.local", url)
+}
+
+func TestTrueNASValidator_ExtractURL_FromIPAddress(t *testing.T) {
+	v := NewTrueNASValidator()
+
+	match := &types.Match{
+		RuleID: "np.truenas.3",
+		Snippet: types.Snippet{
+			Before:   []byte("# NAS at http://192.168.0.30"),
+			Matching: []byte("TRUENAS_API_KEY=8-Lp22ov7halMBLUpG97Wg4y7fibQi3CW19VJiZcCu746zgCs0mdDdTCoOcpgEucgu"),
+			After:    []byte(""),
+		},
+	}
+
+	url := v.extractURL(match)
+	assert.Equal(t, "http://192.168.0.30", url)
+}
+
+func TestTrueNASValidator_ExtractURL_NotFound(t *testing.T) {
+	v := NewTrueNASValidator()
+
+	match := &types.Match{
+		RuleID: "np.truenas.3",
+		Snippet: types.Snippet{
+			Before:   []byte("# no URL here"),
+			Matching: []byte("TRUENAS_API_KEY=8-Lp22ov7halMBLUpG97Wg4y7fibQi3CW19VJiZcCu746zgCs0mdDdTCoOcpgEucgu"),
+			After:    []byte("# nothing here either"),
+		},
+	}
+
+	url := v.extractURL(match)
+	assert.Empty(t, url)
+}
+
+func TestTrueNASValidator_Validate_NoToken(t *testing.T) {
+	v := NewTrueNASValidator()
+
+	match := &types.Match{
+		RuleID:      "np.truenas.3",
+		NamedGroups: map[string][]byte{},
+		Snippet: types.Snippet{
+			Before:   []byte("TRUENAS_URL=https://192.168.1.50"),
+			Matching: []byte(""),
+			After:    []byte(""),
+		},
+	}
+
+	result, err := v.Validate(context.Background(), match)
+	assert.NoError(t, err)
+	assert.Equal(t, types.StatusUndetermined, result.Status)
+	assert.Contains(t, result.Message, "token")
+}
+
+func TestTrueNASValidator_Validate_NoURL(t *testing.T) {
+	v := NewTrueNASValidator()
+
+	match := &types.Match{
+		RuleID: "np.truenas.3",
+		NamedGroups: map[string][]byte{
+			"token": []byte("8-Lp22ov7halMBLUpG97Wg4y7fibQi3CW19VJiZcCu746zgCs0mdDdTCoOcpgEucgu"),
+		},
+		Snippet: types.Snippet{
+			Before:   []byte("# no URL"),
+			Matching: []byte("TRUENAS_API_KEY=8-Lp22ov7halMBLUpG97Wg4y7fibQi3CW19VJiZcCu746zgCs0mdDdTCoOcpgEucgu"),
+			After:    []byte(""),
+		},
+	}
+
+	result, err := v.Validate(context.Background(), match)
+	assert.NoError(t, err)
+	assert.Equal(t, types.StatusUndetermined, result.Status)
+	assert.Contains(t, result.Message, "URL not in context")
+}
+
+// truenasMockTransport redirects requests to the mock server.
+type truenasMockTransport struct {
+	server *httptest.Server
+}
+
+func (t *truenasMockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = "http"
+	req.URL.Host = t.server.Listener.Addr().String()
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+func TestTrueNASValidator_Validate_ValidToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.Path, "/api/v2.0/system/info")
+		assert.Contains(t, r.Header.Get("Authorization"), "Bearer ")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"version":"TrueNAS-SCALE-24.04"}`))
+	}))
+	defer server.Close()
+
+	v := NewTrueNASValidatorWithClient(&http.Client{
+		Transport: &truenasMockTransport{server: server},
+	})
+
+	match := &types.Match{
+		RuleID: "np.truenas.3",
+		NamedGroups: map[string][]byte{
+			"token": []byte("8-Lp22ov7halMBLUpG97Wg4y7fibQi3CW19VJiZcCu746zgCs0mdDdTCoOcpgEucgu"),
+		},
+		Snippet: types.Snippet{
+			Before:   []byte("TRUENAS_URL=https://192.168.1.50"),
+			Matching: []byte("TRUENAS_API_KEY=8-Lp22ov7halMBLUpG97Wg4y7fibQi3CW19VJiZcCu746zgCs0mdDdTCoOcpgEucgu"),
+			After:    []byte(""),
+		},
+	}
+
+	result, err := v.Validate(context.Background(), match)
+	assert.NoError(t, err)
+	assert.Equal(t, types.StatusValid, result.Status)
+	assert.Contains(t, result.Message, "192.168.1.50")
+}
+
+func TestTrueNASValidator_Validate_InvalidToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	v := NewTrueNASValidatorWithClient(&http.Client{
+		Transport: &truenasMockTransport{server: server},
+	})
+
+	match := &types.Match{
+		RuleID: "np.truenas.3",
+		NamedGroups: map[string][]byte{
+			"token": []byte("8-invalidkey00000000000000000000000000000000000000000000000000000"),
+		},
+		Snippet: types.Snippet{
+			Before:   []byte("TRUENAS_URL=https://192.168.1.50"),
+			Matching: []byte("TRUENAS_API_KEY=8-invalidkey00000000000000000000000000000000000000000000000000000"),
+			After:    []byte(""),
+		},
+	}
+
+	result, err := v.Validate(context.Background(), match)
+	assert.NoError(t, err)
+	assert.Equal(t, types.StatusInvalid, result.Status)
+}
+
+func TestTrueNASValidator_Validate_ForbiddenToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	v := NewTrueNASValidatorWithClient(&http.Client{
+		Transport: &truenasMockTransport{server: server},
+	})
+
+	match := &types.Match{
+		RuleID: "np.truenas.2",
+		Groups: [][]byte{
+			[]byte("8-Lp22ov7halMBLUpG97Wg4y7fibQi3CW19VJiZcCu746zgCs0mdDdTCoOcpgEucgu"),
+		},
+		Snippet: types.Snippet{
+			Before:   []byte(""),
+			Matching: []byte(`curl https://10.0.0.5/api/v2.0/system/info -H "Authorization: Bearer 8-Lp22ov7halMBLUpG97Wg4y7fibQi3CW19VJiZcCu746zgCs0mdDdTCoOcpgEucgu"`),
+			After:    []byte(""),
+		},
+	}
+
+	result, err := v.Validate(context.Background(), match)
+	assert.NoError(t, err)
+	assert.Equal(t, types.StatusInvalid, result.Status)
+}
+
+func TestTrueNASValidator_Validate_UnexpectedStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	v := NewTrueNASValidatorWithClient(&http.Client{
+		Transport: &truenasMockTransport{server: server},
+	})
+
+	match := &types.Match{
+		RuleID: "np.truenas.3",
+		NamedGroups: map[string][]byte{
+			"token": []byte("8-Lp22ov7halMBLUpG97Wg4y7fibQi3CW19VJiZcCu746zgCs0mdDdTCoOcpgEucgu"),
+		},
+		Snippet: types.Snippet{
+			Before:   []byte("TRUENAS_URL=https://192.168.1.50"),
+			Matching: []byte("TRUENAS_API_KEY=8-Lp22ov7halMBLUpG97Wg4y7fibQi3CW19VJiZcCu746zgCs0mdDdTCoOcpgEucgu"),
+			After:    []byte(""),
+		},
+	}
+
+	result, err := v.Validate(context.Background(), match)
+	assert.NoError(t, err)
+	assert.Equal(t, types.StatusUndetermined, result.Status)
+}
+
+func TestTrueNASValidator_Validate_PartialCredentials_Rule1(t *testing.T) {
+	v := NewTrueNASValidator()
+
+	// WebSocket match with token but no URL in context
+	match := &types.Match{
+		RuleID: "np.truenas.1",
+		Groups: [][]byte{
+			[]byte("8-Lp22ov7halMBLUpG97Wg4y7fibQi3CW19VJiZcCu746zgCs0mdDdTCoOcpgEucgu"),
+		},
+		Snippet: types.Snippet{
+			Before:   []byte(""),
+			Matching: []byte(`{"params":["8-Lp22ov7halMBLUpG97Wg4y7fibQi3CW19VJiZcCu746zgCs0mdDdTCoOcpgEucgu"]}`),
+			After:    []byte(""),
+		},
+	}
+
+	result, err := v.Validate(context.Background(), match)
+	assert.NoError(t, err)
+	assert.Equal(t, types.StatusUndetermined, result.Status)
+	assert.Contains(t, result.Message, "URL not in context")
+}
+
+func TestTrueNASValidator_ExtractURL_StripAPIPath(t *testing.T) {
+	v := NewTrueNASValidator()
+
+	// Verify that /api/v2.0 is stripped from the extracted URL before building the request
+	match := &types.Match{
+		RuleID: "np.truenas.2",
+		Snippet: types.Snippet{
+			Before:   []byte(""),
+			Matching: []byte(`curl "https://nas.example.com/api/v2.0/device/get_info"`),
+			After:    []byte(""),
+		},
+	}
+
+	url := v.extractURL(match)
+	assert.Equal(t, "https://nas.example.com", url)
+}


### PR DESCRIPTION
## Summary

- Add `np.truenas.3` keyword-proximity detection rule that finds TrueNAS API keys in `.env` files, config files, and source code (complements existing WebSocket and Bearer rules)
- Add Go validator for all 3 TrueNAS rules (`np.truenas.1`, `np.truenas.2`, `np.truenas.3`) that extracts the instance URL from snippet context and validates keys against `/api/v2.0/system/info`
- URL extraction supports env vars (`TRUENAS_URL=`), API paths, WebSocket URLs (`ws://`/`wss://`), truenas hostnames, and IP addresses
- Returns `undetermined` when no instance URL is found nearby (TrueNAS is self-hosted)

## Test plan

- [x] 19 unit tests covering token extraction, URL extraction from various formats, and all validation outcomes (valid, invalid, forbidden, undetermined, partial)
- [x] Full test suite passes (`go test ./...` — 14 packages)
- [x] End-to-end validation tested with real TrueNAS instance via `titus scan --validate`
- [x] Verified validation requests through HTTP proxy (Burp Suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)