### PR TITLE
feat(rules): detect Slack workflow webhooks and trigger URLs

### DIFF
--- a/pkg/rule/rules/slack.yml
+++ b/pkg/rule/rules/slack.yml
@@ -115,6 +115,70 @@ rules:
   - '	url := "https://slack.com/api/channels.history?token=xoxp-113726990690-113803571044-155105854433-53ffb9d16ace50aa79aa1c425a68b131&channel=C4D8D3XMX&count=1&pretty=1"'
 
 
+- name: Slack Workflow Webhook
+  id: np.slack.7
+  pattern: '(?i)(?P<webhook>https://hooks\.slack\.com/workflows/[TE][a-z0-9]{5,14}/A[a-z0-9]{5,14}/[0-9]{6,20}/[a-zA-Z0-9]{8,40})'
+
+  categories:
+  - api
+  - secret
+
+  references:
+  - https://slack.com/help/articles/360041352714-Create-more-advanced-workflows-using-webhooks
+  - https://api.slack.com/workflows
+
+  description: >
+    A Slack Workflow Webhook URL was found.
+    These URLs are used by Workflow Builder automations to trigger multi-step workflows.
+    An attacker with this URL can invoke the workflow and potentially exfiltrate data,
+    send messages, or trigger other automated actions without authentication.
+
+  examples:
+  - 'WORKFLOW_URL=https://hooks.slack.com/workflows/T00EXAMPLE1/A00EXAMPLE1/123456789012345678/aBcDeFgHiJkLmNoPqRsTuVwX'
+  - 'curl -X POST https://hooks.slack.com/workflows/E00EXAMPLE2/A00EXAMPLE2/987654321098765432/xYzAbCdEfGhIjKlM'
+  - |
+      # Trigger Slack workflow
+      webhook_url = "https://hooks.slack.com/workflows/T00EXAMPLE3/A00EXAMPLE3/111222333444555666/qWeRtYuIoPaSdFgH"
+
+  negative_examples:
+  - 'https://hooks.slack.com/services/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'
+  - 'https://hooks.slack.com/triggers/T00EXAMPLE/1234567890123/abcdef1234567890abcdef1234567890'
+  - 'https://slack.com/workflows/T00EXAMPLE1'
+
+
+- name: Slack Trigger URL
+  id: np.slack.8
+  pattern: '(?i)(?P<webhook>https://hooks\.slack\.com/triggers/[TE][a-z0-9]{5,14}/[0-9]{10,16}(?:/[a-f0-9]{32})?)'
+
+  categories:
+  - api
+  - secret
+
+  references:
+  - https://api.slack.com/automation/triggers/webhook
+  - https://api.slack.com/automation/functions
+
+  description: >
+    A Slack Trigger URL was found.
+    These URLs invoke custom automation functions with app-level permissions using Slack's
+    next-generation automation platform. An attacker with this URL can trigger arbitrary
+    custom functions, potentially exfiltrating data or performing privileged actions
+    within the workspace without requiring user authentication.
+
+  examples:
+  - 'TRIGGER_URL=https://hooks.slack.com/triggers/T00EXAMPLE1/1234567890123/a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6'
+  - 'TRIGGER_URL=https://hooks.slack.com/triggers/E00EXAMPLE2/9876543210987/abcdef0123456789abcdef0123456789'
+  - 'curl -X POST https://hooks.slack.com/triggers/TEXAMPLE9/5551234567890/0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d'
+  - |
+      # Invoke Slack automation trigger
+      trigger_url = "https://hooks.slack.com/triggers/T00EXAMPLE3/8157378790976/f0e1d2c3b4a5968778695a4b3c2d1e0f"
+
+  negative_examples:
+  - 'https://hooks.slack.com/services/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'
+  - 'https://hooks.slack.com/workflows/T00EXAMPLE1/A00EXAMPLE1/123456789012345678/aBcDeFgHiJkLmNoPqRsTuVwX'
+  - 'https://hooks.slack.com/triggers/T00EXAMPLE1/1234567890123/NOT_HEX_TOKEN_zzzz'
+
+
 - name: Slack Webhook
   id: np.slack.3
   pattern: '(?i)(?P<webhook>https://hooks.slack.com/services/T[a-z0-9_]{8,12}/B[a-z0-9_]{8,12}/[a-z0-9_]{24})'

--- a/pkg/validator/validators/slack.yaml
+++ b/pkg/validator/validators/slack.yaml
@@ -17,6 +17,57 @@ validators:
       success_codes: [400]  # 400 with "no_text" body means webhook exists (valid but missing payload)
       failure_codes: [403, 404]  # 403=invalid_token (revoked), 404=no_service/no_team (doesn't exist)
 
+  # Slack Workflow Webhook validation (np.slack.7)
+  # Sends intentionally malformed JSON to avoid triggering the workflow.
+  # Slack checks the token before parsing the body for most triggers:
+  #   400 invalid_input       = Valid token, active workflow (payload rejected)
+  #   401 invalid_auth        = Invalid token but endpoint exists
+  #   404 webhook_not_found   = Revoked or deleted
+  #   400 missing_args        = URL never existed (team/trigger ID invalid)
+  # Tested against 33 real-world GitHub-leaked URLs + 10 randomly generated URLs.
+  - name: slack-workflow-webhook
+    rule_ids:
+      - np.slack.7
+    http:
+      method: POST
+      url: "{{webhook}}"
+      auth:
+        type: none
+        secret_group: "webhook"
+      headers:
+        - name: Content-Type
+          value: application/json
+      body: "intentionally malformed JSON from Titus validation"
+      success_codes: [400]
+      failure_codes: [401, 404]
+      success_body_contains: "invalid_input"
+      failure_body_contains: "missing_args"
+
+  # Slack Trigger URL validation (np.slack.8)
+  # Same malformed JSON approach as workflow webhooks — safe and non-intrusive.
+  # Response matrix identical to workflow webhooks:
+  #   400 invalid_input       = Valid token, active trigger
+  #   401 invalid_auth        = Invalid token but endpoint exists
+  #   404 webhook_not_found   = Revoked or deleted
+  #   400 missing_args        = URL never existed
+  - name: slack-trigger-url
+    rule_ids:
+      - np.slack.8
+    http:
+      method: POST
+      url: "{{webhook}}"
+      auth:
+        type: none
+        secret_group: "webhook"
+      headers:
+        - name: Content-Type
+          value: application/json
+      body: "intentionally malformed JSON from Titus validation"
+      success_codes: [400]
+      failure_codes: [401, 404]
+      success_body_contains: "invalid_input"
+      failure_body_contains: "missing_args"
+
   # Slack token validation uses auth.test endpoint (read-only, no scopes required)
   # Returns ok=true with team/user metadata if valid
   # Returns ok=false with error field if invalid (invalid_auth, token_revoked, account_inactive, not_authed)


### PR DESCRIPTION
## Summary
- Add `np.slack.7` for Slack Workflow Webhooks (`/workflows/`) and `np.slack.8` for Slack Trigger URLs (`/triggers/`)
- Previously only `/services/` webhooks were detected — the two more dangerous URL types were completely undetected
- Both rules support `T` (workspace) and `E` (Enterprise Grid) ID prefixes
- Validators use malformed JSON POST (TruffleHog's technique) — non-intrusive, never triggers workflows

## Validation Research

Tested malformed JSON POST against 33 real-world GitHub-leaked URLs + 10 randomly generated URLs:

| Response | Code | Meaning | Count |
|---|---|---|---|
| `invalid_input` | 400 | Active secret | 26 |
| `invalid_auth` | 401 | Exists, token wrong | 1 |
| `webhook_not_found` | 404 | Revoked/deleted | 5 |
| `missing_args` | 400 | Never existed | 11 (all fake) |

End-to-end `titus scan --validate` confirmed correct valid/invalid classification.

## Note on TruffleHog
TruffleHog already detects `/workflows/` but does NOT detect `/triggers/` — we cover both.

## Release Request
Would appreciate a new release cut so we can pull this into the Guard platform — active client ask (ENG-2241).