### PR TITLE
ci: migrate to centralized go-ci.yml reusable workflow (ENG-3081)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,45 +2,20 @@ name: CI
 
 on:
   push:
-    branches: [main, master]
+    branches: [main]
   pull_request:
-    branches: [main, master]
-
-concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
+    branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read
 
-env:
-  CGO_ENABLED: 0
-
 jobs:
-  build-and-test:
-    name: Build and Test (No CGO)
-    runs-on: ubuntu-22.04
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-    - name: Set up Go
-      uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
-      with:
-        go-version-file: 'go.mod'
-        cache: true
-
-    - name: Build
-      run: make build
-
-    - name: Run tests
-      run: make test
-
-    - name: Run vet
-      run: make vet
-
-    - name: Verify binary exists
-      run: |
-        test -x ./dist/titus || (echo "Binary not created" && exit 1)
-        ./dist/titus version || ./dist/titus --help
+  ci:
+    uses: praetorian-inc/public-workflows/.github/workflows/go-ci.yml@f89bda45e8073b1b6ac20198164de2b71ebf0c69  # v1.0.2
+    permissions:
+      contents: read
+    with:
+      build-cmd-path: ./cmd/titus
+      build-binary-name: titus
+    secrets: inherit

--- a/cmd/titus/explore.go
+++ b/cmd/titus/explore.go
@@ -36,7 +36,7 @@ func runExplore(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("loading datastore: %w", err)
 	}
-	defer model.Close()
+	defer func() { _ = model.Close() }()
 
 	p := tea.NewProgram(model, tea.WithAltScreen(), tea.WithMouseCellMotion())
 	if _, err := p.Run(); err != nil {

--- a/cmd/titus/github.go
+++ b/cmd/titus/github.go
@@ -106,8 +106,8 @@ func runGitHubScan(cmd *cobra.Command, args []string) error {
 	}
 
 	if token == "" {
-		fmt.Fprintf(cmd.ErrOrStderr(), "Note: No GitHub token provided. Using unauthenticated access (60 requests/hour, public repos only).\n")
-		fmt.Fprintf(cmd.ErrOrStderr(), "Set GITHUB_TOKEN or use --token for higher rate limits and private repo access.\n\n")
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Note: No GitHub token provided. Using unauthenticated access (60 requests/hour, public repos only).\n")
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Set GITHUB_TOKEN or use --token for higher rate limits and private repo access.\n\n")
 	}
 
 	if baseURL != "" {
@@ -116,9 +116,9 @@ func runGitHubScan(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("invalid --url: %w", err)
 		}
 		if insecure && token != "" {
-			fmt.Fprintf(cmd.ErrOrStderr(), "WARNING: Using HTTP with an API token. Your token will be sent in plaintext.\n")
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "WARNING: Using HTTP with an API token. Your token will be sent in plaintext.\n")
 		}
-		fmt.Fprintf(cmd.ErrOrStderr(), "Using GitHub Enterprise: %s\n", baseURL)
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Using GitHub Enterprise: %s\n", baseURL)
 	}
 
 	var owner, repo string
@@ -171,7 +171,7 @@ func runGitHubScan(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("creating matcher: %w", err)
 	}
-	defer m.Close()
+	defer func() { _ = m.Close() }()
 
 	s, err := store.New(store.Config{
 		Path: githubOutputPath,
@@ -179,7 +179,7 @@ func runGitHubScan(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("creating store: %w", err)
 	}
-	defer s.Close()
+	defer func() { _ = s.Close() }()
 
 	for _, r := range rules {
 		if err := s.AddRule(r); err != nil {
@@ -193,13 +193,13 @@ func runGitHubScan(cmd *cobra.Command, args []string) error {
 	if githubNoClone {
 		enumerator = ghEnum
 	} else {
-		fmt.Fprintf(cmd.ErrOrStderr(), "Enumerating repositories...\n")
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Enumerating repositories...\n")
 		repos, err := ghEnum.ListRepoURLs(ctx)
 		if err != nil {
 			return fmt.Errorf("listing repositories: %w", err)
 		}
 
-		fmt.Fprintf(cmd.ErrOrStderr(), "Found %d repositories to scan\n\n", len(repos))
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Found %d repositories to scan\n\n", len(repos))
 
 		cloneEnum := enum.NewCloneEnumerator(repos, enum.Config{
 			MaxFileSize: 10 * 1024 * 1024,
@@ -275,8 +275,8 @@ func runGitHubScan(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("scanning GitHub: %w", err)
 	}
 
-	fmt.Fprintf(cmd.OutOrStdout(), "GitHub scan complete: %d matches, %d findings\n", matchCount, findingCount)
-	fmt.Fprintf(cmd.OutOrStdout(), "Results stored in: %s\n", githubOutputPath)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "GitHub scan complete: %d matches, %d findings\n", matchCount, findingCount)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Results stored in: %s\n", githubOutputPath)
 
 	if githubOutputFormat == "json" {
 		matches, err := s.GetAllMatches()

--- a/cmd/titus/gitlab.go
+++ b/cmd/titus/gitlab.go
@@ -82,8 +82,8 @@ func runGitLabScan(cmd *cobra.Command, args []string) error {
 	}
 
 	if token == "" {
-		fmt.Fprintf(cmd.ErrOrStderr(), "Note: No GitLab token provided. Using unauthenticated access (public projects only).\n")
-		fmt.Fprintf(cmd.ErrOrStderr(), "Set GITLAB_TOKEN or use --token for private project access.\n\n")
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Note: No GitLab token provided. Using unauthenticated access (public projects only).\n")
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Set GITLAB_TOKEN or use --token for private project access.\n\n")
 	}
 
 	if gitlabBaseURL != "" {
@@ -92,7 +92,7 @@ func runGitLabScan(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("invalid --url: %w", err)
 		}
 		if insecure && token != "" {
-			fmt.Fprintf(cmd.ErrOrStderr(), "WARNING: Using HTTP with an API token. Your token will be sent in plaintext.\n")
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "WARNING: Using HTTP with an API token. Your token will be sent in plaintext.\n")
 		}
 	}
 
@@ -141,13 +141,13 @@ func runGitLabScan(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("creating matcher: %w", err)
 	}
-	defer m.Close()
+	defer func() { _ = m.Close() }()
 
 	s, err := store.New(store.Config{Path: gitlabOutputPath})
 	if err != nil {
 		return fmt.Errorf("creating store: %w", err)
 	}
-	defer s.Close()
+	defer func() { _ = s.Close() }()
 
 	for _, r := range rules {
 		if err := s.AddRule(r); err != nil {
@@ -161,13 +161,13 @@ func runGitLabScan(cmd *cobra.Command, args []string) error {
 	if gitlabNoClone {
 		enumerator = glEnum
 	} else {
-		fmt.Fprintf(cmd.ErrOrStderr(), "Enumerating projects...\n")
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Enumerating projects...\n")
 		projects, err := glEnum.ListProjectURLs(ctx)
 		if err != nil {
 			return fmt.Errorf("listing projects: %w", err)
 		}
 
-		fmt.Fprintf(cmd.ErrOrStderr(), "Found %d projects to scan\n\n", len(projects))
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Found %d projects to scan\n\n", len(projects))
 
 		cloneEnum := enum.NewCloneEnumerator(projects, enum.Config{
 			MaxFileSize: 10 * 1024 * 1024,
@@ -243,8 +243,8 @@ func runGitLabScan(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("scanning: %w", err)
 	}
 
-	fmt.Fprintf(cmd.OutOrStdout(), "GitLab scan complete: %d matches, %d findings\n", matchCount, findingCount)
-	fmt.Fprintf(cmd.OutOrStdout(), "Results stored in: %s\n", gitlabOutputPath)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "GitLab scan complete: %d matches, %d findings\n", matchCount, findingCount)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Results stored in: %s\n", gitlabOutputPath)
 
 	if gitlabOutputFormat == "json" {
 		matches, err := s.GetAllMatches()

--- a/cmd/titus/report.go
+++ b/cmd/titus/report.go
@@ -143,13 +143,13 @@ func aggregateSummary(findings []*types.Finding, matchesByFinding map[string][]*
 
 func outputSummaryHuman(out io.Writer, summary summaryResult, colorEnabled bool) error {
 	if summary.TotalFindings == 0 {
-		fmt.Fprintf(out, "No findings.\n")
+		_, _ = fmt.Fprintf(out, "No findings.\n")
 		return nil
 	}
 
 	s := newStyles(colorEnabled)
 
-	fmt.Fprintf(out, "%s %d findings, %d matches\n\n",
+	_, _ = fmt.Fprintf(out, "%s %d findings, %d matches\n\n",
 		s.heading.Sprint("Total:"), summary.TotalFindings, summary.TotalMatches)
 
 	// Find longest rule name for column width
@@ -161,18 +161,18 @@ func outputSummaryHuman(out io.Writer, summary summaryResult, colorEnabled bool)
 	}
 
 	// Print header
-	fmt.Fprintf(out, " %s   %s   %s \n",
+	_, _ = fmt.Fprintf(out, " %s   %s   %s \n",
 		s.heading.Sprintf("%-*s", maxNameLen, "Rule"),
 		s.heading.Sprint("Findings"),
 		s.heading.Sprint("Matches"))
 
 	// Print separator line
 	separatorLen := maxNameLen + 3 + 10 + 3 + 8
-	fmt.Fprintf(out, "%s\n", strings.Repeat("─", separatorLen))
+	_, _ = fmt.Fprintf(out, "%s\n", strings.Repeat("─", separatorLen))
 
 	// Print data rows
 	for _, r := range summary.Rules {
-		fmt.Fprintf(out, " %s   %8d   %7d \n",
+		_, _ = fmt.Fprintf(out, " %s   %8d   %7d \n",
 			s.ruleName.Sprintf("%-*s", maxNameLen, r.RuleName), r.Findings, r.Matches)
 	}
 
@@ -221,7 +221,7 @@ func runReport(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("opening datastore: %w", err)
 	}
-	defer s.Close()
+	defer func() { _ = s.Close() }()
 
 	// Get findings
 	findings, err := s.GetFindings()
@@ -281,7 +281,7 @@ func runSummary(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("opening datastore: %w", err)
 	}
-	defer s.Close()
+	defer func() { _ = s.Close() }()
 
 	findings, err := s.GetFindings()
 	if err != nil {
@@ -547,7 +547,7 @@ func outputReportHuman(cmd *cobra.Command, findings []*types.Finding, matches []
 	if err != nil {
 		return fmt.Errorf("opening datastore for provenance: %w", err)
 	}
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	// Build content-based finding-to-match map
 	matchesByFinding := buildFindingMatchMap(findings, matches, ruleMap)
@@ -557,7 +557,7 @@ func outputReportHuman(cmd *cobra.Command, findings []*types.Finding, matches []
 	// Output each finding in noseyparker format with colors
 	for i, f := range findings {
 		// Finding header - "Finding N/M" in findingHeading style, "(id xyz)" with ID in id style
-		fmt.Fprintf(out, "%s (%s %s)\n",
+		_, _ = fmt.Fprintf(out, "%s (%s %s)\n",
 			s.findingHeading.Sprintf("Finding %d/%d", i+1, totalFindings),
 			s.heading.Sprint("id"),
 			s.id.Sprint(f.ID))
@@ -567,11 +567,11 @@ func outputReportHuman(cmd *cobra.Command, findings []*types.Finding, matches []
 		if r, ok := ruleMap[f.RuleID]; ok {
 			ruleName = r.Name
 		}
-		fmt.Fprintf(out, "%s %s\n", s.heading.Sprint("Rule:"), s.ruleName.Sprint(ruleName))
+		_, _ = fmt.Fprintf(out, "%s %s\n", s.heading.Sprint("Rule:"), s.ruleName.Sprint(ruleName))
 
 		// Capture groups - "Group N:" in heading style, value in match style
 		for j, group := range f.Groups {
-			fmt.Fprintf(out, "%s %s\n",
+			_, _ = fmt.Fprintf(out, "%s %s\n",
 				s.heading.Sprintf("Group %d:", j+1),
 				s.match.Sprint(string(group)))
 		}
@@ -579,13 +579,13 @@ func outputReportHuman(cmd *cobra.Command, findings []*types.Finding, matches []
 		// Matches for this finding
 		findingMatches := matchesByFinding[f.ID]
 		if len(findingMatches) > 3 {
-			fmt.Fprintf(out, "Showing 3/%d matches:\n", len(findingMatches))
+			_, _ = fmt.Fprintf(out, "Showing 3/%d matches:\n", len(findingMatches))
 			findingMatches = findingMatches[:3]
 		}
 
 		for k, match := range findingMatches {
 			// Match header - "Match N/M" in heading style, "(id xyz)" with ID in id style
-			fmt.Fprintf(out, "\n    %s (%s %s)\n",
+			_, _ = fmt.Fprintf(out, "\n    %s (%s %s)\n",
 				s.heading.Sprintf("Match %d/%d", k+1, len(matchesByFinding[f.ID])),
 				s.heading.Sprint("id"),
 				s.id.Sprint(match.StructuralID))
@@ -593,24 +593,24 @@ func outputReportHuman(cmd *cobra.Command, findings []*types.Finding, matches []
 			// File path from provenance - "File:" in heading style, path in metadata style
 			prov, err := store.GetProvenance(match.BlobID)
 			if err == nil && prov != nil {
-				fmt.Fprintf(out, "    %s %s\n",
+				_, _ = fmt.Fprintf(out, "    %s %s\n",
 					s.heading.Sprint("File:"),
 					s.metadata.Sprint(prov.Path()))
 				if gp, ok := prov.(types.GitProvenance); ok && gp.Commit != nil && !gp.Commit.CommitterTimestamp.IsZero() {
-					fmt.Fprintf(out, "    %s %s\n",
+					_, _ = fmt.Fprintf(out, "    %s %s\n",
 						s.heading.Sprint("Date:"),
 						s.metadata.Sprint(gp.Commit.CommitterTimestamp.Format("2006-01-02 15:04:05")))
 				}
 			}
 
 			// Blob info - "Blob:" in heading style, ID in metadata style
-			fmt.Fprintf(out, "    %s %s\n",
+			_, _ = fmt.Fprintf(out, "    %s %s\n",
 				s.heading.Sprint("Blob:"),
 				s.metadata.Sprint(match.BlobID.Hex()))
 
 			// Line info - "Lines:" in heading style
 			if match.Location.Source.Start.Line > 0 {
-				fmt.Fprintf(out, "    %s %d:%d-%d:%d\n",
+				_, _ = fmt.Fprintf(out, "    %s %d:%d-%d:%d\n",
 					s.heading.Sprint("Lines:"),
 					match.Location.Source.Start.Line, match.Location.Source.Start.Column,
 					match.Location.Source.End.Line, match.Location.Source.End.Column)
@@ -619,7 +619,7 @@ func outputReportHuman(cmd *cobra.Command, findings []*types.Finding, matches []
 			// Context snippet with colored matching portion
 			parts := formatSnippetWithParts(match.Snippet.Before, match.Snippet.Matching, match.Snippet.After, 500)
 			if parts.prefix != "" || parts.before != "" || parts.matching != "" || parts.after != "" || parts.suffix != "" {
-				fmt.Fprintf(out, "\n        %s%s%s%s%s\n",
+				_, _ = fmt.Fprintf(out, "\n        %s%s%s%s%s\n",
 					parts.prefix,
 					parts.before,
 					s.match.Sprint(parts.matching),
@@ -628,7 +628,7 @@ func outputReportHuman(cmd *cobra.Command, findings []*types.Finding, matches []
 			}
 		}
 
-		fmt.Fprintf(out, "\n\n")
+		_, _ = fmt.Fprintf(out, "\n\n")
 	}
 
 	return nil

--- a/cmd/titus/rules.go
+++ b/cmd/titus/rules.go
@@ -95,10 +95,10 @@ func outputRulesJSON(cmd *cobra.Command, rules []*types.Rule) error {
 
 func outputRulesTable(cmd *cobra.Command, rules []*types.Rule) error {
 	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
-	defer w.Flush()
+	defer func() { _ = w.Flush() }()
 
-	fmt.Fprintf(w, "ID\tName\tCategories\n")
-	fmt.Fprintf(w, "--\t----\t----------\n")
+	_, _ = fmt.Fprintf(w, "ID\tName\tCategories\n")
+	_, _ = fmt.Fprintf(w, "--\t----\t----------\n")
 
 	for _, r := range rules {
 		categories := ""
@@ -108,7 +108,7 @@ func outputRulesTable(cmd *cobra.Command, rules []*types.Rule) error {
 				categories += fmt.Sprintf(" (+%d)", len(r.Categories)-1)
 			}
 		}
-		fmt.Fprintf(w, "%s\t%s\t%s\n", r.ID, r.Name, categories)
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\n", r.ID, r.Name, categories)
 	}
 
 	return nil

--- a/cmd/titus/scan.go
+++ b/cmd/titus/scan.go
@@ -141,7 +141,7 @@ func runScan(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("creating matcher: %w", err)
 	}
-	defer m.Close()
+	defer func() { _ = m.Close() }()
 
 	// Create store (memory or datastore)
 	s, ds, err := openScanStore(scanOutputPath, scanStoreBlobs)
@@ -149,9 +149,9 @@ func runScan(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if ds != nil {
-		defer ds.Close()
+		defer func() { _ = ds.Close() }()
 	} else {
-		defer s.Close()
+		defer func() { _ = s.Close() }()
 	}
 
 	// Store rules for foreign key constraints
@@ -406,13 +406,13 @@ func printScanStats(cmd *cobra.Command, format, outputPath string, totalBytes, b
 		totalBytes, blobCount, int(duration.Seconds()), speed, newMatches, matchCount)
 
 	if format == "json" || format == "sarif" {
-		fmt.Fprint(cmd.ErrOrStderr(), statsLine)
+		_, _ = fmt.Fprint(cmd.ErrOrStderr(), statsLine)
 		if outputPath != ":memory:" {
-			fmt.Fprintf(cmd.ErrOrStderr(), "Results stored in: %s/datastore.db\n\n", outputPath)
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Results stored in: %s/datastore.db\n\n", outputPath)
 		}
 	} else {
-		fmt.Fprint(cmd.OutOrStdout(), statsLine)
-		fmt.Fprintf(cmd.OutOrStdout(), "\n")
+		_, _ = fmt.Fprint(cmd.OutOrStdout(), statsLine)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\n")
 	}
 }
 
@@ -592,7 +592,7 @@ func runRepoScan(cmd *cobra.Command, rt repoTarget) error {
 	}
 
 	if token == "" {
-		fmt.Fprintf(cmd.ErrOrStderr(), "Note: No %s token provided. Using unauthenticated access (public repos only).\n\n", rt.Platform)
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Note: No %s token provided. Using unauthenticated access (public repos only).\n\n", rt.Platform)
 	}
 
 	// Build clone URL
@@ -638,7 +638,7 @@ func runRepoScan(cmd *cobra.Command, rt repoTarget) error {
 	if err != nil {
 		return fmt.Errorf("creating matcher: %w", err)
 	}
-	defer m.Close()
+	defer func() { _ = m.Close() }()
 
 	// Create store
 	s, ds, err := openScanStore(scanOutputPath, scanStoreBlobs)
@@ -646,9 +646,9 @@ func runRepoScan(cmd *cobra.Command, rt repoTarget) error {
 		return err
 	}
 	if ds != nil {
-		defer ds.Close()
+		defer func() { _ = ds.Close() }()
 	} else {
-		defer s.Close()
+		defer func() { _ = s.Close() }()
 	}
 
 	for _, r := range rules {
@@ -810,7 +810,7 @@ func runRepoScan(cmd *cobra.Command, rt repoTarget) error {
 // outputNoseyParkerSummary outputs findings in noseyparker table format
 func outputNoseyParkerSummary(cmd *cobra.Command, findings []*types.Finding, ruleMap map[string]*types.Rule) error {
 	if len(findings) == 0 {
-		fmt.Fprintf(cmd.OutOrStdout(), "No findings.\n")
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "No findings.\n")
 		return nil
 	}
 
@@ -845,20 +845,20 @@ func outputNoseyParkerSummary(cmd *cobra.Command, findings []*types.Finding, rul
 	}
 
 	// Print header
-	fmt.Fprintf(cmd.OutOrStdout(), " %-*s   Findings   Matches \n", maxNameLen, "Rule")
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), " %-*s   Findings   Matches \n", maxNameLen, "Rule")
 
 	// Print separator line using box-drawing character
 	separatorLen := maxNameLen + 3 + 10 + 3 + 8
-	fmt.Fprintf(cmd.OutOrStdout(), "%s\n", strings.Repeat("─", separatorLen))
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s\n", strings.Repeat("─", separatorLen))
 
 	// Print data rows
 	for _, stats := range statsMap {
-		fmt.Fprintf(cmd.OutOrStdout(), " %-*s   %8d   %7d \n",
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), " %-*s   %8d   %7d \n",
 			maxNameLen, stats.name, stats.findings, stats.matches)
 	}
 
 	// Print footer
-	fmt.Fprintf(cmd.OutOrStdout(), "\nRun the `report` command next to show finding details.\n")
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\nRun the `report` command next to show finding details.\n")
 
 	return nil
 }
@@ -877,20 +877,20 @@ func outputFindings(cmd *cobra.Command, findings []*types.Finding) error {
 		return encoder.Encode(findings)
 	case "human":
 		if len(findings) == 0 {
-			fmt.Fprintf(cmd.OutOrStdout(), "\nNo findings.\n")
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\nNo findings.\n")
 			return nil
 		}
 
-		fmt.Fprintf(cmd.OutOrStdout(), "\nFindings:\n")
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\nFindings:\n")
 		for i, f := range findings {
-			fmt.Fprintf(cmd.OutOrStdout(), "%d. Rule: %s", i+1, f.RuleID)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%d. Rule: %s", i+1, f.RuleID)
 
 			// Show validation status if available
 			if len(f.Matches) > 0 && f.Matches[0].ValidationResult != nil {
 				vr := f.Matches[0].ValidationResult
-				fmt.Fprintf(cmd.OutOrStdout(), " [%s]", vr.Status)
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), " [%s]", vr.Status)
 			}
-			fmt.Fprintln(cmd.OutOrStdout())
+			_, _ = fmt.Fprintln(cmd.OutOrStdout())
 		}
 		return nil
 	default:

--- a/cmd/titus/serve_test.go
+++ b/cmd/titus/serve_test.go
@@ -46,7 +46,7 @@ func TestServeCommand_Integration(t *testing.T) {
 	// Send close command
 	_, err := pw.Write([]byte(`{"type":"close","payload":{}}` + "\n"))
 	require.NoError(t, err)
-	pw.Close()
+	_ = pw.Close()
 
 	select {
 	case err := <-done:

--- a/cmd/titus/version.go
+++ b/cmd/titus/version.go
@@ -17,6 +17,6 @@ var versionCmd = &cobra.Command{
 }
 
 func runVersion(cmd *cobra.Command, args []string) error {
-	fmt.Fprintf(cmd.OutOrStdout(), "Titus %s (Go port of NoseyParker)\n", version)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Titus %s (Go port of NoseyParker)\n", version)
 	return nil
 }

--- a/pkg/datastore/blobs.go
+++ b/pkg/datastore/blobs.go
@@ -34,7 +34,7 @@ func (b *BlobStore) Store(content []byte) (types.BlobID, error) {
 	}
 
 	if err := os.Rename(tempPath, path); err != nil {
-		os.Remove(tempPath) // Clean up temp file on failure
+		_ = os.Remove(tempPath) // Clean up temp file on failure
 		return types.BlobID{}, fmt.Errorf("renaming blob: %w", err)
 	}
 

--- a/pkg/enum/clone.go
+++ b/pkg/enum/clone.go
@@ -68,7 +68,7 @@ func (e *CloneEnumerator) cloneAndScan(ctx context.Context, repo RepoInfo, callb
 	if err != nil {
 		return fmt.Errorf("creating temp dir: %w", err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	clonePath := filepath.Join(tmpDir, "repo")
 

--- a/pkg/enum/clone_test.go
+++ b/pkg/enum/clone_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/praetorian-inc/titus/pkg/types"
@@ -66,9 +67,12 @@ func TestCloneEnumerator_LocalRepo(t *testing.T) {
 	}
 	e := NewCloneEnumerator(repos, Config{MaxFileSize: 10 * 1024 * 1024})
 
+	var mu sync.Mutex
 	var blobs []string
 	var provenances []types.Provenance
 	err := e.Enumerate(context.Background(), func(content []byte, blobID types.BlobID, prov types.Provenance) error {
+		mu.Lock()
+		defer mu.Unlock()
 		blobs = append(blobs, string(content))
 		provenances = append(provenances, prov)
 		return nil
@@ -113,8 +117,11 @@ func TestCloneEnumerator_GitMode(t *testing.T) {
 	e := NewCloneEnumerator(repos, Config{MaxFileSize: 10 * 1024 * 1024})
 	e.Git = true
 
+	var mu sync.Mutex
 	var blobs []string
 	err := e.Enumerate(context.Background(), func(content []byte, blobID types.BlobID, prov types.Provenance) error {
+		mu.Lock()
+		defer mu.Unlock()
 		blobs = append(blobs, string(content))
 		// In git mode, provenance should be GitProvenance
 		gp, ok := prov.(types.GitProvenance)

--- a/pkg/enum/extractor.go
+++ b/pkg/enum/extractor.go
@@ -125,7 +125,7 @@ func extractXLSX(content []byte) ([]ExtractedContent, error) {
 				continue
 			}
 			data, err := io.ReadAll(rc)
-			rc.Close()
+			_ = rc.Close()
 			if err != nil {
 				continue
 			}
@@ -146,7 +146,7 @@ func extractXLSX(content []byte) ([]ExtractedContent, error) {
 				continue
 			}
 			data, err := io.ReadAll(rc)
-			rc.Close()
+			_ = rc.Close()
 			if err != nil {
 				continue
 			}
@@ -182,7 +182,7 @@ func extractDOCX(content []byte) ([]ExtractedContent, error) {
 				continue
 			}
 			data, err := io.ReadAll(rc)
-			rc.Close()
+			_ = rc.Close()
 			if err != nil {
 				continue
 			}
@@ -218,7 +218,7 @@ func extractPPTX(content []byte) ([]ExtractedContent, error) {
 				continue
 			}
 			data, err := io.ReadAll(rc)
-			rc.Close()
+			_ = rc.Close()
 			if err != nil {
 				continue
 			}
@@ -243,8 +243,8 @@ func extractPDF(content []byte) ([]ExtractedContent, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temp file: %w", err)
 	}
-	defer os.Remove(tmpFile.Name())
-	defer tmpFile.Close()
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
+	defer func() { _ = tmpFile.Close() }()
 
 	// Write the PDF content to the temp file
 	if _, err := tmpFile.Write(content); err != nil {
@@ -252,14 +252,14 @@ func extractPDF(content []byte) ([]ExtractedContent, error) {
 	}
 
 	// Close the file so pdf.Open can read it
-	tmpFile.Close()
+	_ = tmpFile.Close()
 
 	// Open the PDF file
 	f, r, err := pdf.Open(tmpFile.Name())
 	if err != nil {
 		return nil, fmt.Errorf("failed to open PDF: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	// Extract text from all pages
 	var text strings.Builder
@@ -334,7 +334,7 @@ func extractTar(content []byte, isGzipped bool, state *extractState) ([]Extracte
 		if err != nil {
 			return nil, fmt.Errorf("failed to open gzip: %w", err)
 		}
-		defer gzr.Close()
+		defer func() { _ = gzr.Close() }()
 		reader = gzr
 	}
 
@@ -483,7 +483,7 @@ func extractZIPWithState(content []byte, state *extractState) ([]ExtractedConten
 			continue
 		}
 		data, err := io.ReadAll(rc)
-		rc.Close()
+		_ = rc.Close()
 		if err != nil {
 			continue
 		}
@@ -559,7 +559,7 @@ func extractOpenDocument(content []byte) ([]ExtractedContent, error) {
 				continue
 			}
 			data, err := io.ReadAll(rc)
-			rc.Close()
+			_ = rc.Close()
 			if err != nil {
 				continue
 			}
@@ -624,19 +624,19 @@ func extractSQLite(content []byte, state *extractState) ([]ExtractedContent, err
 	if err != nil {
 		return nil, err
 	}
-	defer os.Remove(tmpFile.Name())
-	defer tmpFile.Close()
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
+	defer func() { _ = tmpFile.Close() }()
 
 	if _, err := tmpFile.Write(content); err != nil {
 		return nil, err
 	}
-	tmpFile.Close()
+	_ = tmpFile.Close()
 
 	db, err := sql.Open("sqlite", tmpFile.Name())
 	if err != nil {
 		return nil, err
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	var text strings.Builder
 
@@ -645,7 +645,7 @@ func extractSQLite(content []byte, state *extractState) ([]ExtractedContent, err
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var tables []string
 	for rows.Next() {
@@ -685,7 +685,7 @@ func extractSQLite(content []byte, state *extractState) ([]ExtractedContent, err
 			}
 			text.WriteString("\n")
 		}
-		rows.Close()
+		_ = rows.Close()
 	}
 
 	result := text.String()
@@ -722,7 +722,7 @@ func extract7z(content []byte, state *extractState) ([]ExtractedContent, error) 
 			continue
 		}
 		data, err := io.ReadAll(rc)
-		rc.Close()
+		_ = rc.Close()
 		if err != nil {
 			continue
 		}

--- a/pkg/enum/extractor_test.go
+++ b/pkg/enum/extractor_test.go
@@ -704,14 +704,14 @@ func buildSQLiteWithRows(t *testing.T, n int) []byte {
 		t.Fatalf("failed to create temp file: %v", err)
 	}
 	tmpPath := tmpFile.Name()
-	tmpFile.Close()
-	t.Cleanup(func() { os.Remove(tmpPath) })
+	_ = tmpFile.Close()
+	t.Cleanup(func() { _ = os.Remove(tmpPath) })
 
 	db, err := sql.Open("sqlite", tmpPath)
 	if err != nil {
 		t.Fatalf("failed to open sqlite: %v", err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	if _, err := db.Exec(`CREATE TABLE secrets (val TEXT)`); err != nil {
 		t.Fatalf("failed to create table: %v", err)
@@ -721,7 +721,7 @@ func buildSQLiteWithRows(t *testing.T, n int) []byte {
 			t.Fatalf("failed to insert row %d: %v", i, err)
 		}
 	}
-	db.Close()
+	_ = db.Close()
 
 	content, err := os.ReadFile(tmpPath)
 	if err != nil {

--- a/pkg/enum/filesystem_test.go
+++ b/pkg/enum/filesystem_test.go
@@ -361,7 +361,7 @@ func TestFilesystemEnumerator_CurrentDirectory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get current directory: %v", err)
 	}
-	defer os.Chdir(originalDir)
+	defer func() { _ = os.Chdir(originalDir) }()
 
 	if err := os.Chdir(tmpDir); err != nil {
 		t.Fatalf("failed to change to temp directory: %v", err)

--- a/pkg/enum/git_native.go
+++ b/pkg/enum/git_native.go
@@ -137,7 +137,7 @@ func (e *GitEnumerator) streamBlobContentsWithMeta(ctx context.Context, blobs []
 		if i%1000 == 0 {
 			select {
 			case <-ctx.Done():
-				stdin.Close()
+				_ = stdin.Close()
 				_ = cmd.Wait()
 				return ctx.Err()
 			default:
@@ -146,7 +146,7 @@ func (e *GitEnumerator) streamBlobContentsWithMeta(ctx context.Context, blobs []
 
 		hexStr := hex.EncodeToString(blob.hash[:])
 		if _, err := fmt.Fprintf(stdin, "%s\n", hexStr); err != nil {
-			stdin.Close()
+			_ = stdin.Close()
 			_ = cmd.Wait()
 			if ctx.Err() != nil {
 				return ctx.Err()
@@ -157,7 +157,7 @@ func (e *GitEnumerator) streamBlobContentsWithMeta(ctx context.Context, blobs []
 		// Read response header: "<hash> <type> <size>\n"
 		headerLine, err := reader.ReadString('\n')
 		if err != nil {
-			stdin.Close()
+			_ = stdin.Close()
 			_ = cmd.Wait()
 			if ctx.Err() != nil {
 				return ctx.Err()
@@ -175,7 +175,7 @@ func (e *GitEnumerator) streamBlobContentsWithMeta(ctx context.Context, blobs []
 		objType := parts[1]
 		size, err := strconv.ParseInt(parts[2], 10, 64)
 		if err != nil {
-			stdin.Close()
+			_ = stdin.Close()
 			_ = cmd.Wait()
 			return fmt.Errorf("git cat-file: parse size %q: %w", parts[2], err)
 		}
@@ -183,7 +183,7 @@ func (e *GitEnumerator) streamBlobContentsWithMeta(ctx context.Context, blobs []
 		// Non-blob objects: discard content + trailing newline.
 		if objType != "blob" {
 			if _, err := io.CopyN(io.Discard, reader, size+1); err != nil {
-				stdin.Close()
+				_ = stdin.Close()
 				_ = cmd.Wait()
 				if ctx.Err() != nil {
 					return ctx.Err()
@@ -196,7 +196,7 @@ func (e *GitEnumerator) streamBlobContentsWithMeta(ctx context.Context, blobs []
 		// Oversized blobs: discard.
 		if e.config.MaxFileSize > 0 && size > e.config.MaxFileSize {
 			if _, err := io.CopyN(io.Discard, reader, size+1); err != nil {
-				stdin.Close()
+				_ = stdin.Close()
 				_ = cmd.Wait()
 				if ctx.Err() != nil {
 					return ctx.Err()
@@ -209,7 +209,7 @@ func (e *GitEnumerator) streamBlobContentsWithMeta(ctx context.Context, blobs []
 		// Read blob content.
 		content := make([]byte, size)
 		if _, err := io.ReadFull(reader, content); err != nil {
-			stdin.Close()
+			_ = stdin.Close()
 			_ = cmd.Wait()
 			if ctx.Err() != nil {
 				return ctx.Err()
@@ -219,7 +219,7 @@ func (e *GitEnumerator) streamBlobContentsWithMeta(ctx context.Context, blobs []
 
 		// Consume trailing newline.
 		if _, err := reader.ReadByte(); err != nil {
-			stdin.Close()
+			_ = stdin.Close()
 			_ = cmd.Wait()
 			if ctx.Err() != nil {
 				return ctx.Err()
@@ -242,13 +242,13 @@ func (e *GitEnumerator) streamBlobContentsWithMeta(ctx context.Context, blobs []
 		}
 
 		if err := callback(content, blobID, prov); err != nil {
-			stdin.Close()
+			_ = stdin.Close()
 			_ = cmd.Wait()
 			return err
 		}
 	}
 
-	stdin.Close()
+	_ = stdin.Close()
 
 	if err := cmd.Wait(); err != nil {
 		if ctx.Err() != nil {

--- a/pkg/enum/git_native_test.go
+++ b/pkg/enum/git_native_test.go
@@ -300,7 +300,7 @@ func TestNativeGitEnumerator_MultipleCommits(t *testing.T) {
 
 	// Commit 3: modify file1, delete file2
 	writeFile(t, filepath.Join(tmpDir, "file1.txt"), "content1-modified")
-	os.Remove(filepath.Join(tmpDir, "file2.txt"))
+	_ = os.Remove(filepath.Join(tmpDir, "file2.txt"))
 	gitAddCommit(t, tmpDir, "Commit 3")
 
 	config := Config{Root: tmpDir}

--- a/pkg/enum/git_test.go
+++ b/pkg/enum/git_test.go
@@ -653,7 +653,7 @@ func TestGitEnumerator_WalkAll_MultipleBranches(t *testing.T) {
 	if err := cmd.Run(); err != nil {
 		cmd = exec.Command("git", "checkout", "main")
 		cmd.Dir = tmpDir
-		cmd.Run() // Ignore error - one should work
+		_ = cmd.Run() // Ignore error - one should work
 	}
 
 	// Enumerate with WalkAll=true (should see both branches)
@@ -692,10 +692,10 @@ func TestGitEnumerator_DoesNotApplyIgnorePatterns(t *testing.T) {
 	}
 	cmd = exec.Command("git", "config", "user.email", "test@example.com")
 	cmd.Dir = tmpDir
-	cmd.Run()
+	_ = cmd.Run()
 	cmd = exec.Command("git", "config", "user.name", "Test User")
 	cmd.Dir = tmpDir
-	cmd.Run()
+	_ = cmd.Run()
 
 	// Create a file that matches default ignore patterns
 	if err := os.WriteFile(filepath.Join(tmpDir, "package-lock.json"), []byte(`{"lockfileVersion": 3}`), 0644); err != nil {
@@ -707,10 +707,10 @@ func TestGitEnumerator_DoesNotApplyIgnorePatterns(t *testing.T) {
 
 	cmd = exec.Command("git", "add", ".")
 	cmd.Dir = tmpDir
-	cmd.Run()
+	_ = cmd.Run()
 	cmd = exec.Command("git", "commit", "-m", "Add files")
 	cmd.Dir = tmpDir
-	cmd.Run()
+	_ = cmd.Run()
 
 	// Ignore patterns are NOT applied to git history — see git_native_test.go
 	// for rationale (git rev-list dedup makes ignore unsafe).

--- a/pkg/enum/github.go
+++ b/pkg/enum/github.go
@@ -144,25 +144,38 @@ func (e *GitHubEnumerator) listOrgRepos(ctx context.Context) ([]*github.Reposito
 
 // listUserRepos lists all repositories for a user.
 func (e *GitHubEnumerator) listUserRepos(ctx context.Context) ([]*github.Repository, error) {
-	opts := &github.RepositoryListOptions{
-		ListOptions: github.ListOptions{PerPage: 100},
-	}
-
 	var allRepos []*github.Repository
-	for {
-		repos, resp, err := e.client.Repositories.List(ctx, e.config.User, opts)
-		if err != nil {
-			return nil, fmt.Errorf("listing user repositories: %w", err)
+	if e.config.User != "" {
+		opts := &github.RepositoryListByUserOptions{
+			ListOptions: github.ListOptions{PerPage: 100},
 		}
-
-		allRepos = append(allRepos, repos...)
-
-		if resp.NextPage == 0 {
-			break
+		for {
+			repos, resp, err := e.client.Repositories.ListByUser(ctx, e.config.User, opts)
+			if err != nil {
+				return nil, fmt.Errorf("listing user repositories: %w", err)
+			}
+			allRepos = append(allRepos, repos...)
+			if resp.NextPage == 0 {
+				break
+			}
+			opts.Page = resp.NextPage
 		}
-		opts.Page = resp.NextPage
+	} else {
+		opts := &github.RepositoryListByAuthenticatedUserOptions{
+			ListOptions: github.ListOptions{PerPage: 100},
+		}
+		for {
+			repos, resp, err := e.client.Repositories.ListByAuthenticatedUser(ctx, opts)
+			if err != nil {
+				return nil, fmt.Errorf("listing user repositories: %w", err)
+			}
+			allRepos = append(allRepos, repos...)
+			if resp.NextPage == 0 {
+				break
+			}
+			opts.Page = resp.NextPage
+		}
 	}
-
 	return allRepos, nil
 }
 

--- a/pkg/enum/gitlab_test.go
+++ b/pkg/enum/gitlab_test.go
@@ -163,7 +163,7 @@ func TestGitLabConfig_Structure(t *testing.T) {
 	if config.User != "username" {
 		t.Error("User field not accessible")
 	}
-	if config.Config.MaxFileSize != 1000 {
+	if config.MaxFileSize != 1000 {
 		t.Error("Config.MaxFileSize not accessible")
 	}
 }

--- a/pkg/explore/data.go
+++ b/pkg/explore/data.go
@@ -41,7 +41,7 @@ func loadData(storePath string) (*exploreData, error) {
 	loader := rule.NewLoader()
 	rules, err := loader.LoadBuiltinRules()
 	if err != nil {
-		s.Close()
+		_ = s.Close()
 		return nil, fmt.Errorf("loading rules: %w", err)
 	}
 	ruleMap := make(map[string]*types.Rule)
@@ -52,14 +52,14 @@ func loadData(storePath string) (*exploreData, error) {
 	// Load findings (same as report.go:109-111)
 	findings, err := s.GetFindings()
 	if err != nil {
-		s.Close()
+		_ = s.Close()
 		return nil, fmt.Errorf("retrieving findings: %w", err)
 	}
 
 	// Load all matches (same as report.go:114-116)
 	matches, err := s.GetAllMatches()
 	if err != nil {
-		s.Close()
+		_ = s.Close()
 		return nil, fmt.Errorf("retrieving matches: %w", err)
 	}
 

--- a/pkg/explore/model.go
+++ b/pkg/explore/model.go
@@ -80,7 +80,6 @@ type Model struct {
 
 	width  int
 	height int
-	err    error
 }
 
 // New creates a new Model by loading data from the given datastore path.
@@ -528,18 +527,18 @@ func (m *Model) renderExcludeContent() string {
 	sb.WriteString("\n  Enter pattern (case-sensitive substring match on repo paths):\n")
 
 	if !m.excludeInListMode {
-		sb.WriteString(fmt.Sprintf("  > %s_\n", m.excludeInput))
+		fmt.Fprintf(&sb, "  > %s_\n", m.excludeInput)
 	} else {
-		sb.WriteString(fmt.Sprintf("    %s\n", m.excludeInput))
+		fmt.Fprintf(&sb, "    %s\n", m.excludeInput)
 	}
 
 	if len(m.excludePatterns) > 0 {
 		sb.WriteString("\n  Active patterns (tab to switch, x to delete):\n")
 		for i, p := range m.excludePatterns {
 			if m.excludeInListMode && i == m.excludeCursor {
-				sb.WriteString(fmt.Sprintf("  > %s\n", rejectStyle.Render(p)))
+				fmt.Fprintf(&sb, "  > %s\n", rejectStyle.Render(p))
 			} else {
-				sb.WriteString(fmt.Sprintf("    %s\n", p))
+				fmt.Fprintf(&sb, "    %s\n", p)
 			}
 		}
 	}
@@ -761,7 +760,8 @@ func (m *Model) copySecretToClipboard() tea.Cmd {
 }
 
 func (m *Model) setAnnotation(status string) {
-	if m.focus == paneFindings {
+	switch m.focus {
+	case paneFindings:
 		f := m.findings.selectedFinding()
 		if f == nil {
 			return
@@ -774,7 +774,7 @@ func (m *Model) setAnnotation(status string) {
 			f.AnnotationStatus = status
 			_ = m.data.setFindingAnnotation(f.FindingID, status, f.Comment)
 		}
-	} else if m.focus == paneDetails {
+	case paneDetails:
 		match := m.details.selectedMatch()
 		if match == nil {
 			return
@@ -790,7 +790,8 @@ func (m *Model) setAnnotation(status string) {
 }
 
 func (m *Model) moveNext() {
-	if m.focus == paneFindings {
+	switch m.focus {
+	case paneFindings:
 		if m.findings.cursor < len(m.findings.rows)-1 {
 			m.findings.cursor++
 			m.findings.ensureVisible()
@@ -798,7 +799,7 @@ func (m *Model) moveNext() {
 				m.details.setFinding(f)
 			}
 		}
-	} else if m.focus == paneDetails {
+	case paneDetails:
 		if m.finding() != nil && m.details.matchCursor < len(m.finding().Matches)-1 {
 			m.details.matchCursor++
 		}
@@ -810,7 +811,8 @@ func (m *Model) finding() *findingRow {
 }
 
 func (m *Model) startComment() {
-	if m.focus == paneFindings {
+	switch m.focus {
+	case paneFindings:
 		f := m.findings.selectedFinding()
 		if f == nil {
 			return
@@ -818,7 +820,7 @@ func (m *Model) startComment() {
 		m.commentTarget = "finding"
 		m.commentID = f.FindingID
 		m.commentInput = f.Comment
-	} else if m.focus == paneDetails {
+	case paneDetails:
 		match := m.details.selectedMatch()
 		if match == nil {
 			return
@@ -831,13 +833,14 @@ func (m *Model) startComment() {
 }
 
 func (m *Model) saveComment() {
-	if m.commentTarget == "finding" {
+	switch m.commentTarget {
+	case "finding":
 		f := m.findings.selectedFinding()
 		if f != nil {
 			f.Comment = m.commentInput
 			_ = m.data.setFindingAnnotation(f.FindingID, f.AnnotationStatus, f.Comment)
 		}
-	} else if m.commentTarget == "match" {
+	case "match":
 		match := m.details.selectedMatch()
 		if match != nil {
 			match.Comment = m.commentInput

--- a/pkg/explore/styles.go
+++ b/pkg/explore/styles.go
@@ -40,8 +40,6 @@ var (
 				Background(lipgloss.Color("17")).
 				Foreground(colorHighlight)
 
-	normalRowStyle = lipgloss.NewStyle()
-
 	headerRowStyle = lipgloss.NewStyle().
 			Bold(true).
 			Foreground(colorAccent)

--- a/pkg/matcher/crossrule.go
+++ b/pkg/matcher/crossrule.go
@@ -65,8 +65,7 @@ func (d *CrossRuleDeduplicator) clusterBySharedValues(matches []*types.Match) []
 		parent[i] = i
 	}
 
-	var find func(int) int
-	find = func(x int) int {
+	find := func(x int) int {
 		for parent[x] != x {
 			parent[x] = parent[parent[x]] // path compression
 			x = parent[x]

--- a/pkg/matcher/noseyparker_comparison_test.go
+++ b/pkg/matcher/noseyparker_comparison_test.go
@@ -41,7 +41,7 @@ func TestNoseyParkerParity_HTMLTestFile(t *testing.T) {
 	// Create portable matcher (non-CGO)
 	m, err := NewPortableRegexp(rules, 0, nil)
 	require.NoError(t, err)
-	defer m.Close()
+	defer func() { _ = m.Close() }()
 
 	// Read test file
 	content, err := os.ReadFile("../../extension/test/test-secrets.html")
@@ -106,7 +106,7 @@ func TestNoseyParkerParity_MixedSecrets(t *testing.T) {
 	// Create portable matcher
 	m, err := NewPortableRegexp(rules, 0, nil)
 	require.NoError(t, err)
-	defer m.Close()
+	defer func() { _ = m.Close() }()
 
 	// Read test file
 	content, err := os.ReadFile("../../testdata/secrets/mixed-secrets.txt")
@@ -163,7 +163,7 @@ func BenchmarkTitusVsNoseyParkerSpeed(b *testing.B) {
 	if err != nil {
 		b.Fatalf("Failed to create matcher: %v", err)
 	}
-	defer m.Close()
+	defer func() { _ = m.Close() }()
 
 	// Read test content
 	content, err := os.ReadFile("../../extension/test/test-secrets.html")

--- a/pkg/scanner/core.go
+++ b/pkg/scanner/core.go
@@ -81,7 +81,7 @@ func NewCore(rulesJSON string, logger DebugLogger) (*Core, error) {
 	s, err := store.New(store.Config{Path: ":memory:"})
 	if err != nil {
 		logger.Log("store.New failed: %v", err)
-		m.Close()
+		_ = m.Close()
 		return nil, err
 	}
 	logger.Log("Store created successfully")
@@ -135,10 +135,10 @@ func (c *Core) ScanBatch(items []ContentItem) (*BatchScanResult, error) {
 // Close releases scanner resources
 func (c *Core) Close() {
 	if c.matcher != nil {
-		c.matcher.Close()
+		_ = c.matcher.Close()
 	}
 	if c.store != nil {
-		c.store.Close()
+		_ = c.store.Close()
 	}
 }
 
@@ -173,7 +173,7 @@ func NewCoreWithRules(rules []*types.Rule, logger DebugLogger, warnFunc func(str
 	s, err := store.New(store.Config{Path: ":memory:"})
 	if err != nil {
 		logger.Log("store.New failed: %v", err)
-		m.Close()
+		_ = m.Close()
 		return nil, err
 	}
 	logger.Log("Store created successfully")

--- a/pkg/serve/server.go
+++ b/pkg/serve/server.go
@@ -109,7 +109,7 @@ func (s *Server) processRequest(ctx context.Context, req Request) bool {
 
 func (s *Server) sendReady() {
 	data, _ := json.Marshal(ReadyData{Version: Version})
-	s.encoder.Encode(Response{
+	_ = s.encoder.Encode(Response{
 		Success: true,
 		Type:    "ready",
 		Data:    data,
@@ -130,7 +130,7 @@ func (s *Server) handleScan(payload json.RawMessage) {
 	}
 
 	data, _ := json.Marshal(result)
-	s.encoder.Encode(Response{
+	_ = s.encoder.Encode(Response{
 		Success: true,
 		Type:    "scan",
 		Data:    data,
@@ -151,7 +151,7 @@ func (s *Server) handleScanBatch(payload json.RawMessage) {
 	}
 
 	data, _ := json.Marshal(result)
-	s.encoder.Encode(Response{
+	_ = s.encoder.Encode(Response{
 		Success: true,
 		Type:    "scan_batch",
 		Data:    data,
@@ -203,7 +203,7 @@ func (s *Server) handleValidate(ctx context.Context, payload json.RawMessage) {
 	}
 
 	data, _ := json.Marshal(result)
-	s.encoder.Encode(Response{
+	_ = s.encoder.Encode(Response{
 		Success: true,
 		Type:    "validate",
 		Data:    data,
@@ -211,7 +211,7 @@ func (s *Server) handleValidate(ctx context.Context, payload json.RawMessage) {
 }
 
 func (s *Server) sendError(reqType, msg string) {
-	s.encoder.Encode(Response{
+	_ = s.encoder.Encode(Response{
 		Success: false,
 		Type:    reqType,
 		Error:   msg,

--- a/pkg/serve/server_test.go
+++ b/pkg/serve/server_test.go
@@ -89,7 +89,7 @@ func TestServer_GracefulShutdownOnContext(t *testing.T) {
 
 	// Cancel context
 	cancel()
-	pw.Close()
+	_ = pw.Close()
 
 	select {
 	case err := <-done:

--- a/pkg/store/schema.go
+++ b/pkg/store/schema.go
@@ -165,7 +165,7 @@ func createProvenanceTable(db *sql.DB) error {
 		"committer_timestamp TEXT",
 		"commit_message TEXT",
 	} {
-		db.Exec("ALTER TABLE provenance ADD COLUMN " + col)
+		_, _ = db.Exec("ALTER TABLE provenance ADD COLUMN " + col)
 	}
 
 	// Create index for efficient provenance lookup by blob_id

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -52,7 +52,7 @@ func NewSQLite(path string) (*SQLiteStore, error) {
 	}
 	db.SetMaxOpenConns(1)
 	if err := CreateSchema(db); err != nil {
-		db.Close()
+		_ = db.Close()
 		return nil, fmt.Errorf("creating schema: %w", err)
 	}
 	return &SQLiteStore{db: db, e: db}, nil
@@ -120,7 +120,7 @@ func (s *SQLiteStore) GetMatches(blobID types.BlobID) ([]*types.Match, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	return scanMatches(rows)
 }
 
@@ -129,7 +129,7 @@ func (s *SQLiteStore) GetAllMatches() ([]*types.Match, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	return scanMatches(rows)
 }
 
@@ -147,7 +147,7 @@ func (s *SQLiteStore) GetFindings() ([]*types.Finding, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	var result []*types.Finding
 	for rows.Next() {
 		var f types.Finding
@@ -231,7 +231,7 @@ func (s *SQLiteStore) getAllProvenanceFull(blobID types.BlobID) ([]types.Provena
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	var result []types.Provenance
 	for rows.Next() {
 		var provType string
@@ -271,7 +271,7 @@ func (s *SQLiteStore) getAllProvenanceFull(blobID types.BlobID) ([]types.Provena
 		case "extended":
 			var payload map[string]interface{}
 			if path.Valid {
-				json.Unmarshal([]byte(path.String), &payload)
+				_ = json.Unmarshal([]byte(path.String), &payload)
 			}
 			result = append(result, types.ExtendedProvenance{Payload: payload})
 		}
@@ -287,7 +287,7 @@ func (s *SQLiteStore) getAllProvenanceLegacy(blobID types.BlobID) ([]types.Prove
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	var result []types.Provenance
 	for rows.Next() {
 		var provType string
@@ -307,7 +307,7 @@ func (s *SQLiteStore) getAllProvenanceLegacy(blobID types.BlobID) ([]types.Prove
 		case "extended":
 			var payload map[string]interface{}
 			if path.Valid {
-				json.Unmarshal([]byte(path.String), &payload)
+				_ = json.Unmarshal([]byte(path.String), &payload)
 			}
 			result = append(result, types.ExtendedProvenance{Payload: payload})
 		}
@@ -336,7 +336,7 @@ func (s *SQLiteStore) ExecBatch(fn func(Store) error) error {
 	}
 	txStore := &SQLiteStore{e: tx} // db is nil; ExecBatch on txStore would panic, which is correct
 	if err := fn(txStore); err != nil {
-		tx.Rollback()
+		_ = tx.Rollback()
 		return err
 	}
 	return tx.Commit()

--- a/pkg/store/sqlite_test.go
+++ b/pkg/store/sqlite_test.go
@@ -19,7 +19,7 @@ func TestSQLite_SchemaWithLocationColumns(t *testing.T) {
 
 	store, err := NewSQLite(dbPath)
 	require.NoError(t, err)
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	blobID := types.ComputeBlobID([]byte("test content"))
 	err = store.AddBlob(blobID, 12)
@@ -76,7 +76,7 @@ func TestSQLite_GetAllMatchesWithLocation(t *testing.T) {
 
 	store, err := NewSQLite(dbPath)
 	require.NoError(t, err)
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	blobID1 := types.ComputeBlobID([]byte("content1"))
 	blobID2 := types.ComputeBlobID([]byte("content2"))
@@ -149,7 +149,7 @@ func TestSQLite_GetMatchesRuleName(t *testing.T) {
 
 	store, err := NewSQLite(dbPath)
 	require.NoError(t, err)
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	blobID := types.ComputeBlobID([]byte("test content"))
 	err = store.AddBlob(blobID, 12)
@@ -192,7 +192,7 @@ func TestSQLite_GetAllMatchesRuleName(t *testing.T) {
 
 	store, err := NewSQLite(dbPath)
 	require.NoError(t, err)
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	blobID1 := types.ComputeBlobID([]byte("content1"))
 	blobID2 := types.ComputeBlobID([]byte("content2"))
@@ -263,7 +263,7 @@ func TestSQLite_NullLocationValues(t *testing.T) {
 
 	store, err := NewSQLite(dbPath)
 	require.NoError(t, err)
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	blobID := types.ComputeBlobID([]byte("test content"))
 	err = store.AddBlob(blobID, 12)
@@ -312,7 +312,7 @@ func TestSQLite_ProvenanceWithCommitMetadata(t *testing.T) {
 	dir := t.TempDir()
 	store, err := New(Config{Path: filepath.Join(dir, "test.db")})
 	require.NoError(t, err)
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	blobID := types.ComputeBlobID([]byte("secret content"))
 	err = store.AddBlob(blobID, 14)

--- a/pkg/store/store_default_test.go
+++ b/pkg/store/store_default_test.go
@@ -13,7 +13,7 @@ func TestNew_MemoryPath(t *testing.T) {
 	s, err := New(Config{Path: ":memory:"})
 	require.NoError(t, err)
 	require.NotNil(t, s)
-	defer s.Close()
+	defer func() { _ = s.Close() }()
 }
 
 func TestNew_EmptyPath(t *testing.T) {
@@ -28,5 +28,5 @@ func TestNew_FilePath(t *testing.T) {
 	s, err := New(Config{Path: tmpFile})
 	require.NoError(t, err)
 	require.NotNil(t, s)
-	defer s.Close()
+	defer func() { _ = s.Close() }()
 }

--- a/pkg/validator/amplitude.go
+++ b/pkg/validator/amplitude.go
@@ -82,7 +82,7 @@ func (v *AmplitudeValidator) Validate(ctx context.Context, match *types.Match) (
 			fmt.Sprintf("request failed: %v", err),
 		), nil
 	}
-	defer func() { io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
 
 	// Evaluate response
 	switch resp.StatusCode {

--- a/pkg/validator/branchio.go
+++ b/pkg/validator/branchio.go
@@ -81,7 +81,7 @@ func (v *BranchIOValidator) Validate(ctx context.Context, match *types.Match) (*
 			fmt.Sprintf("request failed: %v", err),
 		), nil
 	}
-	defer func() { io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
 
 	// Evaluate response
 	switch resp.StatusCode {

--- a/pkg/validator/browserstack.go
+++ b/pkg/validator/browserstack.go
@@ -77,7 +77,7 @@ func (v *BrowserStackValidator) Validate(ctx context.Context, match *types.Match
 			fmt.Sprintf("request failed: %v", err),
 		), nil
 	}
-	defer func() { io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
 
 	// Evaluate response
 	switch resp.StatusCode {

--- a/pkg/validator/cypress.go
+++ b/pkg/validator/cypress.go
@@ -98,7 +98,7 @@ func (v *CypressValidator) Validate(ctx context.Context, match *types.Match) (*t
 			fmt.Sprintf("request failed: %v", err),
 		), nil
 	}
-	defer func() { io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
 
 	// Evaluate response
 	switch resp.StatusCode {

--- a/pkg/validator/engine_test.go
+++ b/pkg/validator/engine_test.go
@@ -88,7 +88,7 @@ func TestEngine_ValidateAsync_CacheHitFastPath(t *testing.T) {
 	}
 
 	// Warm cache
-	engine.ValidateMatch(context.Background(), match)
+	_, _ = engine.ValidateMatch(context.Background(), match)
 
 	// Async should return from cache immediately
 	resultCh := engine.ValidateAsync(context.Background(), match)

--- a/pkg/validator/helpscout.go
+++ b/pkg/validator/helpscout.go
@@ -80,7 +80,7 @@ func (v *HelpScoutValidator) Validate(ctx context.Context, match *types.Match) (
 			fmt.Sprintf("request failed: %v", err),
 		), nil
 	}
-	defer func() { io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
 
 	// Evaluate response
 	switch resp.StatusCode {

--- a/pkg/validator/http.go
+++ b/pkg/validator/http.go
@@ -81,7 +81,7 @@ func (v *HTTPValidator) Validate(ctx context.Context, match *types.Match) (*type
 	if err != nil {
 		return types.NewValidationResult(types.StatusUndetermined, 0, fmt.Sprintf("request failed: %v", err)), nil
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	// Read response body if needed for body-based validation
 	var respBody []byte
@@ -91,7 +91,7 @@ func (v *HTTPValidator) Validate(ctx context.Context, match *types.Match) (*type
 			return types.NewValidationResult(types.StatusUndetermined, 0, fmt.Sprintf("failed to read response body: %v", err)), nil
 		}
 	} else {
-		io.Copy(io.Discard, resp.Body)
+		_, _ = io.Copy(io.Discard, resp.Body)
 	}
 
 	// Check response code and body

--- a/pkg/validator/http_test.go
+++ b/pkg/validator/http_test.go
@@ -542,7 +542,7 @@ func TestHTTPValidator_Validate_SuccessBodyContains_Valid(t *testing.T) {
 	// Slack-style API: returns 200 with ok:true/false in body
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"ok":true,"team":"T123"}`))
+		_, _ = w.Write([]byte(`{"ok":true,"team":"T123"}`))
 	}))
 	defer server.Close()
 
@@ -579,7 +579,7 @@ func TestHTTPValidator_Validate_SuccessBodyContains_Invalid(t *testing.T) {
 	// Slack-style API: returns 200 with ok:false for invalid tokens
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"ok":false,"error":"invalid_auth"}`))
+		_, _ = w.Write([]byte(`{"ok":false,"error":"invalid_auth"}`))
 	}))
 	defer server.Close()
 
@@ -616,7 +616,7 @@ func TestHTTPValidator_Validate_FailureBodyContains(t *testing.T) {
 	// API that returns 200 but with error in body
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"status":"error","message":"unauthorized"}`))
+		_, _ = w.Write([]byte(`{"status":"error","message":"unauthorized"}`))
 	}))
 	defer server.Close()
 

--- a/pkg/validator/keenio.go
+++ b/pkg/validator/keenio.go
@@ -141,7 +141,7 @@ func (v *KeenIOValidator) tryEndpoint(ctx context.Context, ep keenEndpoint, apiK
 			fmt.Sprintf("request failed: %v", err),
 		), false, nil
 	}
-	defer func() { io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
 
 	switch resp.StatusCode {
 	case http.StatusOK, http.StatusCreated:

--- a/pkg/validator/mattermost.go
+++ b/pkg/validator/mattermost.go
@@ -80,7 +80,7 @@ func (v *MattermostValidator) validateWebhook(ctx context.Context, match *types.
 	if err != nil {
 		return types.NewValidationResult(types.StatusUndetermined, 0, fmt.Sprintf("request failed: %v", err)), nil
 	}
-	defer func() { io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
 
 	switch resp.StatusCode {
 	case http.StatusOK:
@@ -129,7 +129,7 @@ func (v *MattermostValidator) validateAccessToken(ctx context.Context, match *ty
 	if err != nil {
 		return types.NewValidationResult(types.StatusUndetermined, 0, fmt.Sprintf("request failed: %v", err)), nil
 	}
-	defer func() { io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
 
 	switch resp.StatusCode {
 	case http.StatusOK:

--- a/pkg/validator/mattermost_test.go
+++ b/pkg/validator/mattermost_test.go
@@ -175,7 +175,7 @@ func TestMattermostValidator_AccessToken_Valid(t *testing.T) {
 		assert.Contains(t, r.URL.Path, "/api/v4/users/me")
 		assert.Equal(t, "Bearer testtoken12345678901234", r.Header.Get("Authorization"))
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"id":"abc123","username":"testuser"}`))
+		_, _ = w.Write([]byte(`{"id":"abc123","username":"testuser"}`))
 	}))
 	defer server.Close()
 

--- a/pkg/validator/postgres.go
+++ b/pkg/validator/postgres.go
@@ -67,7 +67,7 @@ func (v *PostgresValidator) Validate(ctx context.Context, match *types.Match) (*
 		// Analyze error to determine if it's auth failure or network issue
 		return v.analyzeConnectionError(err)
 	}
-	defer conn.Close(ctx)
+	defer func() { _ = conn.Close(ctx) }()
 
 	// Connection successful - credentials are valid
 	return types.NewValidationResult(

--- a/pkg/validator/rabbitmq.go
+++ b/pkg/validator/rabbitmq.go
@@ -83,7 +83,7 @@ func (v *RabbitMQValidator) Validate(ctx context.Context, match *types.Match) (*
 			fmt.Sprintf("management API unreachable (plugin may not be enabled): %v", err),
 		), nil
 	}
-	defer func() { io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
 
 	switch resp.StatusCode {
 	case http.StatusOK:

--- a/pkg/validator/rabbitmq_test.go
+++ b/pkg/validator/rabbitmq_test.go
@@ -147,7 +147,7 @@ func TestRabbitMQValidator_ValidCredentials(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"name":"admin","tags":"administrator"}`))
+		_, _ = w.Write([]byte(`{"name":"admin","tags":"administrator"}`))
 	}))
 	defer server.Close()
 
@@ -176,7 +176,7 @@ func TestRabbitMQValidator_InvalidCredentials(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnauthorized)
-		w.Write([]byte(`{"error":"not_authorised","reason":"Login failed"}`))
+		_, _ = w.Write([]byte(`{"error":"not_authorised","reason":"Login failed"}`))
 	}))
 	defer server.Close()
 

--- a/pkg/validator/saucelabs.go
+++ b/pkg/validator/saucelabs.go
@@ -77,7 +77,7 @@ func (v *SauceLabsValidator) Validate(ctx context.Context, match *types.Match) (
 			fmt.Sprintf("request failed: %v", err),
 		), nil
 	}
-	defer func() { io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
 
 	// Evaluate response
 	switch resp.StatusCode {

--- a/pkg/validator/shopify.go
+++ b/pkg/validator/shopify.go
@@ -96,7 +96,7 @@ func (v *ShopifyValidator) Validate(ctx context.Context, match *types.Match) (*t
 			fmt.Sprintf("request failed: %v", err),
 		), nil
 	}
-	defer func() { io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
 
 	// Evaluate response
 	switch resp.StatusCode {

--- a/pkg/validator/truenas.go
+++ b/pkg/validator/truenas.go
@@ -110,7 +110,7 @@ func (v *TrueNASValidator) Validate(ctx context.Context, match *types.Match) (*t
 			fmt.Sprintf("request failed: %v", err),
 		), nil
 	}
-	defer func() { io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
 
 	switch resp.StatusCode {
 	case http.StatusOK:

--- a/pkg/validator/truenas_test.go
+++ b/pkg/validator/truenas_test.go
@@ -217,7 +217,7 @@ func TestTrueNASValidator_Validate_ValidToken(t *testing.T) {
 		assert.Contains(t, r.URL.Path, "/api/v2.0/system/info")
 		assert.Contains(t, r.Header.Get("Authorization"), "Bearer ")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"version":"TrueNAS-SCALE-24.04"}`))
+		_, _ = w.Write([]byte(`{"version":"TrueNAS-SCALE-24.04"}`))
 	}))
 	defer server.Close()
 

--- a/pkg/validator/twilio.go
+++ b/pkg/validator/twilio.go
@@ -88,7 +88,7 @@ func (v *TwilioValidator) Validate(ctx context.Context, match *types.Match) (*ty
 			fmt.Sprintf("request failed: %v", err),
 		), nil
 	}
-	defer func() { io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
 
 	// Evaluate response
 	switch resp.StatusCode {

--- a/pkg/validator/wpengine.go
+++ b/pkg/validator/wpengine.go
@@ -77,7 +77,7 @@ func (v *WPEngineValidator) Validate(ctx context.Context, match *types.Match) (*
 			fmt.Sprintf("request failed: %v", err),
 		), nil
 	}
-	defer func() { io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
 
 	// Evaluate response
 	switch resp.StatusCode {

--- a/pkg/validator/zendesk.go
+++ b/pkg/validator/zendesk.go
@@ -88,7 +88,7 @@ func (v *ZendeskValidator) Validate(ctx context.Context, match *types.Match) (*t
 			fmt.Sprintf("request failed: %v", err),
 		), nil
 	}
-	defer func() { io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
 
 	// Evaluate response
 	switch resp.StatusCode {

--- a/titus.go
+++ b/titus.go
@@ -268,7 +268,7 @@ func (s *Scanner) Close() error {
 	defer s.mu.Unlock()
 
 	if s.matcher != nil {
-		s.matcher.Close()
+		_ = s.matcher.Close()
 	}
 	return nil
 }

--- a/titus_test.go
+++ b/titus_test.go
@@ -11,7 +11,7 @@ import (
 func TestNewScanner(t *testing.T) {
 	scanner, err := NewScanner()
 	require.NoError(t, err)
-	defer scanner.Close()
+	defer func() { _ = scanner.Close() }()
 
 	// Should have loaded builtin rules
 	assert.Greater(t, scanner.RuleCount(), 100, "should have loaded many builtin rules")
@@ -24,7 +24,7 @@ func TestNewScannerWithOptions(t *testing.T) {
 		WithValidationWorkers(2),
 	)
 	require.NoError(t, err)
-	defer scanner.Close()
+	defer func() { _ = scanner.Close() }()
 
 	assert.True(t, scanner.ValidationEnabled())
 }
@@ -32,7 +32,7 @@ func TestNewScannerWithOptions(t *testing.T) {
 func TestScanString(t *testing.T) {
 	scanner, err := NewScanner()
 	require.NoError(t, err)
-	defer scanner.Close()
+	defer func() { _ = scanner.Close() }()
 
 	// Test content with a fake AWS key pattern
 	content := `aws_access_key_id = AKIADEADBEEFDEADBEEF`
@@ -55,7 +55,7 @@ func TestScanString(t *testing.T) {
 func TestScanBytes(t *testing.T) {
 	scanner, err := NewScanner()
 	require.NoError(t, err)
-	defer scanner.Close()
+	defer func() { _ = scanner.Close() }()
 
 	// Test with a realistic AWS access key pattern that's in the builtin rules
 	content := []byte(`AWS_ACCESS_KEY_ID=AKIADEADBEEFDEADBEEF`)
@@ -77,7 +77,7 @@ func TestScanBytes(t *testing.T) {
 func TestScanStringWithContext(t *testing.T) {
 	scanner, err := NewScanner()
 	require.NoError(t, err)
-	defer scanner.Close()
+	defer func() { _ = scanner.Close() }()
 
 	ctx := context.Background()
 	content := `password = "super_secret_password_12345"`
@@ -93,7 +93,7 @@ func TestScanStringWithContext(t *testing.T) {
 func TestScanStringNoMatches(t *testing.T) {
 	scanner, err := NewScanner()
 	require.NoError(t, err)
-	defer scanner.Close()
+	defer func() { _ = scanner.Close() }()
 
 	// Content with no secrets
 	content := `Hello, world! This is just regular text.`
@@ -119,7 +119,7 @@ func TestWithCustomRules(t *testing.T) {
 
 	scanner, err := NewScanner(WithRules(subset))
 	require.NoError(t, err)
-	defer scanner.Close()
+	defer func() { _ = scanner.Close() }()
 
 	assert.Equal(t, 10, scanner.RuleCount())
 }
@@ -139,7 +139,7 @@ func TestLoadBuiltinRules(t *testing.T) {
 func TestRules(t *testing.T) {
 	scanner, err := NewScanner()
 	require.NoError(t, err)
-	defer scanner.Close()
+	defer func() { _ = scanner.Close() }()
 
 	rules := scanner.Rules()
 	assert.Equal(t, scanner.RuleCount(), len(rules))
@@ -156,7 +156,7 @@ func TestMultipleScanners(t *testing.T) {
 		go func(idx int) {
 			scanner, err := NewScanner()
 			require.NoError(t, err)
-			defer scanner.Close()
+			defer func() { _ = scanner.Close() }()
 
 			_, err = scanner.ScanString("test content with aws_access_key_id=AKIAIOSFODNN7EXAMPLE")
 			assert.NoError(t, err)
@@ -174,7 +174,7 @@ func TestSequentialScanning(t *testing.T) {
 	// Single scanner - sequential scans are safe
 	scanner, err := NewScanner()
 	require.NoError(t, err)
-	defer scanner.Close()
+	defer func() { _ = scanner.Close() }()
 
 	for i := range 5 {
 		_, err := scanner.ScanString("test content with aws_access_key_id=AKIAIOSFODNN7EXAMPLE")


### PR DESCRIPTION
## Summary

Migrates titus's CI to the centralized `go-ci.yml@v1.0.2` reusable workflow ([ENG-3092](https://linear.app/praetorianlabs/issue/ENG-3092)). Part of the capability-repo sweep for [ENG-3081](https://linear.app/praetorianlabs/issue/ENG-3081).

Changes: inline ci.yml → 18-line caller. Same lint+test+build behavior, now with SHA-pinned actions, pinned golangci-lint version, and Harden-Runner runtime protection. claude-code.yml, integration.yml, release-new.yml, external-contribution.yml are unchanged.

Test plan: CI workflow runs via the reusable, 8 jobs should pass (lint + test + build × 6 matrix).