### PR TITLE
fix(enum): attach commit metadata in clone filesystem mode

### DIFF
--- a/pkg/enum/clone.go
+++ b/pkg/enum/clone.go
@@ -134,6 +134,9 @@ func (e *CloneEnumerator) cloneAndScan(ctx context.Context, repo RepoInfo, callb
 	}
 
 	// Filesystem mode (default): fast scan of working tree
+	// Collect commit metadata for current files (best-effort; nil map is safe)
+	commitMap, _ := collectCommitMetadataForRepo(ctx, clonePath, false)
+
 	return NewFilesystemEnumerator(cloneConfig).Enumerate(ctx, func(content []byte, blobID types.BlobID, prov types.Provenance) error {
 		// Rewrite file provenance to include repo name
 		if fp, ok := prov.(types.FileProvenance); ok {
@@ -142,10 +145,14 @@ func (e *CloneEnumerator) cloneAndScan(ctx context.Context, repo RepoInfo, callb
 			if err != nil {
 				relPath = fp.FilePath
 			}
-			return callback(content, blobID, types.GitProvenance{
+			gp := types.GitProvenance{
 				RepoPath: repo.Name,
 				BlobPath: relPath,
-			})
+			}
+			if commitMap != nil {
+				gp.Commit = commitMap[relPath]
+			}
+			return callback(content, blobID, gp)
 		}
 		return callback(content, blobID, prov)
 	})

--- a/pkg/enum/commit_metadata.go
+++ b/pkg/enum/commit_metadata.go
@@ -1,0 +1,77 @@
+package enum
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+)
+
+// collectCommitMetadataForRepo runs git log to build a map of file path → commit metadata.
+// When firstAdded is true, uses --diff-filter=A to find the commit that first added each path.
+// When false, finds the most recent commit that touched each path.
+func collectCommitMetadataForRepo(ctx context.Context, repoPath string, firstAdded bool) (map[string]*types.CommitMetadata, error) {
+	args := []string{"log", "--all",
+		"--format=%H%x00%an%x00%ae%x00%aI%x00%cn%x00%ce%x00%cI%x00%s", "--name-only"}
+	if firstAdded {
+		args = append(args, "--diff-filter=A")
+	}
+
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = repoPath
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("git log: pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("git log: start: %w", err)
+	}
+
+	result := make(map[string]*types.CommitMetadata)
+	scanner := bufio.NewScanner(stdout)
+
+	var current *types.CommitMetadata
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+
+		// Lines with 7 null-byte separators are commit headers
+		parts := strings.SplitN(line, "\x00", 8)
+		if len(parts) == 8 && len(parts[0]) == 40 {
+			authorTS, _ := time.Parse(time.RFC3339, parts[3])
+			committerTS, _ := time.Parse(time.RFC3339, parts[6])
+			current = &types.CommitMetadata{
+				CommitID:           parts[0],
+				AuthorName:         parts[1],
+				AuthorEmail:        parts[2],
+				AuthorTimestamp:    authorTS,
+				CommitterName:      parts[4],
+				CommitterEmail:     parts[5],
+				CommitterTimestamp: committerTS,
+				Message:            parts[7],
+			}
+			continue
+		}
+
+		// File path line — only record the first occurrence per path
+		if current != nil {
+			if _, exists := result[line]; !exists {
+				result[line] = current
+			}
+		}
+	}
+
+	if err := cmd.Wait(); err != nil {
+		return result, fmt.Errorf("git log: wait: %w", err)
+	}
+
+	return result, nil
+}

--- a/pkg/enum/git_native.go
+++ b/pkg/enum/git_native.go
@@ -9,7 +9,6 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/praetorian-inc/titus/pkg/types"
 )
@@ -103,63 +102,8 @@ func (e *GitEnumerator) collectBlobEntries(ctx context.Context) ([]blobEntry, er
 }
 
 // collectCommitMetadata runs git log to build a map of file path → first commit metadata.
-// Uses --diff-filter=A to find the commit that first added each path.
 func (e *GitEnumerator) collectCommitMetadata(ctx context.Context) (map[string]*types.CommitMetadata, error) {
-	// Format: fields separated by null bytes to avoid conflicts with pipes in names/subjects
-	cmd := exec.CommandContext(ctx, "git", "log", "--all", "--diff-filter=A",
-		"--format=%H%x00%an%x00%ae%x00%aI%x00%cn%x00%ce%x00%cI%x00%s", "--name-only")
-	cmd.Dir = e.config.Root
-
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return nil, fmt.Errorf("git log: pipe: %w", err)
-	}
-
-	if err := cmd.Start(); err != nil {
-		return nil, fmt.Errorf("git log: start: %w", err)
-	}
-
-	result := make(map[string]*types.CommitMetadata)
-	scanner := bufio.NewScanner(stdout)
-
-	var current *types.CommitMetadata
-	for scanner.Scan() {
-		line := scanner.Text()
-		if line == "" {
-			continue
-		}
-
-		// Lines with 7 null-byte separators are commit headers
-		parts := strings.SplitN(line, "\x00", 8)
-		if len(parts) == 8 && len(parts[0]) == 40 {
-			authorTS, _ := time.Parse(time.RFC3339, parts[3])
-			committerTS, _ := time.Parse(time.RFC3339, parts[6])
-			current = &types.CommitMetadata{
-				CommitID:           parts[0],
-				AuthorName:         parts[1],
-				AuthorEmail:        parts[2],
-				AuthorTimestamp:    authorTS,
-				CommitterName:      parts[4],
-				CommitterEmail:     parts[5],
-				CommitterTimestamp: committerTS,
-				Message:            parts[7],
-			}
-			continue
-		}
-
-		// File path line — only record the first commit that added this path
-		if current != nil {
-			if _, exists := result[line]; !exists {
-				result[line] = current
-			}
-		}
-	}
-
-	if err := cmd.Wait(); err != nil {
-		return result, fmt.Errorf("git log: wait: %w", err)
-	}
-
-	return result, nil
+	return collectCommitMetadataForRepo(ctx, e.config.Root, true)
 }
 
 // streamBlobContentsWithMeta feeds hashes to git cat-file --batch and invokes callback for text blobs.


### PR DESCRIPTION
## Summary

- Extract `collectCommitMetadataForRepo` as a shared function from the native git enumerator
- Use it in the clone enumerator's filesystem mode to populate commit metadata after cloning
- Previously, `titus github`/`titus gitlab` without `--git` produced GitProvenance with no commit hash, author, or timestamp — explore and report showed no Commit, Author, or Date lines

## Before

```
Repo: Plazmaz/leaky-repo
Path: misc-keys/cert-key.pem
Blob: 302aec8baee1cd5be78c094b709969e4daa7a8ad
```

## After

```
Repo: Plazmaz/leaky-repo
Path: misc-keys/cert-key.pem
Commit: 903a9cab...
Author: John Doe <john@example.com>
Date:   2019-11-06 21:56:54
Blob: 302aec8baee1cd5be78c094b709969e4daa7a8ad
```

## Test plan

- [x] All tests pass (`go test ./...`)
- [x] GitHub filesystem mode scan shows Date lines in report and explore
- [x] GitHub `--git` mode still works (uses same shared function)
- [x] Local `--git` scan still works
- [x] Old crusoe datastore backward compatible (5890 findings, no errors)