### PR TITLE
fix(ci): update golangci.yml to v2 config schema

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,8 @@
 version: "2"
 
-linters-settings:
-  errcheck:
+linters:
+  settings:
+    errcheck:
     check-type-assertions: false
     check-blank: false
     exclude-functions:


### PR DESCRIPTION
golangci-lint v2 renamed `linters-settings` to `linters.settings`. PR #186 introduced the config with the v1 key, causing:

```
jsonschema: additional properties 'linters-settings' not allowed
```

This fixes it.