### PR TITLE
fix(explore): sanitize binary content in snippet display

### DIFF
--- a/pkg/explore/details.go
+++ b/pkg/explore/details.go
@@ -101,7 +101,7 @@ func (dp detailsPane) View() string {
 		for i, g := range f.Groups {
 			lines = append(lines, fmt.Sprintf("  %s %s",
 				fieldLabelStyle.Render(fmt.Sprintf("Group %d:", i+1)),
-				snippetMatchStyle.Render(string(g))))
+				snippetMatchStyle.Render(sanitizeForDisplay(g))))
 		}
 
 		if f.AnnotationStatus != "" {
@@ -241,7 +241,7 @@ func renderMatchDetails(m *matchRow, maxWidth int) []string {
 		for name, val := range m.NamedGroups {
 			lines = append(lines, fmt.Sprintf("    %s: %s",
 				fieldLabelStyle.Render(name),
-				snippetMatchStyle.Render(truncateString(string(val), 60))))
+				snippetMatchStyle.Render(truncateString(sanitizeForDisplay(val), 60))))
 		}
 	}
 
@@ -262,9 +262,9 @@ func renderMatchDetails(m *matchRow, maxWidth int) []string {
 	lines = append(lines, fmt.Sprintf("  %s", fieldLabelStyle.Render("Snippet:")))
 
 	snippetWidth := maxWidth - 6
-	before := strings.TrimRight(string(m.Snippet.Before), "\n\r")
-	matching := string(m.Snippet.Matching)
-	after := strings.TrimLeft(string(m.Snippet.After), "\n\r")
+	before := strings.TrimRight(sanitizeForDisplay(m.Snippet.Before), "\n\r")
+	matching := sanitizeForDisplay(m.Snippet.Matching)
+	after := strings.TrimLeft(sanitizeForDisplay(m.Snippet.After), "\n\r")
 
 	// Render snippet lines
 	for _, line := range strings.Split(before, "\n") {

--- a/pkg/explore/filters.go
+++ b/pkg/explore/filters.go
@@ -263,6 +263,29 @@ func padRight(s string, width int) string {
 	return s + strings.Repeat(" ", width-visLen)
 }
 
+// sanitizeForDisplay replaces non-printable characters with a dot,
+// preserving only newlines (for line splitting) and printable ASCII
+// (0x20-0x7E). Tabs and carriage returns are replaced because tabs
+// expand to variable-width columns (breaking truncation) and carriage
+// returns reset the cursor position (overwriting content). A
+// single-byte replacement is used intentionally so that byte-based
+// operations like truncateString remain safe.
+func sanitizeForDisplay(b []byte) string {
+	var sb strings.Builder
+	sb.Grow(len(b))
+	for _, c := range b {
+		switch {
+		case c == '\n':
+			sb.WriteByte(c)
+		case c >= 0x20 && c <= 0x7E:
+			sb.WriteByte(c)
+		default:
+			sb.WriteByte('.')
+		}
+	}
+	return sb.String()
+}
+
 // stripAnsi removes ANSI escape sequences for re-styling.
 func stripAnsi(s string) string {
 	var result strings.Builder

--- a/pkg/explore/filters_test.go
+++ b/pkg/explore/filters_test.go
@@ -1,0 +1,61 @@
+package explore
+
+import "testing"
+
+func TestSanitizeForDisplay(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []byte
+		want  string
+	}{
+		{
+			name:  "printable ascii",
+			input: []byte("hello world"),
+			want:  "hello world",
+		},
+		{
+			name:  "preserves newlines but replaces tabs and carriage returns",
+			input: []byte("line1\n\tline2\r\n"),
+			want:  "line1\n.line2.\n",
+		},
+		{
+			name:  "replaces null bytes",
+			input: []byte("abc\x00def"),
+			want:  "abc.def",
+		},
+		{
+			name:  "replaces control characters",
+			input: []byte("\x01\x02\x03\x1b\x7f"),
+			want:  ".....",
+		},
+		{
+			name:  "replaces high bytes",
+			input: []byte{0x80, 0xFF, 0xFE},
+			want:  "...",
+		},
+		{
+			name:  "mixed binary and text",
+			input: []byte("password=\x00s3cret\x01\x02"),
+			want:  "password=.s3cret..",
+		},
+		{
+			name:  "empty input",
+			input: []byte{},
+			want:  "",
+		},
+		{
+			name:  "nil input",
+			input: nil,
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeForDisplay(tt.input)
+			if got != tt.want {
+				t.Errorf("sanitizeForDisplay(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/explore/findings.go
+++ b/pkg/explore/findings.go
@@ -266,7 +266,7 @@ func formatGroups(groups [][]byte) string {
 	}
 	parts := make([]string, len(groups))
 	for i, g := range groups {
-		parts[i] = string(g)
+		parts[i] = sanitizeForDisplay(g)
 	}
 	return strings.Join(parts, ", ")
 }

--- a/pkg/explore/model.go
+++ b/pkg/explore/model.go
@@ -585,11 +585,11 @@ func (m *Model) openSource() tea.Cmd {
 	// Fallback: show snippet in overlay
 	var sb strings.Builder
 	if len(match.Snippet.Before) > 0 {
-		sb.Write(match.Snippet.Before)
+		sb.WriteString(sanitizeForDisplay(match.Snippet.Before))
 	}
-	sb.Write(match.Snippet.Matching)
+	sb.WriteString(sanitizeForDisplay(match.Snippet.Matching))
 	if len(match.Snippet.After) > 0 {
-		sb.Write(match.Snippet.After)
+		sb.WriteString(sanitizeForDisplay(match.Snippet.After))
 	}
 
 	m.sourceContent = sb.String()


### PR DESCRIPTION
## Summary
- Secrets found in binary files printed non-printable characters to the terminal, corrupting the explore TUI layout
- Added `sanitizeForDisplay()` that replaces non-printable bytes with `.` at all display sites (snippets, capture groups, named groups, source overlay)
- Only `\n` is preserved (for line splitting); `\t` and `\r` are replaced since tabs break width calculations and carriage returns overwrite pane borders
- Uses single-byte ASCII replacement to stay compatible with byte-based `truncateString`