### PR TITLE
fix: populate RuleName in JSON and SARIF scan output

### DIFF
--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -116,7 +116,7 @@ func (s *SQLiteStore) AddMatch(m *types.Match) error {
 }
 
 func (s *SQLiteStore) GetMatches(blobID types.BlobID) ([]*types.Match, error) {
-	rows, err := s.e.Query(`SELECT blob_id, rule_id, structural_id, offset_start, offset_end, snippet_before, snippet_matching, snippet_after, groups_json, validation_status, validation_confidence, validation_message, validation_timestamp, finding_id, start_line, start_column, end_line, end_column FROM matches WHERE blob_id = ?`, blobID.Hex())
+	rows, err := s.e.Query(`SELECT m.blob_id, m.rule_id, r.name, m.structural_id, m.offset_start, m.offset_end, m.snippet_before, m.snippet_matching, m.snippet_after, m.groups_json, m.validation_status, m.validation_confidence, m.validation_message, m.validation_timestamp, m.finding_id, m.start_line, m.start_column, m.end_line, m.end_column FROM matches m JOIN rules r ON m.rule_id = r.id WHERE m.blob_id = ?`, blobID.Hex())
 	if err != nil {
 		return nil, err
 	}
@@ -125,7 +125,7 @@ func (s *SQLiteStore) GetMatches(blobID types.BlobID) ([]*types.Match, error) {
 }
 
 func (s *SQLiteStore) GetAllMatches() ([]*types.Match, error) {
-	rows, err := s.e.Query(`SELECT blob_id, rule_id, structural_id, offset_start, offset_end, snippet_before, snippet_matching, snippet_after, groups_json, validation_status, validation_confidence, validation_message, validation_timestamp, finding_id, start_line, start_column, end_line, end_column FROM matches`)
+	rows, err := s.e.Query(`SELECT m.blob_id, m.rule_id, r.name, m.structural_id, m.offset_start, m.offset_end, m.snippet_before, m.snippet_matching, m.snippet_after, m.groups_json, m.validation_status, m.validation_confidence, m.validation_message, m.validation_timestamp, m.finding_id, m.start_line, m.start_column, m.end_line, m.end_column FROM matches m JOIN rules r ON m.rule_id = r.id`)
 	if err != nil {
 		return nil, err
 	}
@@ -303,7 +303,7 @@ func scanMatches(rows *sql.Rows) ([]*types.Match, error) {
 		var validationStatus, validationMessage, validationTimestamp sql.NullString
 		var validationConfidence sql.NullFloat64
 		var findingID, startLine, startColumn, endLine, endColumn sql.NullInt64
-		err := rows.Scan(&blobIDHex, &m.RuleID, &m.StructuralID, &m.Location.Offset.Start, &m.Location.Offset.End,
+		err := rows.Scan(&blobIDHex, &m.RuleID, &m.RuleName, &m.StructuralID, &m.Location.Offset.Start, &m.Location.Offset.End,
 			&snippetBefore, &snippetMatching, &snippetAfter, &groupsJSON,
 			&validationStatus, &validationConfidence, &validationMessage, &validationTimestamp,
 			&findingID, &startLine, &startColumn, &endLine, &endColumn)

--- a/pkg/store/sqlite_test.go
+++ b/pkg/store/sqlite_test.go
@@ -141,6 +141,117 @@ func TestSQLite_GetAllMatchesWithLocation(t *testing.T) {
 	}
 }
 
+func TestSQLite_GetMatchesRuleName(t *testing.T) {
+	// Arrange
+	tempDir := t.TempDir()
+	dbPath := filepath.Join(tempDir, "test.db")
+
+	store, err := NewSQLite(dbPath)
+	require.NoError(t, err)
+	defer store.Close()
+
+	blobID := types.ComputeBlobID([]byte("test content"))
+	err = store.AddBlob(blobID, 12)
+	require.NoError(t, err)
+
+	rule := &types.Rule{
+		ID:           "np.test.1",
+		Name:         "Test Rule",
+		Pattern:      "test",
+		StructuralID: "struct123",
+	}
+	err = store.AddRule(rule)
+	require.NoError(t, err)
+
+	// Create match without RuleName — the store should populate it
+	match := &types.Match{
+		BlobID:       blobID,
+		StructuralID: "match123",
+		RuleID:       "np.test.1",
+		Location:     types.Location{Offset: types.OffsetSpan{Start: 0, End: 10}},
+		Snippet:      types.Snippet{Matching: []byte("test")},
+	}
+
+	err = store.AddMatch(match)
+	require.NoError(t, err)
+
+	// Act
+	matches, err := store.GetMatches(blobID)
+
+	// Assert
+	require.NoError(t, err)
+	require.Len(t, matches, 1)
+	assert.Equal(t, "Test Rule", matches[0].RuleName)
+}
+
+func TestSQLite_GetAllMatchesRuleName(t *testing.T) {
+	// Arrange
+	tempDir := t.TempDir()
+	dbPath := filepath.Join(tempDir, "test.db")
+
+	store, err := NewSQLite(dbPath)
+	require.NoError(t, err)
+	defer store.Close()
+
+	blobID1 := types.ComputeBlobID([]byte("content1"))
+	blobID2 := types.ComputeBlobID([]byte("content2"))
+
+	err = store.AddBlob(blobID1, 8)
+	require.NoError(t, err)
+	err = store.AddBlob(blobID2, 8)
+	require.NoError(t, err)
+
+	rule1 := &types.Rule{
+		ID:           "np.test.1",
+		Name:         "Test Rule 1",
+		Pattern:      "test1",
+		StructuralID: "struct123",
+	}
+	rule2 := &types.Rule{
+		ID:           "np.test.2",
+		Name:         "Test Rule 2",
+		Pattern:      "test2",
+		StructuralID: "struct456",
+	}
+	err = store.AddRule(rule1)
+	require.NoError(t, err)
+	err = store.AddRule(rule2)
+	require.NoError(t, err)
+
+	// Create matches without RuleName — the store should populate it
+	match1 := &types.Match{
+		BlobID:       blobID1,
+		StructuralID: "match1",
+		RuleID:       "np.test.1",
+		Location:     types.Location{Offset: types.OffsetSpan{Start: 0, End: 5}},
+	}
+	match2 := &types.Match{
+		BlobID:       blobID2,
+		StructuralID: "match2",
+		RuleID:       "np.test.2",
+		Location:     types.Location{Offset: types.OffsetSpan{Start: 0, End: 5}},
+	}
+
+	err = store.AddMatch(match1)
+	require.NoError(t, err)
+	err = store.AddMatch(match2)
+	require.NoError(t, err)
+
+	// Act
+	allMatches, err := store.GetAllMatches()
+
+	// Assert
+	require.NoError(t, err)
+	require.Len(t, allMatches, 2)
+
+	ruleNames := make(map[string]string)
+	for _, m := range allMatches {
+		ruleNames[m.RuleID] = m.RuleName
+	}
+	assert.Equal(t, "Test Rule 1", ruleNames["np.test.1"])
+	assert.Equal(t, "Test Rule 2", ruleNames["np.test.2"])
+}
+
 func TestSQLite_NullLocationValues(t *testing.T) {
 	// Test that matches without location data (finding_id and line/column nulls) work correctly
 	// This ensures backward compatibility


### PR DESCRIPTION
## Summary
- Fix empty `RuleName` field in `--format json` and `--format sarif` scan output when using a file-based datastore
- Root cause: `GetMatches()` and `GetAllMatches()` queried only the `matches` table, which does not store `rule_name` — the field was lost during the SQLite roundtrip
- Fix: JOIN the `rules` table in both queries so `RuleName` is populated for all callers
- Add regression tests for `GetMatches` and `GetAllMatches` verifying `RuleName` is populated

## Test plan
- [x] `make test` — all tests pass
- [x] Manual test: `titus scan --format json --output /tmp/test.ds` confirms `RuleName` is populated
- [x] Manual test: human format output unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)