### PR TITLE
fix(ci): fix golangci.yml errcheck indentation

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,13 +3,16 @@ version: "2"
 linters:
   settings:
     errcheck:
-    check-type-assertions: false
-    check-blank: false
-    exclude-functions:
-      # Deferred close/cleanup calls — errors are intentionally discarded
-      - (io.Closer).Close
-      - (*os.File).Close
-      - (io.ReadCloser).Close
-      - (*compress/gzip.Reader).Close
-      - (*compress/gzip.Writer).Close
-      - (*archive/zip.Writer).Close
+      check-type-assertions: false
+      check-blank: false
+      exclude-functions:
+        # Deferred close/cleanup calls — errors are intentionally discarded
+        - (io.Closer).Close
+        - (*os.File).Close
+        - (io.ReadCloser).Close
+        - (*compress/gzip.Reader).Close
+        - (*compress/gzip.Writer).Close
+        - (*archive/zip.Writer).Close
+        - (github.com/praetorian-inc/titus/pkg/matcher.Matcher).Close
+        - (github.com/praetorian-inc/titus/pkg/store.Store).Close
+        - (*github.com/praetorian-inc/titus/pkg/datastore.Datastore).Close

--- a/cmd/titus/scan.go
+++ b/cmd/titus/scan.go
@@ -149,7 +149,7 @@ func runScan(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("creating matcher: %w", err)
 	}
-	defer func() { _ = m.Close() }()
+	defer m.Close()
 
 	// Create store (memory or datastore)
 	s, ds, err := openScanStore(scanOutputPath, scanStoreBlobs)
@@ -157,9 +157,9 @@ func runScan(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if ds != nil {
-		defer func() { _ = ds.Close() }()
+		defer ds.Close()
 	} else {
-		defer func() { _ = s.Close() }()
+		defer s.Close()
 	}
 
 	// Store rules for foreign key constraints
@@ -670,7 +670,7 @@ func runRepoScan(cmd *cobra.Command, rt repoTarget) error {
 	if err != nil {
 		return fmt.Errorf("creating matcher: %w", err)
 	}
-	defer func() { _ = m.Close() }()
+	defer m.Close()
 
 	// Create store
 	s, ds, err := openScanStore(scanOutputPath, scanStoreBlobs)
@@ -678,9 +678,9 @@ func runRepoScan(cmd *cobra.Command, rt repoTarget) error {
 		return err
 	}
 	if ds != nil {
-		defer func() { _ = ds.Close() }()
+		defer ds.Close()
 	} else {
-		defer func() { _ = s.Close() }()
+		defer s.Close()
 	}
 
 	for _, r := range rules {


### PR DESCRIPTION
The errcheck settings were at the wrong indentation level under `linters.settings`, causing YAML to parse `errcheck:` as null with its children floating as siblings. This fixes the nesting.