### PR TITLE
feat(github): add --skip-forks flag to exclude forked repos

### DIFF
--- a/cmd/titus/github.go
+++ b/cmd/titus/github.go
@@ -22,6 +22,7 @@ var (
 	githubOutputFormat string
 	githubNoClone      bool
 	githubGit          bool
+	githubSkipForks    bool
 	githubRateLimit    float64
 )
 
@@ -72,6 +73,7 @@ func init() {
 	githubScanCmd.Flags().StringVar(&githubOutputFormat, "format", "human", "Output format: json, human")
 	githubScanCmd.Flags().BoolVar(&githubNoClone, "no-clone", false, "Fetch files via API instead of cloning (requires token, no git history)")
 	githubScanCmd.Flags().BoolVar(&githubGit, "git", false, "Scan full git history (slower; default scans only current files)")
+	githubScanCmd.Flags().BoolVar(&githubSkipForks, "skip-forks", false, "Skip forked repositories when scanning orgs or users")
 	githubScanCmd.Flags().Float64Var(&githubRateLimit, "rate-limit", 0, "Delay in seconds between repository clones (e.g., 2 or 0.5; 0 = no delay)")
 
 	githubCmd.Flags().StringVar(&githubToken, "token", "", "GitHub API token (or GITHUB_TOKEN env; optional for public repos)")
@@ -82,6 +84,7 @@ func init() {
 	githubCmd.Flags().StringVar(&githubOutputFormat, "format", "human", "Output format: json, human")
 	githubCmd.Flags().BoolVar(&githubNoClone, "no-clone", false, "Fetch files via API instead of cloning (requires token, no git history)")
 	githubCmd.Flags().BoolVar(&githubGit, "git", false, "Scan full git history (slower; default scans only current files)")
+	githubCmd.Flags().BoolVar(&githubSkipForks, "skip-forks", false, "Skip forked repositories when scanning orgs or users")
 	githubCmd.Flags().Float64Var(&githubRateLimit, "rate-limit", 0, "Delay in seconds between repository clones (e.g., 2 or 0.5; 0 = no delay)")
 
 	githubCmd.AddCommand(githubScanCmd)
@@ -136,12 +139,13 @@ func runGitHubScan(cmd *cobra.Command, args []string) error {
 	}
 
 	ghEnum, err := enum.NewGitHubEnumerator(enum.GitHubConfig{
-		Token:   token,
-		BaseURL: baseURL,
-		Owner:   owner,
-		Repo:    repo,
-		Org:     githubOrg,
-		User:    githubUser,
+		Token:     token,
+		BaseURL:   baseURL,
+		Owner:     owner,
+		Repo:      repo,
+		Org:       githubOrg,
+		User:      githubUser,
+		SkipForks: githubSkipForks,
 		Config: enum.Config{
 			MaxFileSize: 10 * 1024 * 1024,
 		},

--- a/pkg/enum/github.go
+++ b/pkg/enum/github.go
@@ -16,13 +16,14 @@ import (
 
 // GitHubConfig configures GitHub API enumeration.
 type GitHubConfig struct {
-	Token   string // GitHub API token (optional; unauthenticated if empty)
-	BaseURL string // GitHub Enterprise base URL (optional; defaults to github.com)
-	Owner   string // Repository owner (for single repo)
-	Repo    string // Repository name (for single repo)
-	Org     string // Organization name (list all org repos)
-	User    string // User name (list all user repos)
-	Config         // Embedded base config
+	Token     string // GitHub API token (optional; unauthenticated if empty)
+	BaseURL   string // GitHub Enterprise base URL (optional; defaults to github.com)
+	Owner     string // Repository owner (for single repo)
+	Repo      string // Repository name (for single repo)
+	Org       string // Organization name (list all org repos)
+	User      string // User name (list all user repos)
+	SkipForks bool   // Skip forked repositories when scanning orgs/users
+	Config           // Embedded base config
 }
 
 // GitHubEnumerator enumerates blobs from GitHub via API.
@@ -78,6 +79,9 @@ func (e *GitHubEnumerator) Enumerate(ctx context.Context, callback func(content 
 
 	// Enumerate each repository
 	for _, repo := range repos {
+		if e.config.SkipForks && repo.GetFork() {
+			continue
+		}
 		if err := e.enumerateRepo(ctx, repo, callback); err != nil {
 			return fmt.Errorf("enumerating %s: %w", repo.GetFullName(), err)
 		}
@@ -171,6 +175,9 @@ func (e *GitHubEnumerator) ListRepoURLs(ctx context.Context) ([]RepoInfo, error)
 
 	var urls []RepoInfo
 	for _, repo := range repos {
+		if e.config.SkipForks && repo.GetFork() {
+			continue
+		}
 		urls = append(urls, RepoInfo{
 			Name:          repo.GetFullName(),
 			CloneURL:      repo.GetCloneURL(),


### PR DESCRIPTION
## Summary
- Adds `--skip-forks` flag to `titus github` and `titus github scan` commands
- When set, forked repositories are excluded when scanning `--org` or `--user` targets
- Uses the GitHub API's existing fork metadata (`repo.GetFork()`), so no extra API calls are needed
- Works in both clone mode and `--no-clone` (API) mode

## Test plan
- [x] Tested on `praetorian-inc` org: 92 public repos, 17 forks correctly skipped, 75 scanned
- [x] Tested on a user account with mixed owned/forked repos: forks correctly excluded
- [x] Verified `go build ./...` compiles cleanly
- [x] Verified existing `TestGitHub*` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)