### PR TITLE
fix(ci): add concurrency cancel-in-progress to Go CI/security callers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ on:
       - 'Makefile'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,6 +15,10 @@ on:
     - cron: '0 6 * * 1'  # Mondays 06:00 UTC — weekly baseline
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Adds `concurrency: { cancel-in-progress: true }` to ci.yml and security.yml callers. Without this, rapid pushes to a PR branch create parallel workflow runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)