### PR TITLE
fix(validator): Google Maps API key validation false negatives

### DIFF
--- a/pkg/validator/validators/google-maps.yaml
+++ b/pkg/validator/validators/google-maps.yaml
@@ -1,0 +1,19 @@
+# pkg/validator/validators/google-maps.yaml
+# Google Maps API keys validated against the Geocoding API
+# The generic google.yaml validator uses the YouTube Data API, which returns
+# 403 for keys restricted to Maps Platform APIs — causing false negatives.
+# This validator targets Maps-restricted keys specifically.
+validators:
+  - name: google-maps-api-key
+    rule_ids:
+      - np.google.8
+    http:
+      method: GET
+      url: https://maps.googleapis.com/maps/api/geocode/json?address=1
+      auth:
+        type: query
+        secret_group: "key"
+        query_param: "key"
+      success_codes: [200]
+      failure_codes: [400, 403]
+      failure_body_contains: "REQUEST_DENIED"

--- a/pkg/validator/validators/google.yaml
+++ b/pkg/validator/validators/google.yaml
@@ -9,7 +9,6 @@ validators:
     rule_ids:
       - np.youtube.1
       - np.google.5
-      - np.google.8
     http:
       method: GET
       url: https://www.googleapis.com/youtube/v3/videos?part=id&id=dQw4w9WgXcQ


### PR DESCRIPTION
## Summary
- Split `np.google.8` (Google Maps API Key) out of the YouTube-based `google.yaml` validator into a dedicated `google-maps.yaml`
- New validator hits the **Geocoding API** (`maps.googleapis.com/maps/api/geocode/json`) instead of the YouTube Data API
- Added `failure_body_contains: "REQUEST_DENIED"` to handle the Geocoding API returning HTTP 200 with error in the JSON body

## Problem
Maps-restricted API keys were incorrectly reported as **Invalid** because the YouTube endpoint returns 403 for keys that don't have YouTube API access — even though the key is active and valid for Maps Platform APIs.

## Verification
Tested with `titus serve` against real keys:
| Key | Old (YouTube) | New (Geocoding) |
|-----|--------------|-----------------|
| Valid Maps key | ❌ Invalid (403) | ✅ Valid (200) |
| Fake key | ✅ Invalid (403) | ✅ Invalid (REQUEST_DENIED in body) |

## Files changed
- `pkg/validator/validators/google.yaml` — removed `np.google.8` from YouTube validator
- `pkg/validator/validators/google-maps.yaml` — new Maps-specific validator

🤖 Generated with [Claude Code](https://claude.com/claude-code)