### PR TITLE
feat(enum): remove --include-hidden flag, always scan hidden files

### DIFF
--- a/cmd/titus/scan.go
+++ b/cmd/titus/scan.go
@@ -47,7 +47,6 @@ var (
 	scanOutputFormat        string
 	scanGit                 bool
 	scanMaxFileSize         int64
-	scanIncludeHidden       bool
 	scanContextLines        int
 	scanIncremental         bool
 	scanValidate            bool
@@ -77,7 +76,6 @@ func init() {
 	scanCmd.Flags().StringVar(&scanOutputFormat, "format", "human", "Output format: json, sarif, human")
 	scanCmd.Flags().BoolVar(&scanGit, "git", false, "Treat target as git repository (enumerate git history)")
 	scanCmd.Flags().Int64Var(&scanMaxFileSize, "max-file-size", 10*1024*1024, "Maximum file size to scan (bytes)")
-	scanCmd.Flags().BoolVar(&scanIncludeHidden, "include-hidden", false, "Include hidden files and directories")
 	scanCmd.Flags().IntVar(&scanContextLines, "context-lines", 3, "Lines of context before/after matches (0 to disable)")
 	scanCmd.Flags().BoolVar(&scanIncremental, "incremental", false, "Skip already-scanned blobs")
 	scanCmd.Flags().BoolVar(&scanValidate, "validate", false, "validate detected secrets against their source APIs")
@@ -486,7 +484,6 @@ func createEnumerator(target string, useGit bool) (enum.Enumerator, error) {
 
 	config := enum.Config{
 		Root:            target,
-		IncludeHidden:   scanIncludeHidden,
 		MaxFileSize:     scanMaxFileSize,
 		FollowSymlinks:  false,
 		ExtractArchives: string(scanExtractArchivesFlag),

--- a/pkg/enum/enum.go
+++ b/pkg/enum/enum.go
@@ -36,9 +36,6 @@ type Config struct {
 	// Root is the starting path for enumeration.
 	Root string
 
-	// IncludeHidden includes hidden files/directories (starting with .).
-	IncludeHidden bool
-
 	// MaxFileSize is the maximum file size to process (0 = no limit).
 	MaxFileSize int64
 

--- a/pkg/enum/filesystem.go
+++ b/pkg/enum/filesystem.go
@@ -56,17 +56,10 @@ func (e *FilesystemEnumerator) Enumerate(ctx context.Context, callback func(cont
 		}
 
 		if info.IsDir() {
-			if !e.config.IncludeHidden && isHidden(info.Name()) {
-				return filepath.SkipDir
-			}
 			return nil
 		}
 
 		if info.Mode()&os.ModeSymlink != 0 && !e.config.FollowSymlinks {
-			return nil
-		}
-
-		if !e.config.IncludeHidden && isHidden(info.Name()) {
 			return nil
 		}
 
@@ -201,15 +194,6 @@ func shouldExtract(config Config, ext string) bool {
 		}
 	}
 	return false
-}
-
-// isHidden checks if a filename is hidden (starts with .).
-// The special entries "." and ".." are NOT considered hidden.
-func isHidden(name string) bool {
-	if name == "." || name == ".." {
-		return false
-	}
-	return strings.HasPrefix(name, ".")
 }
 
 // isBinary detects if content is binary by checking first 8KB for null bytes.

--- a/pkg/enum/filesystem_test.go
+++ b/pkg/enum/filesystem_test.go
@@ -38,9 +38,8 @@ func TestFilesystemEnumerator(t *testing.T) {
 
 	// Enumerate and collect results
 	config := Config{
-		Root:          tmpDir,
-		IncludeHidden: false,
-		MaxFileSize:   0,
+		Root:        tmpDir,
+		MaxFileSize: 0,
 	}
 	enumerator := NewFilesystemEnumerator(config)
 
@@ -69,69 +68,6 @@ func TestFilesystemEnumerator(t *testing.T) {
 	// Should find 3 files
 	if len(foundFiles) != 3 {
 		t.Errorf("expected 3 files, got %d: %v", len(foundFiles), foundFiles)
-	}
-}
-
-func TestFilesystemEnumerator_HiddenFiles(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	// Create visible and hidden files
-	visibleFile := filepath.Join(tmpDir, "visible.txt")
-	if err := os.WriteFile(visibleFile, []byte("visible"), 0644); err != nil {
-		t.Fatalf("failed to create file: %v", err)
-	}
-
-	hiddenFile := filepath.Join(tmpDir, ".hidden.txt")
-	if err := os.WriteFile(hiddenFile, []byte("hidden"), 0644); err != nil {
-		t.Fatalf("failed to create file: %v", err)
-	}
-
-	// Test without including hidden files
-	config := Config{
-		Root:          tmpDir,
-		IncludeHidden: false,
-	}
-	enumerator := NewFilesystemEnumerator(config)
-
-	var mu sync.Mutex
-	var foundFiles []string
-	err := enumerator.Enumerate(context.Background(), func(content []byte, blobID types.BlobID, prov types.Provenance) error {
-		mu.Lock()
-		defer mu.Unlock()
-		foundFiles = append(foundFiles, filepath.Base(prov.Path()))
-		return nil
-	})
-
-	if err != nil {
-		t.Fatalf("enumerate failed: %v", err)
-	}
-
-	if len(foundFiles) != 1 {
-		t.Errorf("expected 1 file, got %d", len(foundFiles))
-	}
-	if len(foundFiles) > 0 && foundFiles[0] != "visible.txt" {
-		t.Errorf("expected visible.txt, got %s", foundFiles[0])
-	}
-
-	// Test with including hidden files
-	config.IncludeHidden = true
-	enumerator = NewFilesystemEnumerator(config)
-
-	var mu2 sync.Mutex
-	foundFiles = nil
-	err = enumerator.Enumerate(context.Background(), func(content []byte, blobID types.BlobID, prov types.Provenance) error {
-		mu2.Lock()
-		defer mu2.Unlock()
-		foundFiles = append(foundFiles, filepath.Base(prov.Path()))
-		return nil
-	})
-
-	if err != nil {
-		t.Fatalf("enumerate failed: %v", err)
-	}
-
-	if len(foundFiles) != 2 {
-		t.Errorf("expected 2 files, got %d", len(foundFiles))
 	}
 }
 
@@ -250,8 +186,7 @@ func TestFilesystemEnumerator_Gitignore(t *testing.T) {
 
 	// Enumerate
 	config := Config{
-		Root:          tmpDir,
-		IncludeHidden: true, // Include .gitignore itself
+		Root: tmpDir,
 	}
 	enumerator := NewFilesystemEnumerator(config)
 
@@ -294,7 +229,6 @@ func TestFilesystemEnumerator_Gitignore(t *testing.T) {
 
 func TestFilesystemEnumerator_CurrentDirectory(t *testing.T) {
 	// Regression test: scanning "." should not skip the entire directory
-	// because "." starts with a dot (isHidden should not treat it as hidden)
 	tmpDir := t.TempDir()
 
 	// Create a test file
@@ -316,8 +250,7 @@ func TestFilesystemEnumerator_CurrentDirectory(t *testing.T) {
 
 	// Enumerate using "." as root (this was the bug: it would skip everything)
 	config := Config{
-		Root:          ".",
-		IncludeHidden: false, // The bug manifests when hidden files are NOT included
+		Root: ".",
 	}
 	enumerator := NewFilesystemEnumerator(config)
 
@@ -340,30 +273,6 @@ func TestFilesystemEnumerator_CurrentDirectory(t *testing.T) {
 	}
 	if len(foundFiles) > 0 && foundFiles[0] != "secret.txt" {
 		t.Errorf("expected secret.txt, got %s", foundFiles[0])
-	}
-}
-
-func TestIsHidden(t *testing.T) {
-	tests := []struct {
-		name     string
-		filename string
-		want     bool
-	}{
-		{"current dir", ".", false},
-		{"parent dir", "..", false},
-		{"hidden file", ".hidden", true},
-		{"hidden directory", ".git", true},
-		{"normal file", "file.txt", false},
-		{"normal directory", "src", false},
-		{"dotfile", ".gitignore", true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := isHidden(tt.filename); got != tt.want {
-				t.Errorf("isHidden(%q) = %v, want %v", tt.filename, got, tt.want)
-			}
-		})
 	}
 }
 


### PR DESCRIPTION
Hidden files and directories are now always enumerated during filesystem scans, matching the behavior of the git enumerator.