### PR TITLE
feat(report): hide rejected findings by default with --show-rejected opt-in

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,7 @@ linters:
         - (*compress/gzip.Reader).Close
         - (*compress/gzip.Writer).Close
         - (*archive/zip.Writer).Close
+        - (*database/sql.Rows).Close
         - (github.com/praetorian-inc/titus/pkg/matcher.Matcher).Close
         - (github.com/praetorian-inc/titus/pkg/store.Store).Close
         - (*github.com/praetorian-inc/titus/pkg/datastore.Datastore).Close

--- a/cmd/titus/report.go
+++ b/cmd/titus/report.go
@@ -250,7 +250,10 @@ func runReport(cmd *cobra.Command, args []string) error {
 
 	// Filter out findings with rejected annotations unless --show-rejected is set
 	if !reportShowRejected {
-		findings, matches = filterRejected(s, findings, matches, ruleMap)
+		findings, matches, err = filterRejected(s, findings, matches, ruleMap)
+		if err != nil {
+			return fmt.Errorf("filtering rejected findings: %w", err)
+		}
 	}
 
 	// Output based on format
@@ -312,7 +315,10 @@ func runSummary(cmd *cobra.Command, args []string) error {
 
 	// Filter out findings with rejected annotations unless --show-rejected is set
 	if !reportShowRejected {
-		findings, matches = filterRejected(s, findings, matches, ruleMap)
+		findings, matches, err = filterRejected(s, findings, matches, ruleMap)
+		if err != nil {
+			return fmt.Errorf("filtering rejected findings: %w", err)
+		}
 	}
 
 	matchesByFinding := buildFindingMatchMap(findings, matches, ruleMap)
@@ -347,19 +353,25 @@ func runSummary(cmd *cobra.Command, args []string) error {
 // =============================================================================
 
 // filterRejected removes findings that have a "reject" annotation and all
-// matches associated with those findings.
-func filterRejected(s store.Store, findings []*types.Finding, matches []*types.Match, ruleMap map[string]*types.Rule) ([]*types.Finding, []*types.Match) {
+// matches associated with those findings. Returns an error if the annotation
+// lookup fails so callers can decide whether to proceed without filtering or
+// abort entirely.
+func filterRejected(s store.Store, findings []*types.Finding, matches []*types.Match, ruleMap map[string]*types.Rule) ([]*types.Finding, []*types.Match, error) {
+	annotations, err := s.GetAnnotationsByType("finding")
+	if err != nil {
+		return nil, nil, fmt.Errorf("retrieving annotations: %w", err)
+	}
+
 	// Determine which finding IDs are rejected
 	rejectedFindingIDs := make(map[string]bool)
 	for _, f := range findings {
-		status, _, err := s.GetAnnotation("finding", f.ID)
-		if err == nil && status == store.StatusReject {
+		if annotations[f.ID] == store.StatusReject {
 			rejectedFindingIDs[f.ID] = true
 		}
 	}
 
 	if len(rejectedFindingIDs) == 0 {
-		return findings, matches
+		return findings, matches, nil
 	}
 
 	// Collect structural IDs of matches that belong to rejected findings
@@ -385,7 +397,7 @@ func filterRejected(s store.Store, findings []*types.Finding, matches []*types.M
 		}
 	}
 
-	return filteredFindings, filteredMatches
+	return filteredFindings, filteredMatches, nil
 }
 
 // buildFindingMatchMap groups matches by finding ID using content-based computation.

--- a/cmd/titus/report.go
+++ b/cmd/titus/report.go
@@ -18,10 +18,11 @@ import (
 )
 
 var (
-	reportDatastore string
-	reportFormat    string
-	reportColor     string
-	summaryFormat   string
+	reportDatastore      string
+	reportFormat         string
+	reportColor          string
+	summaryFormat        string
+	reportShowRejected bool
 )
 
 // styles holds color formatters matching NoseyParker color scheme
@@ -190,6 +191,7 @@ func init() {
 	reportCmd.Flags().StringVar(&reportFormat, "format", "human", "Output format: human, json, sarif")
 	reportCmd.PersistentFlags().StringVar(&reportColor, "color", "auto", "Color output: auto, always, never")
 	reportCmd.PersistentFlags().Lookup("color").NoOptDefVal = "always"
+	reportCmd.PersistentFlags().BoolVar(&reportShowRejected, "show-rejected", false, "Include findings marked as rejected via the explore command (hidden by default)")
 
 	reportCmd.AddCommand(summaryCmd)
 	summaryCmd.Flags().StringVar(&summaryFormat, "format", "human", "Output format: human, json")
@@ -244,6 +246,11 @@ func runReport(cmd *cobra.Command, args []string) error {
 	ruleMap := make(map[string]*types.Rule)
 	for _, r := range rules {
 		ruleMap[r.ID] = r
+	}
+
+	// Filter out findings with rejected annotations unless --show-rejected is set
+	if !reportShowRejected {
+		findings, matches = filterRejected(s, findings, matches, ruleMap)
 	}
 
 	// Output based on format
@@ -303,6 +310,11 @@ func runSummary(cmd *cobra.Command, args []string) error {
 		ruleMap[r.ID] = r
 	}
 
+	// Filter out findings with rejected annotations unless --show-rejected is set
+	if !reportShowRejected {
+		findings, matches = filterRejected(s, findings, matches, ruleMap)
+	}
+
 	matchesByFinding := buildFindingMatchMap(findings, matches, ruleMap)
 	summary := aggregateSummary(findings, matchesByFinding, ruleMap)
 
@@ -333,6 +345,48 @@ func runSummary(cmd *cobra.Command, args []string) error {
 // =============================================================================
 // HELPERS
 // =============================================================================
+
+// filterRejected removes findings that have a "reject" annotation and all
+// matches associated with those findings.
+func filterRejected(s store.Store, findings []*types.Finding, matches []*types.Match, ruleMap map[string]*types.Rule) ([]*types.Finding, []*types.Match) {
+	// Determine which finding IDs are rejected
+	rejectedFindingIDs := make(map[string]bool)
+	for _, f := range findings {
+		status, _, err := s.GetAnnotation("finding", f.ID)
+		if err == nil && status == "reject" {
+			rejectedFindingIDs[f.ID] = true
+		}
+	}
+
+	if len(rejectedFindingIDs) == 0 {
+		return findings, matches
+	}
+
+	// Collect structural IDs of matches that belong to rejected findings
+	matchesByFinding := buildFindingMatchMap(findings, matches, ruleMap)
+	rejectedMatchIDs := make(map[string]bool)
+	for fID := range rejectedFindingIDs {
+		for _, m := range matchesByFinding[fID] {
+			rejectedMatchIDs[m.StructuralID] = true
+		}
+	}
+
+	filteredFindings := make([]*types.Finding, 0, len(findings))
+	for _, f := range findings {
+		if !rejectedFindingIDs[f.ID] {
+			filteredFindings = append(filteredFindings, f)
+		}
+	}
+
+	filteredMatches := make([]*types.Match, 0, len(matches))
+	for _, m := range matches {
+		if !rejectedMatchIDs[m.StructuralID] {
+			filteredMatches = append(filteredMatches, m)
+		}
+	}
+
+	return filteredFindings, filteredMatches
+}
 
 // buildFindingMatchMap groups matches by finding ID using content-based computation.
 // It uses structural ID matching with a fallback to RuleID + Groups matching.

--- a/cmd/titus/report.go
+++ b/cmd/titus/report.go
@@ -353,7 +353,7 @@ func filterRejected(s store.Store, findings []*types.Finding, matches []*types.M
 	rejectedFindingIDs := make(map[string]bool)
 	for _, f := range findings {
 		status, _, err := s.GetAnnotation("finding", f.ID)
-		if err == nil && status == "reject" {
+		if err == nil && status == store.StatusReject {
 			rejectedFindingIDs[f.ID] = true
 		}
 	}

--- a/cmd/titus/report_test.go
+++ b/cmd/titus/report_test.go
@@ -515,25 +515,24 @@ func TestOutputSummaryJSON(t *testing.T) {
 // =============================================================================
 
 // fakeRejectionStore is a minimal store.Store implementation for testing
-// filterRejected. Only GetAnnotation is meaningful; all other methods are
+// filterRejected. Only GetAnnotationsByType is meaningful; all other methods are
 // satisfied by embedding store.Store (nil panic guard — tests must not call
 // any other method).
 type fakeRejectionStore struct {
 	store.Store
 	rejections map[string]string // key: finding ID, value: status string
-	errIDs     map[string]error  // key: finding ID, value: error to return
+	bulkErr    error             // error to return from GetAnnotationsByType
 }
 
-func (f *fakeRejectionStore) GetAnnotation(targetType, targetID string) (string, string, error) {
-	if f.errIDs != nil {
-		if err, ok := f.errIDs[targetID]; ok {
-			return "", "", err
-		}
+func (f *fakeRejectionStore) GetAnnotationsByType(targetType string) (map[string]string, error) {
+	if f.bulkErr != nil {
+		return nil, f.bulkErr
 	}
-	if status, ok := f.rejections[targetID]; ok {
-		return status, "", nil
+	result := make(map[string]string)
+	for id, status := range f.rejections {
+		result[id] = status
 	}
-	return "", "", nil
+	return result, nil
 }
 
 // =============================================================================
@@ -577,7 +576,8 @@ func TestReportCmd_ShowRejectedFlag_Description(t *testing.T) {
 
 func TestFilterRejected_EmptyFindings(t *testing.T) {
 	s := &fakeRejectionStore{rejections: map[string]string{}}
-	findings, matches := filterRejected(s, nil, nil, nil)
+	findings, matches, err := filterRejected(s, nil, nil, nil)
+	require.NoError(t, err)
 	assert.Empty(t, findings)
 	assert.Empty(t, matches)
 }
@@ -608,7 +608,8 @@ func TestFilterRejected_NoRejections_ReturnsInputsUnchanged(t *testing.T) {
 	// Store returns empty status for all IDs — no rejections
 	s := &fakeRejectionStore{rejections: map[string]string{}}
 
-	gotFindings, gotMatches := filterRejected(s, findings, matches, ruleMap)
+	gotFindings, gotMatches, err := filterRejected(s, findings, matches, ruleMap)
+	require.NoError(t, err)
 
 	assert.Len(t, gotFindings, 2, "all findings should be retained when none are rejected")
 	assert.Len(t, gotMatches, 2, "all matches should be retained when none are rejected")
@@ -646,7 +647,8 @@ func TestFilterRejected_AllFindingsRejected_ReturnsEmpty(t *testing.T) {
 		},
 	}
 
-	gotFindings, gotMatches := filterRejected(s, findings, matches, ruleMap)
+	gotFindings, gotMatches, err := filterRejected(s, findings, matches, ruleMap)
+	require.NoError(t, err)
 
 	assert.Empty(t, gotFindings, "all findings should be removed when all are rejected")
 	assert.Empty(t, gotMatches, "all matches should be removed when all findings are rejected")
@@ -707,7 +709,8 @@ func TestFilterRejected_PartialRejection_RemovesRejectedFindingAndItsMatches(t *
 		rejections: map[string]string{f2.ID: store.StatusReject},
 	}
 
-	gotFindings, gotMatches := filterRejected(s, findings, matches, ruleMap)
+	gotFindings, gotMatches, err := filterRejected(s, findings, matches, ruleMap)
+	require.NoError(t, err)
 
 	require.Len(t, gotFindings, 2, "should have 2 findings after rejecting middle one")
 	assert.Equal(t, f1, gotFindings[0], "first finding retained")
@@ -753,51 +756,18 @@ func TestFilterRejected_NonRejectStatusRetained(t *testing.T) {
 		rejections: map[string]string{f1.ID: store.StatusAccept},
 	}
 
-	gotFindings, gotMatches := filterRejected(s, findings, matches, ruleMap)
+	gotFindings, gotMatches, err := filterRejected(s, findings, matches, ruleMap)
+	require.NoError(t, err)
 
 	assert.Len(t, gotFindings, 2, "findings with non-reject status should be retained")
 	assert.Len(t, gotMatches, 2, "matches for non-rejected findings should be retained")
 }
 
-func TestFilterRejected_AnnotationErrorIsIgnored(t *testing.T) {
-	rule := &types.Rule{
-		ID:           "rule-1",
-		StructuralID: "struct-errtest",
-	}
-	ruleMap := map[string]*types.Rule{"rule-1": rule}
-
-	f1 := &types.Finding{
-		ID:     types.ComputeFindingID(rule.StructuralID, [][]byte{[]byte("err-val")}),
-		RuleID: "rule-1",
-		Groups: [][]byte{[]byte("err-val")},
-	}
-	f2 := &types.Finding{
-		ID:     types.ComputeFindingID(rule.StructuralID, [][]byte{[]byte("ok-val")}),
-		RuleID: "rule-1",
-		Groups: [][]byte{[]byte("ok-val")},
-	}
-	findings := []*types.Finding{f1, f2}
-	matches := []*types.Match{
-		{StructuralID: "sm-err", RuleID: "rule-1", Groups: [][]byte{[]byte("err-val")}},
-		{StructuralID: "sm-ok", RuleID: "rule-1", Groups: [][]byte{[]byte("ok-val")}},
-	}
-
-	// f1 returns an error from GetAnnotation (even though "reject" would be the
-	// status) — the error path means it must NOT be filtered.
-	// f2 returns status "reject" with no error — it MUST be filtered.
-	s := &fakeRejectionStore{
-		rejections: map[string]string{f2.ID: store.StatusReject},
-		errIDs:     map[string]error{f1.ID: errors.New("db read error")},
-	}
-
-	gotFindings, gotMatches := filterRejected(s, findings, matches, ruleMap)
-
-	// f1 retained (error → no rejection), f2 removed
-	require.Len(t, gotFindings, 1)
-	assert.Equal(t, f1.ID, gotFindings[0].ID, "finding whose annotation returned an error should be retained")
-
-	require.Len(t, gotMatches, 1)
-	assert.Equal(t, "sm-err", gotMatches[0].StructuralID, "match for error-path finding should be retained")
+func TestFilterRejected_BulkAnnotationError_Propagates(t *testing.T) {
+	s := &fakeRejectionStore{bulkErr: errors.New("db exploded")}
+	_, _, err := filterRejected(s, []*types.Finding{{ID: "f1"}}, nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "db exploded")
 }
 
 func TestFilterRejected_MatchWithoutFindingIsRetained(t *testing.T) {
@@ -833,7 +803,8 @@ func TestFilterRejected_MatchWithoutFindingIsRetained(t *testing.T) {
 		rejections: map[string]string{rejected.ID: store.StatusReject},
 	}
 
-	gotFindings, gotMatches := filterRejected(s, findings, matches, ruleMap)
+	gotFindings, gotMatches, err := filterRejected(s, findings, matches, ruleMap)
+	require.NoError(t, err)
 
 	assert.Empty(t, gotFindings, "rejected finding should be removed")
 
@@ -874,7 +845,8 @@ func TestFilterRejected_DuplicateStructuralIDs(t *testing.T) {
 		rejections: map[string]string{f1.ID: store.StatusReject},
 	}
 
-	gotFindings, gotMatches := filterRejected(s, findings, matches, ruleMap)
+	gotFindings, gotMatches, err := filterRejected(s, findings, matches, ruleMap)
+	require.NoError(t, err)
 
 	assert.Empty(t, gotFindings)
 	// Both matches share the same StructuralID that is in the rejected set;

--- a/cmd/titus/report_test.go
+++ b/cmd/titus/report_test.go
@@ -641,8 +641,8 @@ func TestFilterRejected_AllFindingsRejected_ReturnsEmpty(t *testing.T) {
 
 	s := &fakeRejectionStore{
 		rejections: map[string]string{
-			f1.ID: "reject",
-			f2.ID: "reject",
+			f1.ID: store.StatusReject,
+			f2.ID: store.StatusReject,
 		},
 	}
 
@@ -704,7 +704,7 @@ func TestFilterRejected_PartialRejection_RemovesRejectedFindingAndItsMatches(t *
 
 	// Only f2 (middle) is rejected.
 	s := &fakeRejectionStore{
-		rejections: map[string]string{f2.ID: "reject"},
+		rejections: map[string]string{f2.ID: store.StatusReject},
 	}
 
 	gotFindings, gotMatches := filterRejected(s, findings, matches, ruleMap)
@@ -750,7 +750,7 @@ func TestFilterRejected_NonRejectStatusRetained(t *testing.T) {
 
 	// f1 has "accept" status, f2 has no status — neither should be filtered.
 	s := &fakeRejectionStore{
-		rejections: map[string]string{f1.ID: "accept"},
+		rejections: map[string]string{f1.ID: store.StatusAccept},
 	}
 
 	gotFindings, gotMatches := filterRejected(s, findings, matches, ruleMap)
@@ -786,7 +786,7 @@ func TestFilterRejected_AnnotationErrorIsIgnored(t *testing.T) {
 	// status) — the error path means it must NOT be filtered.
 	// f2 returns status "reject" with no error — it MUST be filtered.
 	s := &fakeRejectionStore{
-		rejections: map[string]string{f2.ID: "reject"},
+		rejections: map[string]string{f2.ID: store.StatusReject},
 		errIDs:     map[string]error{f1.ID: errors.New("db read error")},
 	}
 
@@ -830,7 +830,7 @@ func TestFilterRejected_MatchWithoutFindingIsRetained(t *testing.T) {
 	matches := []*types.Match{orphanMatch, rejectedMatch}
 
 	s := &fakeRejectionStore{
-		rejections: map[string]string{rejected.ID: "reject"},
+		rejections: map[string]string{rejected.ID: store.StatusReject},
 	}
 
 	gotFindings, gotMatches := filterRejected(s, findings, matches, ruleMap)
@@ -871,7 +871,7 @@ func TestFilterRejected_DuplicateStructuralIDs(t *testing.T) {
 	matches := []*types.Match{m1, m2}
 
 	s := &fakeRejectionStore{
-		rejections: map[string]string{f1.ID: "reject"},
+		rejections: map[string]string{f1.ID: store.StatusReject},
 	}
 
 	gotFindings, gotMatches := filterRejected(s, findings, matches, ruleMap)

--- a/cmd/titus/report_test.go
+++ b/cmd/titus/report_test.go
@@ -3,10 +3,14 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
+	"github.com/praetorian-inc/titus/pkg/store"
 	"github.com/praetorian-inc/titus/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOutputReportHuman_FullSnippetContext(t *testing.T) {
@@ -504,4 +508,376 @@ func TestOutputSummaryJSON(t *testing.T) {
 	if parsed.Rules[0].RuleName != "AWS API Key" {
 		t.Errorf("Expected first rule_name='AWS API Key', got %q", parsed.Rules[0].RuleName)
 	}
+}
+
+// =============================================================================
+// Fake store for filterRejected tests
+// =============================================================================
+
+// fakeRejectionStore is a minimal store.Store implementation for testing
+// filterRejected. Only GetAnnotation is meaningful; all other methods are
+// satisfied by embedding store.Store (nil panic guard — tests must not call
+// any other method).
+type fakeRejectionStore struct {
+	store.Store
+	rejections map[string]string // key: finding ID, value: status string
+	errIDs     map[string]error  // key: finding ID, value: error to return
+}
+
+func (f *fakeRejectionStore) GetAnnotation(targetType, targetID string) (string, string, error) {
+	if f.errIDs != nil {
+		if err, ok := f.errIDs[targetID]; ok {
+			return "", "", err
+		}
+	}
+	if status, ok := f.rejections[targetID]; ok {
+		return status, "", nil
+	}
+	return "", "", nil
+}
+
+// =============================================================================
+// Flag wiring tests
+// =============================================================================
+
+func TestReportCmd_ShowRejectedFlag_RegisteredAsPersistent(t *testing.T) {
+	flag := reportCmd.PersistentFlags().Lookup("show-rejected")
+	require.NotNil(t, flag, "expected --show-rejected to be registered as a persistent flag on reportCmd")
+	assert.Equal(t, "bool", flag.Value.Type())
+}
+
+func TestReportCmd_ShowRejectedFlag_DefaultsToFalse(t *testing.T) {
+	flag := reportCmd.PersistentFlags().Lookup("show-rejected")
+	require.NotNil(t, flag)
+	assert.Equal(t, "false", flag.DefValue)
+}
+
+func TestSummaryCmd_InheritsShowRejectedFromReport(t *testing.T) {
+	// The flag is persistent on reportCmd so summaryCmd inherits it.
+	inherited := summaryCmd.InheritedFlags().Lookup("show-rejected")
+	assert.NotNil(t, inherited, "summaryCmd should inherit --show-rejected from reportCmd persistent flags")
+
+	// It must NOT appear as a locally-defined (non-inherited) flag on summaryCmd.
+	// Use LocalNonPersistentFlags which only returns flags defined directly on
+	// summaryCmd, not those merged in from parent persistent flag sets.
+	local := summaryCmd.LocalNonPersistentFlags().Lookup("show-rejected")
+	assert.Nil(t, local, "--show-rejected must not be a local flag on summaryCmd, only inherited")
+}
+
+func TestReportCmd_ShowRejectedFlag_Description(t *testing.T) {
+	flag := reportCmd.PersistentFlags().Lookup("show-rejected")
+	require.NotNil(t, flag)
+	assert.Contains(t, flag.Usage, "rejected",
+		"flag description should mention 'rejected'")
+}
+
+// =============================================================================
+// filterRejected core logic tests
+// =============================================================================
+
+func TestFilterRejected_EmptyFindings(t *testing.T) {
+	s := &fakeRejectionStore{rejections: map[string]string{}}
+	findings, matches := filterRejected(s, nil, nil, nil)
+	assert.Empty(t, findings)
+	assert.Empty(t, matches)
+}
+
+func TestFilterRejected_NoRejections_ReturnsInputsUnchanged(t *testing.T) {
+	rule := &types.Rule{
+		ID:           "rule-1",
+		StructuralID: "struct-1",
+	}
+	ruleMap := map[string]*types.Rule{"rule-1": rule}
+
+	f1 := &types.Finding{
+		ID:     types.ComputeFindingID(rule.StructuralID, [][]byte{[]byte("secret-a")}),
+		RuleID: "rule-1",
+		Groups: [][]byte{[]byte("secret-a")},
+	}
+	f2 := &types.Finding{
+		ID:     types.ComputeFindingID(rule.StructuralID, [][]byte{[]byte("secret-b")}),
+		RuleID: "rule-1",
+		Groups: [][]byte{[]byte("secret-b")},
+	}
+	findings := []*types.Finding{f1, f2}
+
+	m1 := &types.Match{StructuralID: "match-1", RuleID: "rule-1", Groups: [][]byte{[]byte("secret-a")}}
+	m2 := &types.Match{StructuralID: "match-2", RuleID: "rule-1", Groups: [][]byte{[]byte("secret-b")}}
+	matches := []*types.Match{m1, m2}
+
+	// Store returns empty status for all IDs — no rejections
+	s := &fakeRejectionStore{rejections: map[string]string{}}
+
+	gotFindings, gotMatches := filterRejected(s, findings, matches, ruleMap)
+
+	assert.Len(t, gotFindings, 2, "all findings should be retained when none are rejected")
+	assert.Len(t, gotMatches, 2, "all matches should be retained when none are rejected")
+	assert.Equal(t, findings, gotFindings, "returned findings slice should equal input")
+	assert.Equal(t, matches, gotMatches, "returned matches slice should equal input")
+}
+
+func TestFilterRejected_AllFindingsRejected_ReturnsEmpty(t *testing.T) {
+	rule := &types.Rule{
+		ID:           "rule-1",
+		StructuralID: "struct-1",
+	}
+	ruleMap := map[string]*types.Rule{"rule-1": rule}
+
+	f1 := &types.Finding{
+		ID:     types.ComputeFindingID(rule.StructuralID, [][]byte{[]byte("secret-a")}),
+		RuleID: "rule-1",
+		Groups: [][]byte{[]byte("secret-a")},
+	}
+	f2 := &types.Finding{
+		ID:     types.ComputeFindingID(rule.StructuralID, [][]byte{[]byte("secret-b")}),
+		RuleID: "rule-1",
+		Groups: [][]byte{[]byte("secret-b")},
+	}
+	findings := []*types.Finding{f1, f2}
+
+	m1 := &types.Match{StructuralID: "match-1", RuleID: "rule-1", Groups: [][]byte{[]byte("secret-a")}}
+	m2 := &types.Match{StructuralID: "match-2", RuleID: "rule-1", Groups: [][]byte{[]byte("secret-b")}}
+	matches := []*types.Match{m1, m2}
+
+	s := &fakeRejectionStore{
+		rejections: map[string]string{
+			f1.ID: "reject",
+			f2.ID: "reject",
+		},
+	}
+
+	gotFindings, gotMatches := filterRejected(s, findings, matches, ruleMap)
+
+	assert.Empty(t, gotFindings, "all findings should be removed when all are rejected")
+	assert.Empty(t, gotMatches, "all matches should be removed when all findings are rejected")
+}
+
+func TestFilterRejected_PartialRejection_RemovesRejectedFindingAndItsMatches(t *testing.T) {
+	rule := &types.Rule{
+		ID:           "rule-1",
+		StructuralID: "struct-partial",
+	}
+	ruleMap := map[string]*types.Rule{"rule-1": rule}
+
+	// Three findings: first, middle (to be rejected), last
+	f1 := &types.Finding{
+		ID:     types.ComputeFindingID(rule.StructuralID, [][]byte{[]byte("secret-1")}),
+		RuleID: "rule-1",
+		Groups: [][]byte{[]byte("secret-1")},
+	}
+	f2 := &types.Finding{
+		ID:     types.ComputeFindingID(rule.StructuralID, [][]byte{[]byte("secret-2")}),
+		RuleID: "rule-1",
+		Groups: [][]byte{[]byte("secret-2")},
+	}
+	f3 := &types.Finding{
+		ID:     types.ComputeFindingID(rule.StructuralID, [][]byte{[]byte("secret-3")}),
+		RuleID: "rule-1",
+		Groups: [][]byte{[]byte("secret-3")},
+	}
+	findings := []*types.Finding{f1, f2, f3}
+
+	// Build matches with StructuralID set so buildFindingMatchMap can resolve
+	// them via ComputeFindingID.  We assign each match a RuleID and Groups
+	// matching its parent finding so the content-based map links them.
+	m1 := &types.Match{
+		StructuralID: "smatch-1",
+		RuleID:       "rule-1",
+		Groups:       [][]byte{[]byte("secret-1")},
+	}
+	m2a := &types.Match{
+		StructuralID: "smatch-2a",
+		RuleID:       "rule-1",
+		Groups:       [][]byte{[]byte("secret-2")},
+	}
+	m2b := &types.Match{
+		StructuralID: "smatch-2b",
+		RuleID:       "rule-1",
+		Groups:       [][]byte{[]byte("secret-2")},
+	}
+	m3 := &types.Match{
+		StructuralID: "smatch-3",
+		RuleID:       "rule-1",
+		Groups:       [][]byte{[]byte("secret-3")},
+	}
+	matches := []*types.Match{m1, m2a, m2b, m3}
+
+	// Only f2 (middle) is rejected.
+	s := &fakeRejectionStore{
+		rejections: map[string]string{f2.ID: "reject"},
+	}
+
+	gotFindings, gotMatches := filterRejected(s, findings, matches, ruleMap)
+
+	require.Len(t, gotFindings, 2, "should have 2 findings after rejecting middle one")
+	assert.Equal(t, f1, gotFindings[0], "first finding retained")
+	assert.Equal(t, f3, gotFindings[1], "last finding retained")
+
+	// Matches for f2 (m2a and m2b) should be removed; m1 and m3 should remain.
+	require.Len(t, gotMatches, 2, "should have 2 matches after removing rejected finding's matches")
+	structIDs := make([]string, 0, len(gotMatches))
+	for _, m := range gotMatches {
+		structIDs = append(structIDs, m.StructuralID)
+	}
+	assert.Contains(t, structIDs, "smatch-1")
+	assert.Contains(t, structIDs, "smatch-3")
+	assert.NotContains(t, structIDs, "smatch-2a")
+	assert.NotContains(t, structIDs, "smatch-2b")
+}
+
+func TestFilterRejected_NonRejectStatusRetained(t *testing.T) {
+	rule := &types.Rule{
+		ID:           "rule-1",
+		StructuralID: "struct-nonreject",
+	}
+	ruleMap := map[string]*types.Rule{"rule-1": rule}
+
+	f1 := &types.Finding{
+		ID:     types.ComputeFindingID(rule.StructuralID, [][]byte{[]byte("val-1")}),
+		RuleID: "rule-1",
+		Groups: [][]byte{[]byte("val-1")},
+	}
+	f2 := &types.Finding{
+		ID:     types.ComputeFindingID(rule.StructuralID, [][]byte{[]byte("val-2")}),
+		RuleID: "rule-1",
+		Groups: [][]byte{[]byte("val-2")},
+	}
+	findings := []*types.Finding{f1, f2}
+	matches := []*types.Match{
+		{StructuralID: "sm-1", RuleID: "rule-1", Groups: [][]byte{[]byte("val-1")}},
+		{StructuralID: "sm-2", RuleID: "rule-1", Groups: [][]byte{[]byte("val-2")}},
+	}
+
+	// f1 has "accept" status, f2 has no status — neither should be filtered.
+	s := &fakeRejectionStore{
+		rejections: map[string]string{f1.ID: "accept"},
+	}
+
+	gotFindings, gotMatches := filterRejected(s, findings, matches, ruleMap)
+
+	assert.Len(t, gotFindings, 2, "findings with non-reject status should be retained")
+	assert.Len(t, gotMatches, 2, "matches for non-rejected findings should be retained")
+}
+
+func TestFilterRejected_AnnotationErrorIsIgnored(t *testing.T) {
+	rule := &types.Rule{
+		ID:           "rule-1",
+		StructuralID: "struct-errtest",
+	}
+	ruleMap := map[string]*types.Rule{"rule-1": rule}
+
+	f1 := &types.Finding{
+		ID:     types.ComputeFindingID(rule.StructuralID, [][]byte{[]byte("err-val")}),
+		RuleID: "rule-1",
+		Groups: [][]byte{[]byte("err-val")},
+	}
+	f2 := &types.Finding{
+		ID:     types.ComputeFindingID(rule.StructuralID, [][]byte{[]byte("ok-val")}),
+		RuleID: "rule-1",
+		Groups: [][]byte{[]byte("ok-val")},
+	}
+	findings := []*types.Finding{f1, f2}
+	matches := []*types.Match{
+		{StructuralID: "sm-err", RuleID: "rule-1", Groups: [][]byte{[]byte("err-val")}},
+		{StructuralID: "sm-ok", RuleID: "rule-1", Groups: [][]byte{[]byte("ok-val")}},
+	}
+
+	// f1 returns an error from GetAnnotation (even though "reject" would be the
+	// status) — the error path means it must NOT be filtered.
+	// f2 returns status "reject" with no error — it MUST be filtered.
+	s := &fakeRejectionStore{
+		rejections: map[string]string{f2.ID: "reject"},
+		errIDs:     map[string]error{f1.ID: errors.New("db read error")},
+	}
+
+	gotFindings, gotMatches := filterRejected(s, findings, matches, ruleMap)
+
+	// f1 retained (error → no rejection), f2 removed
+	require.Len(t, gotFindings, 1)
+	assert.Equal(t, f1.ID, gotFindings[0].ID, "finding whose annotation returned an error should be retained")
+
+	require.Len(t, gotMatches, 1)
+	assert.Equal(t, "sm-err", gotMatches[0].StructuralID, "match for error-path finding should be retained")
+}
+
+func TestFilterRejected_MatchWithoutFindingIsRetained(t *testing.T) {
+	rule := &types.Rule{
+		ID:           "rule-1",
+		StructuralID: "struct-orphan",
+	}
+	ruleMap := map[string]*types.Rule{"rule-1": rule}
+
+	// Only one finding; its match uses groups "reject-me".
+	rejected := &types.Finding{
+		ID:     types.ComputeFindingID(rule.StructuralID, [][]byte{[]byte("reject-me")}),
+		RuleID: "rule-1",
+		Groups: [][]byte{[]byte("reject-me")},
+	}
+	findings := []*types.Finding{rejected}
+
+	// "Orphan" match: its Groups do not match any finding in ruleMap
+	// (different groups value, so buildFindingMatchMap won't link it).
+	orphanMatch := &types.Match{
+		StructuralID: "sm-orphan",
+		RuleID:       "rule-other", // not in ruleMap → won't resolve to any finding
+		Groups:       [][]byte{[]byte("orphan-val")},
+	}
+	rejectedMatch := &types.Match{
+		StructuralID: "sm-rejected",
+		RuleID:       "rule-1",
+		Groups:       [][]byte{[]byte("reject-me")},
+	}
+	matches := []*types.Match{orphanMatch, rejectedMatch}
+
+	s := &fakeRejectionStore{
+		rejections: map[string]string{rejected.ID: "reject"},
+	}
+
+	gotFindings, gotMatches := filterRejected(s, findings, matches, ruleMap)
+
+	assert.Empty(t, gotFindings, "rejected finding should be removed")
+
+	// The orphan match is NOT linked to any rejected finding, so it must survive.
+	require.Len(t, gotMatches, 1, "orphan match unrelated to rejected finding should be retained")
+	assert.Equal(t, "sm-orphan", gotMatches[0].StructuralID)
+}
+
+func TestFilterRejected_DuplicateStructuralIDs(t *testing.T) {
+	rule := &types.Rule{
+		ID:           "rule-1",
+		StructuralID: "struct-dup",
+	}
+	ruleMap := map[string]*types.Rule{"rule-1": rule}
+
+	f1 := &types.Finding{
+		ID:     types.ComputeFindingID(rule.StructuralID, [][]byte{[]byte("dup-val")}),
+		RuleID: "rule-1",
+		Groups: [][]byte{[]byte("dup-val")},
+	}
+	findings := []*types.Finding{f1}
+
+	// Two matches sharing the exact same StructuralID (defensive scenario).
+	sharedID := "sm-shared"
+	m1 := &types.Match{
+		StructuralID: sharedID,
+		RuleID:       "rule-1",
+		Groups:       [][]byte{[]byte("dup-val")},
+	}
+	m2 := &types.Match{
+		StructuralID: sharedID,
+		RuleID:       "rule-1",
+		Groups:       [][]byte{[]byte("dup-val")},
+	}
+	matches := []*types.Match{m1, m2}
+
+	s := &fakeRejectionStore{
+		rejections: map[string]string{f1.ID: "reject"},
+	}
+
+	gotFindings, gotMatches := filterRejected(s, findings, matches, ruleMap)
+
+	assert.Empty(t, gotFindings)
+	// Both matches share the same StructuralID that is in the rejected set;
+	// both should be removed.
+	assert.Empty(t, gotMatches, "both matches with the shared StructuralID should be removed when finding is rejected")
 }

--- a/pkg/explore/model.go
+++ b/pkg/explore/model.go
@@ -10,6 +10,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
+	"github.com/praetorian-inc/titus/pkg/store"
 	"github.com/praetorian-inc/titus/pkg/types"
 )
 
@@ -202,17 +203,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.focus == paneFindings || m.focus == paneDetails {
 			switch {
 			case keyMatches(msg, defaultKeys.Accept):
-				m.setAnnotation("accept")
+				m.setAnnotation(store.StatusAccept)
 				return m, nil
 			case keyMatches(msg, defaultKeys.Reject):
-				m.setAnnotation("reject")
+				m.setAnnotation(store.StatusReject)
 				return m, nil
 			case keyMatches(msg, defaultKeys.AcceptNext):
-				m.setAnnotation("accept")
+				m.setAnnotation(store.StatusAccept)
 				m.moveNext()
 				return m, nil
 			case keyMatches(msg, defaultKeys.RejectNext):
-				m.setAnnotation("reject")
+				m.setAnnotation(store.StatusReject)
 				m.moveNext()
 				return m, nil
 			case keyMatches(msg, defaultKeys.Comment):

--- a/pkg/explore/styles.go
+++ b/pkg/explore/styles.go
@@ -1,6 +1,9 @@
 package explore
 
-import "github.com/charmbracelet/lipgloss"
+import (
+	"github.com/charmbracelet/lipgloss"
+	"github.com/praetorian-inc/titus/pkg/store"
+)
 
 // Colors
 var (
@@ -121,10 +124,10 @@ func renderValidationStatus(status string) string {
 // renderAnnotationStatus returns a styled string for an annotation status.
 func renderAnnotationStatus(status string) string {
 	switch status {
-	case "accept":
-		return acceptStyle.Render("accept")
-	case "reject":
-		return rejectStyle.Render("reject")
+	case store.StatusAccept:
+		return acceptStyle.Render(store.StatusAccept)
+	case store.StatusReject:
+		return rejectStyle.Render(store.StatusReject)
 	default:
 		return ""
 	}

--- a/pkg/store/annotation.go
+++ b/pkg/store/annotation.go
@@ -1,0 +1,15 @@
+// Package store persists annotations, findings, matches, and related scan data.
+//
+// This file defines canonical values for annotation fields so callers don't
+// have to hardcode string literals.
+package store
+
+// Annotation status values for findings and matches. Used with SetAnnotation
+// and returned from GetAnnotation.
+const (
+	// StatusAccept marks a finding or match as accepted (a true positive).
+	StatusAccept = "accept"
+	// StatusReject marks a finding or match as rejected (a false positive).
+	// Rejected findings are hidden from `titus report` by default.
+	StatusReject = "reject"
+)

--- a/pkg/store/memory.go
+++ b/pkg/store/memory.go
@@ -208,6 +208,11 @@ func (m *MemoryStore) SetAnnotation(targetType, targetID, status, comment string
 	return nil
 }
 
+// GetAnnotationsByType is a no-op for in-memory store.
+func (m *MemoryStore) GetAnnotationsByType(targetType string) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+
 // Close closes the database connection.
 // For in-memory store, this is a no-op.
 func (m *MemoryStore) Close() error {

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -364,6 +364,33 @@ func (s *SQLiteStore) GetAnnotation(targetType, targetID string) (string, string
 	return status.String, comment.String, nil
 }
 
+func (s *SQLiteStore) GetAnnotationsByType(targetType string) (map[string]string, error) {
+	rows, err := s.e.Query(
+		"SELECT target_id, status FROM annotations WHERE target_type = ? AND status IS NOT NULL",
+		targetType,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	result := make(map[string]string)
+	for rows.Next() {
+		var id string
+		var status sql.NullString
+		if err := rows.Scan(&id, &status); err != nil {
+			return nil, err
+		}
+		if status.Valid {
+			result[id] = status.String
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
 func (s *SQLiteStore) SetAnnotation(targetType, targetID, status, comment string) error {
 	var statusVal, commentVal sql.NullString
 	if status != "" {

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -54,6 +54,10 @@ type Store interface {
 	// SetAnnotation creates or updates an annotation.
 	SetAnnotation(targetType, targetID, status, comment string) error
 
+	// GetAnnotationsByType returns a map of targetID → status for all annotations
+	// of the given targetType. Useful when filtering many findings at once.
+	GetAnnotationsByType(targetType string) (map[string]string, error)
+
 	// Close closes the database connection.
 	Close() error
 }


### PR DESCRIPTION
## Summary

Rejected findings (marked via the `explore` command) are now excluded from `titus report` and `titus report summary` output by default. Users can pass `--show-rejected` to include them.

Closes #189.

## Design

- **Default is to hide** rejected findings — the whole point of marking something "reject" in explore is to not see it again.
- **`--show-rejected`** (default `false`) is the opt-in to include them back in the output.
- **Persistent flag** on `reportCmd` so both `titus report ... --show-rejected` and `titus report summary --show-rejected` work.
- **Filter semantics**: removes both the rejected finding AND all matches belonging to that finding. Match-level filtering uses the existing `buildFindingMatchMap` helper for consistency.
- **No-op fast path**: if zero findings are rejected, returns the inputs unchanged.

## Origin

Logic is adapted from the proposal in [sw-mreyes/titus:feat/filter-rejected-findings](https://github.com/praetorian-inc/titus/compare/main...sw-mreyes:titus:feat/filter-rejected-findings). The fork applied the filter unconditionally; this version makes it the default with an opt-out flag to show them.

## Test plan
- [x] `go build ./...` — clean
- [x] `go test ./cmd/titus/...` — all existing tests pass
- [ ] Manual: `titus report` hides rejected findings by default
- [ ] Manual: `titus report --show-rejected` includes rejected findings
- [ ] Manual: `titus report summary` / `titus report summary --show-rejected` mirror the same behavior