### PR TITLE
fix(report): include file path in JSON output

### DIFF
--- a/cmd/titus/report.go
+++ b/cmd/titus/report.go
@@ -260,7 +260,7 @@ func runReport(cmd *cobra.Command, args []string) error {
 	// Output based on format
 	switch reportFormat {
 	case "json":
-		return outputReportJSON(cmd, findings, matches, ruleMap)
+		return outputReportJSON(cmd, s, findings, matches, ruleMap)
 	case "human":
 		return outputReportHuman(cmd, findings, matches, storePath, ruleMap)
 	case "sarif":
@@ -627,18 +627,57 @@ func outputReportSARIF(cmd *cobra.Command, s store.Store, findings []*types.Find
 	return nil
 }
 
-func outputReportJSON(cmd *cobra.Command, findings []*types.Finding, matches []*types.Match, ruleMap map[string]*types.Rule) error {
-	// Group matches by finding ID using content-based computation
+// jsonMatch is a shadow type for types.Match that adds a file_path field to
+// the JSON output without modifying the shared types.Match struct. Embedding
+// *types.Match exposes all existing fields; the outer FilePath field takes
+// precedence over any same-named field on the embedded struct.
+type jsonMatch struct {
+	*types.Match
+	FilePath string `json:"file_path"`
+}
+
+// jsonFinding is a shadow type for types.Finding that replaces the Matches
+// slice with []jsonMatch so each match carries a file_path. The json tag
+// here must match the marshaled name of types.Finding.Matches; if that
+// field ever gains an explicit json tag, update this tag in lockstep or
+// the output will contain two "Matches" keys.
+type jsonFinding struct {
+	*types.Finding
+	Matches []jsonMatch `json:"Matches"`
+}
+
+func outputReportJSON(cmd *cobra.Command, s store.Store, findings []*types.Finding, matches []*types.Match, ruleMap map[string]*types.Rule) error {
+	// Group matches by finding ID using content-based computation.
 	matchesByFinding := buildFindingMatchMap(findings, matches, ruleMap)
 
-	// Attach matches to their findings
+	// Cache provenance path lookups to avoid redundant store queries.
+	provenanceCache := make(map[types.BlobID]string)
+
+	// Build the output slice using the shadow types so we don't mutate
+	// the shared types.Finding/types.Match structs.
+	out := make([]jsonFinding, 0, len(findings))
 	for _, f := range findings {
-		f.Matches = matchesByFinding[f.ID]
+		ms := matchesByFinding[f.ID]
+		jms := make([]jsonMatch, 0, len(ms))
+		for _, m := range ms {
+			filePath, ok := provenanceCache[m.BlobID]
+			if !ok {
+				prov, err := s.GetProvenance(m.BlobID)
+				if err != nil {
+					filePath = m.BlobID.Hex()
+				} else {
+					filePath = prov.Path()
+				}
+				provenanceCache[m.BlobID] = filePath
+			}
+			jms = append(jms, jsonMatch{Match: m, FilePath: filePath})
+		}
+		out = append(out, jsonFinding{Finding: f, Matches: jms})
 	}
 
 	encoder := json.NewEncoder(cmd.OutOrStdout())
 	encoder.SetIndent("", "  ")
-	return encoder.Encode(findings)
+	return encoder.Encode(out)
 }
 
 func outputReportHuman(cmd *cobra.Command, findings []*types.Finding, matches []*types.Match, datastorePath string, ruleMap map[string]*types.Rule) error {

--- a/cmd/titus/report_test.go
+++ b/cmd/titus/report_test.go
@@ -956,7 +956,7 @@ func TestReport_JSON_ScoreRoundTrip_Golden(t *testing.T) {
 	cmd := &cobra.Command{}
 	var buf bytes.Buffer
 	cmd.SetOut(&buf)
-	require.NoError(t, outputReportJSON(cmd, findings, matches, ruleMap))
+	require.NoError(t, outputReportJSON(cmd, s, findings, matches, ruleMap))
 
 	goldenPath := "testdata/golden/score_json.golden.json"
 	wantBytes, err := os.ReadFile(goldenPath)
@@ -1061,4 +1061,146 @@ func TestFilterRejected_DuplicateStructuralIDs(t *testing.T) {
 	// Both matches share the same StructuralID that is in the rejected set;
 	// both should be removed.
 	assert.Empty(t, gotMatches, "both matches with the shared StructuralID should be removed when finding is rejected")
+}
+
+// =============================================================================
+// Tests for outputReportJSON file_path field (issue #197)
+// =============================================================================
+
+// jsonMatchOutput is used to decode the Matches field from outputReportJSON output.
+type jsonMatchOutput struct {
+	BlobID       types.BlobID `json:"BlobID"`
+	StructuralID string       `json:"StructuralID"`
+	RuleID       string       `json:"RuleID"`
+	FilePath     string       `json:"file_path"`
+}
+
+// jsonFindingOutput is used to decode the top-level finding output.
+type jsonFindingOutput struct {
+	ID      string            `json:"ID"`
+	RuleID  string            `json:"RuleID"`
+	Matches []jsonMatchOutput `json:"Matches"`
+}
+
+func TestOutputReportJSON_IncludesFilePath(t *testing.T) {
+	tmpDir := t.TempDir()
+	s, err := store.New(store.Config{Path: filepath.Join(tmpDir, "test.db")})
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+
+	// Set up rule
+	rule := &types.Rule{ID: "np.test.1", Name: "Test Rule", Pattern: "sk_test_.*"}
+	rule.StructuralID = rule.ComputeStructuralID()
+	require.NoError(t, s.AddRule(rule))
+
+	// Set up finding
+	groups := [][]byte{[]byte("sk_test_secret")}
+	finding := &types.Finding{
+		ID:     types.ComputeFindingID(rule.StructuralID, groups),
+		RuleID: "np.test.1",
+		Groups: groups,
+	}
+	require.NoError(t, s.AddFinding(finding))
+
+	// Set up blob with provenance pointing to a known path
+	blobID := types.ComputeBlobID([]byte("STRIPE_SECRET_KEY=sk_test_secret"))
+	require.NoError(t, s.AddBlob(blobID, 32))
+	wantPath := "/tmp/demo/creds.txt"
+	require.NoError(t, s.AddProvenance(blobID, types.FileProvenance{FilePath: wantPath}))
+
+	// Set up match linking blob to finding
+	match := &types.Match{
+		StructuralID: "sm-stripe-1",
+		RuleID:       "np.test.1",
+		BlobID:       blobID,
+		Groups:       groups,
+		Location:     types.Location{},
+		Snippet: types.Snippet{
+			Matching: []byte("sk_test_secret"),
+		},
+	}
+	require.NoError(t, s.AddMatch(match))
+
+	findings, err := s.GetFindings()
+	require.NoError(t, err)
+	matches, err := s.GetAllMatches()
+	require.NoError(t, err)
+	ruleMap := map[string]*types.Rule{"np.test.1": rule}
+
+	cmd := &cobra.Command{}
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	require.NoError(t, outputReportJSON(cmd, s, findings, matches, ruleMap))
+
+	// Parse the JSON output
+	var output []jsonFindingOutput
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &output), "output must be valid JSON")
+
+	require.Len(t, output, 1, "expected exactly one finding")
+	require.Len(t, output[0].Matches, 1, "expected exactly one match")
+
+	gotMatch := output[0].Matches[0]
+
+	// Primary assertion: file_path must be the provenance path, not a blob hex string.
+	assert.Equal(t, wantPath, gotMatch.FilePath,
+		"file_path should equal the provenance path, not the blob hex")
+
+	// Existing fields must be preserved.
+	assert.Equal(t, "np.test.1", gotMatch.RuleID, "RuleID should be preserved in match output")
+	assert.Equal(t, "sm-stripe-1", gotMatch.StructuralID, "StructuralID should be preserved in match output")
+}
+
+func TestOutputReportJSON_FilePathFallsBackToBlobHex(t *testing.T) {
+	// When no provenance exists for a blob, file_path should fall back to blob hex string.
+	tmpDir := t.TempDir()
+	s, err := store.New(store.Config{Path: filepath.Join(tmpDir, "test.db")})
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+
+	rule := &types.Rule{ID: "np.test.2", Name: "Test Rule 2", Pattern: "tok_.*"}
+	rule.StructuralID = rule.ComputeStructuralID()
+	require.NoError(t, s.AddRule(rule))
+
+	groups := [][]byte{[]byte("tok_abc")}
+	finding := &types.Finding{
+		ID:     types.ComputeFindingID(rule.StructuralID, groups),
+		RuleID: "np.test.2",
+		Groups: groups,
+	}
+	require.NoError(t, s.AddFinding(finding))
+
+	blobID := types.ComputeBlobID([]byte("TOKEN=tok_abc"))
+	require.NoError(t, s.AddBlob(blobID, 13))
+	// No AddProvenance call — no provenance for this blob.
+
+	match := &types.Match{
+		StructuralID: "sm-token-1",
+		RuleID:       "np.test.2",
+		BlobID:       blobID,
+		Groups:       groups,
+		Location:     types.Location{},
+	}
+	require.NoError(t, s.AddMatch(match))
+
+	findings, err := s.GetFindings()
+	require.NoError(t, err)
+	matches, err := s.GetAllMatches()
+	require.NoError(t, err)
+	ruleMap := map[string]*types.Rule{"np.test.2": rule}
+
+	cmd := &cobra.Command{}
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	require.NoError(t, outputReportJSON(cmd, s, findings, matches, ruleMap))
+
+	var output []jsonFindingOutput
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &output))
+
+	require.Len(t, output, 1)
+	require.Len(t, output[0].Matches, 1)
+
+	gotMatch := output[0].Matches[0]
+	// file_path must fall back to the blob ID hex string when no provenance exists.
+	assert.Equal(t, blobID.Hex(), gotMatch.FilePath,
+		"file_path should fall back to BlobID.Hex() when provenance is unavailable")
 }

--- a/cmd/titus/report_test.go
+++ b/cmd/titus/report_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -1203,4 +1204,44 @@ func TestOutputReportJSON_FilePathFallsBackToBlobHex(t *testing.T) {
 	// file_path must fall back to the blob ID hex string when no provenance exists.
 	assert.Equal(t, blobID.Hex(), gotMatch.FilePath,
 		"file_path should fall back to BlobID.Hex() when provenance is unavailable")
+}
+
+// =============================================================================
+// Regression test: jsonFinding.Matches tag must track types.Finding.Matches
+// =============================================================================
+
+func TestJSONFindingMatchesTagTracksFinding(t *testing.T) {
+	// If types.Finding.Matches ever gains or changes its json tag, the
+	// shadow jsonFinding.Matches tag must be updated in lockstep, otherwise
+	// titus report --format json will emit two "Matches" keys (or one wrong
+	// key and the embedded original). This test enforces that coupling.
+
+	findingField, ok := reflect.TypeOf(types.Finding{}).FieldByName("Matches")
+	require.True(t, ok, "types.Finding.Matches field not found")
+
+	findingMarshaledName := marshaledJSONName(findingField)
+
+	jfField, ok := reflect.TypeOf(jsonFinding{}).FieldByName("Matches")
+	require.True(t, ok, "jsonFinding.Matches field not found")
+
+	jfMarshaledName := marshaledJSONName(jfField)
+
+	require.Equal(t, findingMarshaledName, jfMarshaledName,
+		"jsonFinding.Matches json key (%q) must match types.Finding.Matches json key (%q); "+
+			"update the tag in cmd/titus/report.go when types.Finding.Matches changes",
+		jfMarshaledName, findingMarshaledName)
+}
+
+// marshaledJSONName returns the JSON key encoding/json would use for the field,
+// handling untagged fields (default field-name behavior) and tag options like ",omitempty".
+func marshaledJSONName(f reflect.StructField) string {
+	tag := f.Tag.Get("json")
+	if tag == "" {
+		return f.Name
+	}
+	name, _, _ := strings.Cut(tag, ",")
+	if name == "" {
+		return f.Name
+	}
+	return name
 }

--- a/cmd/titus/testdata/golden/score_json.golden.json
+++ b/cmd/titus/testdata/golden/score_json.golden.json
@@ -5,12 +5,12 @@
     "Groups": [
       "eDF4Mng="
     ],
-    "Matches": null,
     "Score": {
       "Final": 75,
       "Base": 75,
       "SuggestedSeverity": "high",
       "Applied": []
-    }
+    },
+    "Matches": []
   }
 ]


### PR DESCRIPTION
## Summary

- `titus report --format json` now emits a `file_path` field on each match, resolved from the datastore's provenance table.
- Introduces thin JSON shadow types in `cmd/titus/report.go` so `types.Match` and `types.Finding` stay untouched (no impact on `titus scan --format json` or any other consumer of those structs).
- Reuses the exact provenance-cache pattern already present in `outputReportSARIF`; fallback to `BlobID.Hex()` on lookup error matches SARIF behavior.

## Context

Fixes one of the three bugs reported in #197 — the other two (SARIF format, missing validation_result) are already working on main:

- **Bug 1 (this PR):** JSON missing file path → previously `outputReportJSON` serialized findings directly without resolving blob provenance. Now each match carries `file_path`.
- **Bug 2:** `titus report --format sarif` unimplemented → shipped with the M1 finding-scoring work; live-verified on main.
- **Bug 3:** Validation status missing from JSON → works when `--validate` is passed; the field is `validation_result` (snake_case, omitempty). Live-demoed against real Stripe/GitHub APIs.

## Test plan

- [x] `TestOutputReportJSON_IncludesFilePath` — real store, real provenance, asserts `file_path` equals the source path
- [x] `TestOutputReportJSON_FilePathFallsBackToBlobHex` — exercises the missing-provenance fallback branch
- [x] Existing `score_json.golden.json` updated (mechanical: `null` → `[]` for empty Matches, field reorder from the shadow embedding; no value changes)
- [x] `go test ./cmd/titus/...` — 103 pass
- [x] `make test` — all 17 packages green
- [x] Manual smoke test: scanned a fixture file, confirmed `file_path` resolves to the on-disk path in JSON output

## Backward compatibility

- JSON consumers still see `BlobID`, `StructuralID`, `RuleID`, `Snippet`, `Location`, `ValidationResult` (when --validate), `Score` — all unchanged.
- New: each match gains `file_path`.
- Minor: empty `Matches` now serializes as `[]` instead of `null`, and the embedded-struct serialization order places `Matches` last. Neither affects correct JSON parsers.

Closes #197