### PR TITLE
feat(ci): add CLAUDE.md drift detection

### DIFF
--- a/.github/workflows/claude-md-drift.yml
+++ b/.github/workflows/claude-md-drift.yml
@@ -1,0 +1,20 @@
+name: CLAUDE.md Drift Detection
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+
+concurrency:
+  group: claude-drift-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  drift-check:
+    uses: praetorian-inc/public-workflows/.github/workflows/claude-md-drift.yml@87c0808aa16862a7ffef0cd94c516a02eb48242b  # v2.3.0
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+


### PR DESCRIPTION
Adds caller for the centralized CLAUDE.md drift detection workflow. Detects when code changes in a PR may have made CLAUDE.md documentation stale.

- Two-phase: shell pre-filter (zero LLM cost) → Haiku semantic check (~$0.003-0.01/run)
- Only runs when changed code has a relevant CLAUDE.md ancestor
- Skips if all relevant CLAUDE.md files are already modified in the PR
- Idempotent comments on re-runs
- Concurrency: cancel-in-progress per PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)