### PR TITLE
fix: use /v1/models endpoint for Anthropic API key validation

### DIFF
--- a/pkg/validator/validators/anthropic.yaml
+++ b/pkg/validator/validators/anthropic.yaml
@@ -6,14 +6,17 @@ validators:
 
   http:
     method: GET
-    url: "https://api.anthropic.com/v1/messages"
+    url: "https://api.anthropic.com/v1/models"
     auth:
       type: header
       secret_group: "token"
       header_name: "x-api-key"
+    headers:
+      - name: "anthropic-version"
+        value: "2023-06-01"
 
     # Success codes indicate valid API key
-    success_codes: [200, 400]  # 200 = valid + proper request, 400 = valid key but malformed request body
+    success_codes: [200]  # 200 = valid key, returns list of available models
 
     # Failure codes indicate invalid or unauthorized key
     failure_codes: [401, 403]


### PR DESCRIPTION
## Summary
- The Anthropic validator was using `GET /v1/messages` which returns HTTP 405 (Method Not Allowed) regardless of key validity, causing all validations to return `undetermined`
- Changed to `GET /v1/models` which correctly returns 200 for valid keys and 401 for invalid keys
- Added required `anthropic-version` header

## Test plan
- [x] Verify valid Anthropic key returns 200 from `/v1/models`
- [x] Verify invalid key returns 401
- [x] Run existing validator tests