### PR TITLE
feat: add WarnFunc callback, NewCoreWithRules, and named capture group support

### DIFF
--- a/cmd/titus/scan.go
+++ b/cmd/titus/scan.go
@@ -134,6 +134,9 @@ func runScan(cmd *cobra.Command, args []string) error {
 	m, err := matcher.New(matcher.Config{
 		Rules:        rules,
 		ContextLines: scanContextLines,
+		WarnFunc: func(format string, args ...any) {
+			fmt.Fprintf(os.Stderr, format, args...)
+		},
 	})
 	if err != nil {
 		return fmt.Errorf("creating matcher: %w", err)
@@ -628,6 +631,9 @@ func runRepoScan(cmd *cobra.Command, rt repoTarget) error {
 	m, err := matcher.New(matcher.Config{
 		Rules:        rules,
 		ContextLines: scanContextLines,
+		WarnFunc: func(format string, args ...any) {
+			fmt.Fprintf(os.Stderr, format, args...)
+		},
 	})
 	if err != nil {
 		return fmt.Errorf("creating matcher: %w", err)

--- a/pkg/matcher/matcher.go
+++ b/pkg/matcher/matcher.go
@@ -25,4 +25,8 @@ type Config struct {
 
 	// ContextLines is the number of lines of context to extract before/after matches (0 = none)
 	ContextLines int
+
+	// WarnFunc, if non-nil, is called for non-fatal regex warnings
+	// (timeouts, pattern errors). If nil, warnings are silently discarded.
+	WarnFunc func(format string, args ...any)
 }

--- a/pkg/matcher/matcher_default.go
+++ b/pkg/matcher/matcher_default.go
@@ -8,7 +8,7 @@ package matcher
 // - High detection accuracy: finds 20% more secrets than NoseyParker v0.24.0
 // - Performance: comparable on small files, sufficient for most use cases
 func New(cfg Config) (Matcher, error) {
-	inner, err := NewPortableRegexp(cfg.Rules, cfg.ContextLines)
+	inner, err := NewPortableRegexp(cfg.Rules, cfg.ContextLines, cfg.WarnFunc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/matcher/matcher_vectorscan.go
+++ b/pkg/matcher/matcher_vectorscan.go
@@ -13,7 +13,7 @@ package matcher
 // - CGO is enabled
 // - The "vectorscan" build tag is specified
 func New(cfg Config) (Matcher, error) {
-	inner, err := NewVectorscan(cfg.Rules, cfg.ContextLines)
+	inner, err := NewVectorscan(cfg.Rules, cfg.ContextLines, cfg.WarnFunc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/matcher/matcher_wasm.go
+++ b/pkg/matcher/matcher_wasm.go
@@ -4,7 +4,7 @@ package matcher
 
 // New creates a regexp-based matcher for WASM builds.
 func New(cfg Config) (Matcher, error) {
-	inner, err := NewRegexp(cfg.Rules, cfg.ContextLines)
+	inner, err := NewRegexp(cfg.Rules, cfg.ContextLines, cfg.WarnFunc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/matcher/noseyparker_comparison_test.go
+++ b/pkg/matcher/noseyparker_comparison_test.go
@@ -39,7 +39,7 @@ func TestNoseyParkerParity_HTMLTestFile(t *testing.T) {
 	require.NotEmpty(t, rules)
 
 	// Create portable matcher (non-CGO)
-	m, err := NewPortableRegexp(rules, 0)
+	m, err := NewPortableRegexp(rules, 0, nil)
 	require.NoError(t, err)
 	defer m.Close()
 
@@ -104,7 +104,7 @@ func TestNoseyParkerParity_MixedSecrets(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create portable matcher
-	m, err := NewPortableRegexp(rules, 0)
+	m, err := NewPortableRegexp(rules, 0, nil)
 	require.NoError(t, err)
 	defer m.Close()
 
@@ -159,7 +159,7 @@ func BenchmarkTitusVsNoseyParkerSpeed(b *testing.B) {
 	}
 
 	// Create matcher once
-	m, err := NewPortableRegexp(rules, 0)
+	m, err := NewPortableRegexp(rules, 0, nil)
 	if err != nil {
 		b.Fatalf("Failed to create matcher: %v", err)
 	}

--- a/pkg/matcher/regexp.go
+++ b/pkg/matcher/regexp.go
@@ -4,7 +4,6 @@ package matcher
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -20,10 +19,11 @@ type RegexpMatcher struct {
 	rules        []*types.Rule
 	regexCache   map[string]*regexp2.Regexp
 	contextLines int
+	warnf        func(string, ...any)
 }
 
 // NewRegexp creates a new regexp-based matcher.
-func NewRegexp(rules []*types.Rule, contextLines int) (*RegexpMatcher, error) {
+func NewRegexp(rules []*types.Rule, contextLines int, warnf func(string, ...any)) (*RegexpMatcher, error) {
 	if len(rules) == 0 {
 		return nil, fmt.Errorf("no rules provided")
 	}
@@ -32,6 +32,7 @@ func NewRegexp(rules []*types.Rule, contextLines int) (*RegexpMatcher, error) {
 		rules:        rules,
 		regexCache:   make(map[string]*regexp2.Regexp),
 		contextLines: contextLines,
+		warnf:        warnf,
 	}
 
 	// Pre-compile all patterns to catch errors early
@@ -74,10 +75,12 @@ func (m *RegexpMatcher) MatchWithBlobID(content []byte, blobID types.BlobID) ([]
 		// Find first match
 		match, err := re.FindStringMatch(contentStr)
 		if err != nil {
-			if strings.Contains(err.Error(), "match timeout") {
-				fmt.Fprintf(os.Stderr, "[warn] rule %s regex timeout on content (skipping rule for this blob)\n", rule.ID)
-			} else {
-				fmt.Fprintf(os.Stderr, "[warn] rule %s regex error (skipping rule for this blob): %v\n", rule.ID, err)
+			if m.warnf != nil {
+				if strings.Contains(err.Error(), "match timeout") {
+					m.warnf("[warn] rule %s regex timeout on content (skipping rule for this blob)\n", rule.ID)
+				} else {
+					m.warnf("[warn] rule %s regex error (skipping rule for this blob): %v\n", rule.ID, err)
+				}
 			}
 			continue
 		}
@@ -153,10 +156,12 @@ func (m *RegexpMatcher) MatchWithBlobID(content []byte, blobID types.BlobID) ([]
 			// Find next match
 			match, err = re.FindNextMatch(match)
 			if err != nil {
-				if strings.Contains(err.Error(), "match timeout") {
-					fmt.Fprintf(os.Stderr, "[warn] rule %s regex timeout on content (skipping rule for this blob)\n", rule.ID)
-				} else {
-					fmt.Fprintf(os.Stderr, "[warn] rule %s regex error (skipping rule for this blob): %v\n", rule.ID, err)
+				if m.warnf != nil {
+					if strings.Contains(err.Error(), "match timeout") {
+						m.warnf("[warn] rule %s regex timeout on content (skipping rule for this blob)\n", rule.ID)
+					} else {
+						m.warnf("[warn] rule %s regex error (skipping rule for this blob): %v\n", rule.ID, err)
+					}
 				}
 				break
 			}

--- a/pkg/matcher/regexp_portable.go
+++ b/pkg/matcher/regexp_portable.go
@@ -5,7 +5,6 @@ package matcher
 import (
 	"context"
 	"fmt"
-	"os"
 	"runtime"
 	"strings"
 	"sync"
@@ -40,6 +39,7 @@ type PortableRegexpMatcher struct {
 	groupNameCache map[string][]string          // read-only after init, safe for concurrent reads
 	dedup          *Deduplicator
 	contextLines   int
+	warnf          func(string, ...any)
 }
 
 // NewPortableRegexp creates a new portable regexp-based matcher (non-CGO).
@@ -50,7 +50,7 @@ type PortableRegexpMatcher struct {
 // - CGO is disabled or unavailable (library mode)
 // - Cross-compilation without CGO dependencies
 // - Benchmarking CGO vs non-CGO performance
-func NewPortableRegexp(rules []*types.Rule, contextLines int) (*PortableRegexpMatcher, error) {
+func NewPortableRegexp(rules []*types.Rule, contextLines int, warnf func(string, ...any)) (*PortableRegexpMatcher, error) {
 	if len(rules) == 0 {
 		return nil, fmt.Errorf("no rules provided")
 	}
@@ -61,6 +61,7 @@ func NewPortableRegexp(rules []*types.Rule, contextLines int) (*PortableRegexpMa
 		groupNameCache: make(map[string][]string),
 		dedup:          NewContentDeduplicator(),
 		contextLines:   contextLines,
+		warnf:          warnf,
 	}
 
 	// Pre-compile all patterns to catch errors early
@@ -118,10 +119,12 @@ func (m *PortableRegexpMatcher) matchSequential(content []byte, blobID types.Blo
 		// Find first match
 		match, err := re.FindRunesMatch(contentRunes)
 		if err != nil {
-			if strings.Contains(err.Error(), "match timeout") {
-				fmt.Fprintf(os.Stderr, "[warn] rule %s regex timeout on content (skipping rule for this blob)\n", rule.ID)
-			} else {
-				fmt.Fprintf(os.Stderr, "[warn] rule %s regex error (skipping rule for this blob): %v\n", rule.ID, err)
+			if m.warnf != nil {
+				if strings.Contains(err.Error(), "match timeout") {
+					m.warnf("[warn] rule %s regex timeout on content (skipping rule for this blob)\n", rule.ID)
+				} else {
+					m.warnf("[warn] rule %s regex error (skipping rule for this blob): %v\n", rule.ID, err)
+				}
 			}
 			continue
 		}
@@ -144,10 +147,12 @@ func (m *PortableRegexpMatcher) matchSequential(content []byte, blobID types.Blo
 			// Find next match
 			match, err = re.FindNextMatch(match)
 			if err != nil {
-				if strings.Contains(err.Error(), "match timeout") {
-					fmt.Fprintf(os.Stderr, "[warn] rule %s regex timeout on content (skipping rule for this blob)\n", rule.ID)
-				} else {
-					fmt.Fprintf(os.Stderr, "[warn] rule %s regex error (skipping rule for this blob): %v\n", rule.ID, err)
+				if m.warnf != nil {
+					if strings.Contains(err.Error(), "match timeout") {
+						m.warnf("[warn] rule %s regex timeout on content (skipping rule for this blob)\n", rule.ID)
+					} else {
+						m.warnf("[warn] rule %s regex error (skipping rule for this blob): %v\n", rule.ID, err)
+					}
 				}
 				break
 			}
@@ -208,10 +213,12 @@ func (m *PortableRegexpMatcher) matchParallel(content []byte, blobID types.BlobI
 				// Find first match
 				match, err := re.FindRunesMatch(contentRunes)
 				if err != nil {
-					if strings.Contains(err.Error(), "match timeout") {
-						fmt.Fprintf(os.Stderr, "[warn] rule %s regex timeout on content (skipping rule for this blob)\n", rule.ID)
-					} else {
-						fmt.Fprintf(os.Stderr, "[warn] rule %s regex error (skipping rule for this blob): %v\n", rule.ID, err)
+					if m.warnf != nil {
+						if strings.Contains(err.Error(), "match timeout") {
+							m.warnf("[warn] rule %s regex timeout on content (skipping rule for this blob)\n", rule.ID)
+						} else {
+							m.warnf("[warn] rule %s regex error (skipping rule for this blob): %v\n", rule.ID, err)
+						}
 					}
 					continue
 				}
@@ -227,10 +234,12 @@ func (m *PortableRegexpMatcher) matchParallel(content []byte, blobID types.BlobI
 					// Find next match
 					match, err = re.FindNextMatch(match)
 					if err != nil {
-						if strings.Contains(err.Error(), "match timeout") {
-							fmt.Fprintf(os.Stderr, "[warn] rule %s regex timeout on content (skipping rule for this blob)\n", rule.ID)
-						} else {
-							fmt.Fprintf(os.Stderr, "[warn] rule %s regex error (skipping rule for this blob): %v\n", rule.ID, err)
+						if m.warnf != nil {
+							if strings.Contains(err.Error(), "match timeout") {
+								m.warnf("[warn] rule %s regex timeout on content (skipping rule for this blob)\n", rule.ID)
+							} else {
+								m.warnf("[warn] rule %s regex error (skipping rule for this blob): %v\n", rule.ID, err)
+							}
 						}
 						break
 					}

--- a/pkg/matcher/regexp_test.go
+++ b/pkg/matcher/regexp_test.go
@@ -36,7 +36,7 @@ func TestMatchParallel_Correctness(t *testing.T) {
 	content := []byte(contentBuilder.String())
 	require.Greater(t, len(content), 10000, "Content must be >10KB to trigger parallel path")
 
-	matcher, err := NewPortableRegexp(rules, 0)
+	matcher, err := NewPortableRegexp(rules, 0, nil)
 	require.NoError(t, err)
 
 	matches, err := matcher.Match(content)
@@ -94,7 +94,7 @@ func TestMatchParallel_vs_Sequential_Equivalence(t *testing.T) {
 			}
 			content := []byte(contentBuilder.String())
 
-			matcher, err := NewPortableRegexp(rules, 2)
+			matcher, err := NewPortableRegexp(rules, 2, nil)
 			require.NoError(t, err)
 
 			matches, err := matcher.Match(content)
@@ -128,7 +128,7 @@ func TestMatch_FindingID_Populated(t *testing.T) {
 
 	content := []byte("aws_access_key=AKIAZ52KNG5GARBXTEST\n")
 
-	matcher, err := NewPortableRegexp(rules, 0)
+	matcher, err := NewPortableRegexp(rules, 0, nil)
 	require.NoError(t, err)
 
 	matches, err := matcher.Match(content)
@@ -171,7 +171,7 @@ func TestPortableRegexp_TimeoutIsTolerated(t *testing.T) {
 	catastrophicContent := strings.Repeat("a", 5000) + "c" // no 'b' → triggers timeout on rule 1
 	content := []byte(catastrophicContent + "\n" + `password = "secret123"`)
 
-	m, err := NewPortableRegexp(rules, 0)
+	m, err := NewPortableRegexp(rules, 0, nil)
 	require.NoError(t, err)
 
 	// This must NOT return an error even though catastrophic-rule times out.
@@ -212,7 +212,7 @@ func TestPortableRegexp_TimeoutIsTolerated_Parallel(t *testing.T) {
 	content := []byte(sb.String())
 	require.Greater(t, len(content), parallelThreshold, "must trigger parallel path")
 
-	m, err := NewPortableRegexp(rules, 0)
+	m, err := NewPortableRegexp(rules, 0, nil)
 	require.NoError(t, err)
 
 	matches, err := m.MatchWithBlobID(content, types.ComputeBlobID(content))
@@ -253,7 +253,7 @@ func TestMatchParallel_RaceDetector(t *testing.T) {
 	content := []byte(contentBuilder.String())
 	require.Greater(t, len(content), 10000)
 
-	matcher, err := NewPortableRegexp(rules, 1)
+	matcher, err := NewPortableRegexp(rules, 1, nil)
 	require.NoError(t, err)
 
 	// Run multiple times to increase chance of detecting races
@@ -279,7 +279,7 @@ func TestMatch_SnippetAndOffset_ASCII(t *testing.T) {
 	//                 0123456789...
 	//                        ^-- "secret_key" starts at byte 7
 
-	matcher, err := NewPortableRegexp(rules, 0)
+	matcher, err := NewPortableRegexp(rules, 0, nil)
 	require.NoError(t, err)
 
 	matches, err := matcher.Match(content)
@@ -362,7 +362,7 @@ func TestMatch_SnippetAndOffset_UTF8(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			content := []byte(tc.content)
 
-			matcher, err := NewPortableRegexp(rules, 0)
+			matcher, err := NewPortableRegexp(rules, 0, nil)
 			require.NoError(t, err)
 
 			matches, err := matcher.Match(content)
@@ -405,7 +405,7 @@ func TestMatch_SnippetContext_UTF8(t *testing.T) {
 	// Content with multi-byte chars before and after the match
 	content := []byte("café secret_key 🔑end")
 
-	matcher, err := NewPortableRegexp(rules, 3) // 3 lines of context
+	matcher, err := NewPortableRegexp(rules, 3, nil) // 3 lines of context
 	require.NoError(t, err)
 
 	matches, err := matcher.Match(content)

--- a/pkg/matcher/vectorscan.go
+++ b/pkg/matcher/vectorscan.go
@@ -5,6 +5,7 @@ package matcher
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"runtime"
 	"strings"
 	"sync"
@@ -48,6 +49,8 @@ type VectorscanMatcher struct {
 	// Hybrid approach: track which rules use Hyperscan vs regexp2 fallback
 	hsRules       []*types.Rule // Rules compiled into Hyperscan
 	fallbackRules []*types.Rule // Rules that require regexp2 fallback
+
+	warnf func(string, ...any)
 }
 
 // knownIncompatiblePatterns contains rule IDs that are known to be
@@ -63,6 +66,11 @@ var knownIncompatiblePatterns = map[string]bool{
 	// Currently empty - all rules are Hyperscan-compatible
 }
 
+// namedGroupRegex matches named capture group openings in both Python (?P<name>)
+// and .NET (?<name>) syntax. Used to convert them to non-capturing groups for
+// Hyperscan compatibility.
+var namedGroupRegex = regexp.MustCompile(`\(\?P?<[^>]+>`)
+
 // NewVectorscan creates a new Hyperscan/Vectorscan-based matcher.
 // This is the high-performance option requiring CGO and the Hyperscan library.
 //
@@ -70,7 +78,7 @@ var knownIncompatiblePatterns = map[string]bool{
 // - Maximum performance is required (10-100x faster than regexp2)
 // - CGO is available and acceptable
 // - Scanning large files or many files
-func NewVectorscan(rules []*types.Rule, contextLines int) (*VectorscanMatcher, error) {
+func NewVectorscan(rules []*types.Rule, contextLines int, warnf func(string, ...any)) (*VectorscanMatcher, error) {
 	if len(rules) == 0 {
 		return nil, fmt.Errorf("no rules provided")
 	}
@@ -82,6 +90,7 @@ func NewVectorscan(rules []*types.Rule, contextLines int) (*VectorscanMatcher, e
 		regexCache:     make(map[string]*regexp2.Regexp),
 		groupNameCache: make(map[string][]string),
 		prefilter:      prefilter.New(rules),
+		warnf:          warnf,
 	}
 
 	// Compile patterns into Hyperscan database
@@ -295,7 +304,7 @@ func findIncompatiblePatterns(patterns []*hyperscan.Pattern) []int {
 }
 
 // preprocessPatternForHyperscan modifies a pattern for Hyperscan compatibility.
-// Hyperscan doesn't support extended mode ((?x)) so we strip it.
+// Hyperscan doesn't support extended mode ((?x)) or named capture groups so we strip/convert them.
 func preprocessPatternForHyperscan(pattern string) string {
 	// Strip extended mode if present
 	if hasExtendedMode(pattern) {
@@ -306,6 +315,12 @@ func preprocessPatternForHyperscan(pattern string) string {
 	pattern = strings.ReplaceAll(pattern, "(?i)", "")
 	pattern = strings.ReplaceAll(pattern, "(?s)", "")
 	pattern = strings.ReplaceAll(pattern, "(?m)", "")
+
+	// Convert named capture groups to non-capturing groups.
+	// Hyperscan does not support named captures ((?P<name>...) or (?<name>...)).
+	// Since Hyperscan is only used as a prefilter and regexp2 handles actual
+	// capture extraction, converting to (?:...) preserves matching semantics.
+	pattern = namedGroupRegex.ReplaceAllString(pattern, "(?:")
 
 	return pattern
 }
@@ -468,10 +483,12 @@ func (m *VectorscanMatcher) matchChunk(content []byte, blobID types.BlobID, opts
 		// Find all precise matches using regexp2
 		match, err := re.FindRunesMatch(contentRunes)
 		if err != nil {
-			if strings.Contains(err.Error(), "match timeout") {
-				fmt.Fprintf(os.Stderr, "[warn] rule %s regex timeout on content (skipping rule for this blob)\n", rule.ID)
-			} else {
-				fmt.Fprintf(os.Stderr, "[warn] rule %s regex error (skipping rule for this blob): %v\n", rule.ID, err)
+			if m.warnf != nil {
+				if strings.Contains(err.Error(), "match timeout") {
+					m.warnf("[warn] rule %s regex timeout on content (skipping rule for this blob)\n", rule.ID)
+				} else {
+					m.warnf("[warn] rule %s regex error (skipping rule for this blob): %v\n", rule.ID, err)
+				}
 			}
 			stat.Duration = time.Since(startTime)
 			ruleStats[rule.ID] = stat
@@ -491,10 +508,12 @@ func (m *VectorscanMatcher) matchChunk(content []byte, blobID types.BlobID, opts
 			if start < 0 || end > len(content) || start > end {
 				match, err = re.FindNextMatch(match)
 				if err != nil {
-					if strings.Contains(err.Error(), "match timeout") {
-						fmt.Fprintf(os.Stderr, "[warn] rule %s regex timeout on content (skipping rule for this blob)\n", rule.ID)
-					} else {
-						fmt.Fprintf(os.Stderr, "[warn] rule %s regex error (skipping rule for this blob): %v\n", rule.ID, err)
+					if m.warnf != nil {
+						if strings.Contains(err.Error(), "match timeout") {
+							m.warnf("[warn] rule %s regex timeout on content (skipping rule for this blob)\n", rule.ID)
+						} else {
+							m.warnf("[warn] rule %s regex error (skipping rule for this blob): %v\n", rule.ID, err)
+						}
 					}
 					break
 				}
@@ -514,10 +533,12 @@ func (m *VectorscanMatcher) matchChunk(content []byte, blobID types.BlobID, opts
 
 			match, err = re.FindNextMatch(match)
 			if err != nil {
-				if strings.Contains(err.Error(), "match timeout") {
-					fmt.Fprintf(os.Stderr, "[warn] rule %s regex timeout on content (skipping rule for this blob)\n", rule.ID)
-				} else {
-					fmt.Fprintf(os.Stderr, "[warn] rule %s regex error (skipping rule for this blob): %v\n", rule.ID, err)
+				if m.warnf != nil {
+					if strings.Contains(err.Error(), "match timeout") {
+						m.warnf("[warn] rule %s regex timeout on content (skipping rule for this blob)\n", rule.ID)
+					} else {
+						m.warnf("[warn] rule %s regex error (skipping rule for this blob): %v\n", rule.ID, err)
+					}
 				}
 				break
 			}
@@ -723,10 +744,12 @@ func (m *VectorscanMatcher) matchFallbackRules(content []byte, blobID types.Blob
 		// Find all matches for this rule
 		match, err := re.FindRunesMatch(contentRunes)
 		if err != nil {
-			if strings.Contains(err.Error(), "match timeout") {
-				fmt.Fprintf(os.Stderr, "[warn] rule %s regex timeout on content (skipping rule for this blob)\n", rule.ID)
-			} else {
-				fmt.Fprintf(os.Stderr, "[warn] rule %s regex error (skipping rule for this blob): %v\n", rule.ID, err)
+			if m.warnf != nil {
+				if strings.Contains(err.Error(), "match timeout") {
+					m.warnf("[warn] rule %s regex timeout on content (skipping rule for this blob)\n", rule.ID)
+				} else {
+					m.warnf("[warn] rule %s regex error (skipping rule for this blob): %v\n", rule.ID, err)
+				}
 			}
 			continue
 		}
@@ -744,10 +767,12 @@ func (m *VectorscanMatcher) matchFallbackRules(content []byte, blobID types.Blob
 			if start < 0 || end > len(content) || start > end {
 				match, err = re.FindNextMatch(match)
 				if err != nil {
-					if strings.Contains(err.Error(), "match timeout") {
-						fmt.Fprintf(os.Stderr, "[warn] rule %s regex timeout on content (skipping rule for this blob)\n", rule.ID)
-					} else {
-						fmt.Fprintf(os.Stderr, "[warn] rule %s regex error (skipping rule for this blob): %v\n", rule.ID, err)
+					if m.warnf != nil {
+						if strings.Contains(err.Error(), "match timeout") {
+							m.warnf("[warn] rule %s regex timeout on content (skipping rule for this blob)\n", rule.ID)
+						} else {
+							m.warnf("[warn] rule %s regex error (skipping rule for this blob): %v\n", rule.ID, err)
+						}
 					}
 					break
 				}
@@ -761,10 +786,12 @@ func (m *VectorscanMatcher) matchFallbackRules(content []byte, blobID types.Blob
 
 			match, err = re.FindNextMatch(match)
 			if err != nil {
-				if strings.Contains(err.Error(), "match timeout") {
-					fmt.Fprintf(os.Stderr, "[warn] rule %s regex timeout on content (skipping rule for this blob)\n", rule.ID)
-				} else {
-					fmt.Fprintf(os.Stderr, "[warn] rule %s regex error (skipping rule for this blob): %v\n", rule.ID, err)
+				if m.warnf != nil {
+					if strings.Contains(err.Error(), "match timeout") {
+						m.warnf("[warn] rule %s regex timeout on content (skipping rule for this blob)\n", rule.ID)
+					} else {
+						m.warnf("[warn] rule %s regex error (skipping rule for this blob): %v\n", rule.ID, err)
+					}
 				}
 				break
 			}

--- a/pkg/matcher/vectorscan_hybrid_simple_test.go
+++ b/pkg/matcher/vectorscan_hybrid_simple_test.go
@@ -28,7 +28,7 @@ func TestVectorscanMatcher_HybridSimple(t *testing.T) {
 
 	// Should successfully create matcher
 	t.Log("Creating matcher...")
-	matcher, err := NewVectorscan(rules, 2)
+	matcher, err := NewVectorscan(rules, 2, nil)
 	require.NoError(t, err, "matcher should be created")
 	t.Log("Matcher created successfully")
 

--- a/pkg/matcher/vectorscan_hybrid_test.go
+++ b/pkg/matcher/vectorscan_hybrid_test.go
@@ -33,7 +33,7 @@ func TestVectorscanMatcher_HybridApproach(t *testing.T) {
 	}
 
 	// Should successfully create matcher despite complex pattern
-	matcher, err := NewVectorscan(rules, 2)
+	matcher, err := NewVectorscan(rules, 2, nil)
 	require.NoError(t, err, "matcher should be created even with complex patterns")
 	// Skip defer matcher.Close() - pre-existing bug in hyperscan cleanup causes hangs
 
@@ -76,7 +76,7 @@ func TestVectorscanMatcher_AllPatternsFallback(t *testing.T) {
 	}
 
 	// Should create matcher even if all patterns require fallback
-	matcher, err := NewVectorscan(rules, 2)
+	matcher, err := NewVectorscan(rules, 2, nil)
 	require.NoError(t, err, "matcher should be created with only fallback patterns")
 	// Skip defer matcher.Close() - pre-existing bug in hyperscan cleanup causes hangs
 
@@ -113,7 +113,7 @@ func TestVectorscanMatcher_DiagnosticOutput(t *testing.T) {
 
 	// Capture stderr to verify diagnostic output
 	// (We'll just test that it doesn't panic for now)
-	matcher, err := NewVectorscan(rules, 2)
+	matcher, err := NewVectorscan(rules, 2, nil)
 	require.NoError(t, err)
 	// Skip defer matcher.Close() - pre-existing bug in hyperscan cleanup causes hangs
 

--- a/pkg/matcher/vectorscan_test.go
+++ b/pkg/matcher/vectorscan_test.go
@@ -20,7 +20,7 @@ func TestVectorscanMatcher_BasicMatch(t *testing.T) {
 		},
 	}
 
-	matcher, err := NewVectorscan(rules, 2)
+	matcher, err := NewVectorscan(rules, 2, nil)
 	require.NoError(t, err)
 	defer matcher.Close()
 
@@ -40,7 +40,7 @@ func TestVectorscanMatcher_NoMatch(t *testing.T) {
 		},
 	}
 
-	matcher, err := NewVectorscan(rules, 2)
+	matcher, err := NewVectorscan(rules, 2, nil)
 	require.NoError(t, err)
 	defer matcher.Close()
 
@@ -63,7 +63,7 @@ func TestVectorscanMatcher_ExtendedMode(t *testing.T) {
 		},
 	}
 
-	matcher, err := NewVectorscan(rules, 2)
+	matcher, err := NewVectorscan(rules, 2, nil)
 	require.NoError(t, err)
 	defer matcher.Close()
 
@@ -82,7 +82,7 @@ func TestVectorscanMatcher_CaseInsensitive(t *testing.T) {
 		},
 	}
 
-	matcher, err := NewVectorscan(rules, 2)
+	matcher, err := NewVectorscan(rules, 2, nil)
 	require.NoError(t, err)
 	defer matcher.Close()
 
@@ -110,7 +110,7 @@ func TestVectorscanMatcher_DefaultFlagsConfiguration(t *testing.T) {
 		},
 	}
 
-	matcher, err := NewVectorscan(rules, 0)
+	matcher, err := NewVectorscan(rules, 0, nil)
 	require.NoError(t, err)
 	defer matcher.Close()
 
@@ -137,7 +137,7 @@ func TestVectorscanMatcher_MultipleRules(t *testing.T) {
 		},
 	}
 
-	matcher, err := NewVectorscan(rules, 2)
+	matcher, err := NewVectorscan(rules, 2, nil)
 	require.NoError(t, err)
 	defer matcher.Close()
 
@@ -166,7 +166,7 @@ func TestVectorscanMatcher_Close(t *testing.T) {
 		},
 	}
 
-	matcher, err := NewVectorscan(rules, 2)
+	matcher, err := NewVectorscan(rules, 2, nil)
 	require.NoError(t, err)
 
 	// Close should not error
@@ -185,7 +185,7 @@ func TestVectorscanMatcher_CloseDoesNotHang(t *testing.T) {
 		},
 	}
 
-	matcher, err := NewVectorscan(rules, 2)
+	matcher, err := NewVectorscan(rules, 2, nil)
 	require.NoError(t, err)
 
 	// Perform some matches to populate the scratch pool
@@ -210,7 +210,7 @@ func TestVectorscanMatcher_CloseDoesNotHang(t *testing.T) {
 
 func TestVectorscanMatcher_EmptyRules(t *testing.T) {
 	rules := []*types.Rule{}
-	_, err := NewVectorscan(rules, 2)
+	_, err := NewVectorscan(rules, 2, nil)
 	assert.Error(t, err)
 }
 
@@ -223,7 +223,7 @@ func TestVectorscanMatcher_DotAllMode(t *testing.T) {
 		},
 	}
 
-	matcher, err := NewVectorscan(rules, 2)
+	matcher, err := NewVectorscan(rules, 2, nil)
 	require.NoError(t, err)
 	defer matcher.Close()
 
@@ -242,7 +242,7 @@ func TestVectorscanMatcher_MultilineMode(t *testing.T) {
 		},
 	}
 
-	matcher, err := NewVectorscan(rules, 2)
+	matcher, err := NewVectorscan(rules, 2, nil)
 	require.NoError(t, err)
 	defer matcher.Close()
 
@@ -261,7 +261,7 @@ func TestVectorscanMatcher_CaptureGroups(t *testing.T) {
 		},
 	}
 
-	matcher, err := NewVectorscan(rules, 2)
+	matcher, err := NewVectorscan(rules, 2, nil)
 	require.NoError(t, err)
 	defer matcher.Close()
 
@@ -284,7 +284,7 @@ func TestVectorscanMatcher_NamedCaptureGroups(t *testing.T) {
 		},
 	}
 
-	matcher, err := NewVectorscan(rules, 2)
+	matcher, err := NewVectorscan(rules, 2, nil)
 	require.NoError(t, err)
 	defer matcher.Close()
 
@@ -308,7 +308,7 @@ func TestVectorscanMatcher_ContextExtraction(t *testing.T) {
 		},
 	}
 
-	matcher, err := NewVectorscan(rules, 2)
+	matcher, err := NewVectorscan(rules, 2, nil)
 	require.NoError(t, err)
 	defer matcher.Close()
 
@@ -333,7 +333,7 @@ func TestVectorscanMatcher_Deduplication(t *testing.T) {
 		},
 	}
 
-	matcher, err := NewVectorscan(rules, 2)
+	matcher, err := NewVectorscan(rules, 2, nil)
 	require.NoError(t, err)
 	defer matcher.Close()
 
@@ -359,7 +359,7 @@ func TestVectorscanMatcher_LargeContent(t *testing.T) {
 		},
 	}
 
-	matcher, err := NewVectorscan(rules, 2)
+	matcher, err := NewVectorscan(rules, 2, nil)
 	require.NoError(t, err)
 	defer matcher.Close()
 
@@ -381,7 +381,7 @@ func TestVectorscanMatcher_InvalidPattern(t *testing.T) {
 		},
 	}
 
-	_, err := NewVectorscan(rules, 2)
+	_, err := NewVectorscan(rules, 2, nil)
 	assert.Error(t, err)
 }
 
@@ -394,7 +394,7 @@ func TestVectorscanMatcher_UTF8Content(t *testing.T) {
 		},
 	}
 
-	matcher, err := NewVectorscan(rules, 2)
+	matcher, err := NewVectorscan(rules, 2, nil)
 	require.NoError(t, err)
 	defer matcher.Close()
 
@@ -414,7 +414,7 @@ func TestVectorscanMatcher_ConcurrentMatching(t *testing.T) {
 		},
 	}
 
-	matcher, err := NewVectorscan(rules, 2)
+	matcher, err := NewVectorscan(rules, 2, nil)
 	require.NoError(t, err)
 	defer matcher.Close()
 
@@ -485,7 +485,7 @@ func TestVectorscanMatcher_BlobIDConsistency(t *testing.T) {
 		},
 	}
 
-	matcher, err := NewVectorscan(rules, 2)
+	matcher, err := NewVectorscan(rules, 2, nil)
 	require.NoError(t, err)
 	defer matcher.Close()
 
@@ -509,7 +509,7 @@ func TestVectorscanMatcher_LocationAccuracy(t *testing.T) {
 		},
 	}
 
-	matcher, err := NewVectorscan(rules, 2)
+	matcher, err := NewVectorscan(rules, 2, nil)
 	require.NoError(t, err)
 	defer matcher.Close()
 
@@ -568,7 +568,7 @@ func TestVectorscanMatcher_CombinedFlagsCaseInsensitive(t *testing.T) {
 		},
 	}
 
-	matcher, err := NewVectorscan(rules, 2)
+	matcher, err := NewVectorscan(rules, 2, nil)
 	require.NoError(t, err)
 	defer matcher.Close()
 

--- a/pkg/rule/new_rules_test.go
+++ b/pkg/rule/new_rules_test.go
@@ -27,7 +27,7 @@ func TestDatadogRUMToken_Detection(t *testing.T) {
 	require.NotNil(t, rumRule, "kingfisher.datadog.4 rule should exist")
 
 	// Create matcher with just this rule
-	m, err := matcher.NewPortableRegexp([]*types.Rule{rumRule}, 0)
+	m, err := matcher.NewPortableRegexp([]*types.Rule{rumRule}, 0, nil)
 	require.NoError(t, err)
 
 	testCases := []struct {
@@ -104,7 +104,7 @@ func TestLaunchDarklyClientSideID_Detection(t *testing.T) {
 	require.NotNil(t, ldRule, "kingfisher.launchdarkly.2 rule should exist")
 
 	// Create matcher with just this rule
-	m, err := matcher.NewPortableRegexp([]*types.Rule{ldRule}, 0)
+	m, err := matcher.NewPortableRegexp([]*types.Rule{ldRule}, 0, nil)
 	require.NoError(t, err)
 
 	testCases := []struct {
@@ -181,7 +181,7 @@ func TestSentryDSN_Detection(t *testing.T) {
 	require.NotNil(t, dsnRule, "kingfisher.sentry.4 rule should exist")
 
 	// Create matcher with just this rule
-	m, err := matcher.NewPortableRegexp([]*types.Rule{dsnRule}, 0)
+	m, err := matcher.NewPortableRegexp([]*types.Rule{dsnRule}, 0, nil)
 	require.NoError(t, err)
 
 	testCases := []struct {

--- a/pkg/scanner/core.go
+++ b/pkg/scanner/core.go
@@ -150,6 +150,42 @@ func (c *Core) SetCanValidate(fn func(ruleID string) bool) {
 	matcher.SetCanValidate(c.matcher, fn)
 }
 
+// NewCoreWithRules creates a new Core scanner with pre-loaded rules.
+// This avoids JSON round-tripping when the caller already has []*types.Rule.
+func NewCoreWithRules(rules []*types.Rule, logger DebugLogger, warnFunc func(string, ...any)) (*Core, error) {
+	if logger == nil {
+		logger = NoopLogger{}
+	}
+
+	logger.Log("NewCoreWithRules starting with %d rules...", len(rules))
+
+	m, err := matcher.New(matcher.Config{
+		Rules:        rules,
+		ContextLines: 2,
+		WarnFunc:     warnFunc,
+	})
+	if err != nil {
+		logger.Log("matcher.New failed: %v", err)
+		return nil, err
+	}
+	logger.Log("Matcher created successfully")
+
+	s, err := store.New(store.Config{Path: ":memory:"})
+	if err != nil {
+		logger.Log("store.New failed: %v", err)
+		m.Close()
+		return nil, err
+	}
+	logger.Log("Store created successfully")
+
+	logger.Log("NewCoreWithRules complete")
+	return &Core{
+		matcher: m,
+		store:   s,
+		logger:  logger,
+	}, nil
+}
+
 // GetBuiltinRules returns the built-in rules (cached)
 func GetBuiltinRules() ([]*types.Rule, error) {
 	return loadBuiltinRulesCached()


### PR DESCRIPTION
## Summary

Three changes to support using Titus as an embedded Go library:

- **`WarnFunc` callback** on `matcher.Config`: per-instance control over regex warning output. When nil, warnings are silently discarded. When set, called with printf-style format+args for each regex timeout or error. The CLI passes a function that writes to stderr, preserving existing behavior.
- **`NewCoreWithRules()` constructor**: accepts pre-loaded `[]*types.Rule` directly, avoiding JSON round-tripping when the caller has already parsed and filtered rules. Also accepts an optional `warnFunc` for warning control.
- **Named capture group handling**: converts `(?P<name>)` and `(?<name>)` to non-capturing groups `(?:)` during Hyperscan preprocessing. Hyperscan doesn't support named captures, but since it's only used as a prefilter (regexp2 handles actual capture extraction), this preserves matching semantics while allowing these rules to use the fast Hyperscan path.

## Design

`WarnFunc` is a callback field on `matcher.Config`, threaded through `New()` into each matcher implementation as a `warnf` field. The 12 warning sites across `vectorscan.go`, `regexp_portable.go`, and `regexp.go` check `if m.warnf != nil` before calling, so the nil case has zero overhead.

This avoids a package-level global, keeping warning behavior per-instance and letting library consumers control verbosity independently.

## Test plan

- [x] Existing matcher tests pass (`go test ./pkg/matcher/...`)
- [x] CLI tests pass (`go test ./cmd/titus/...`)
- [x] Named capture group preprocessing test cases pass
- [x] `NewCoreWithRules` creates a functional scanner
- [x] CLI preserves existing stderr warning behavior