### PR TITLE
Added support for new GitHub App tokens

### DIFF
--- a/pkg/rule/rules/github.yml
+++ b/pkg/rule/rules/github.yml
@@ -123,6 +123,40 @@ rules:
       GITHUB_SECRET=37d02377a3e9d849e18704c3ec883f9c5787d857
 
 
+- name: GitHub App Installation Token (JWT format)
+  id: np.github.8
+  base_score: 85
+  # GitHub announced on April 24, 2026 that server-to-server installation tokens
+  # (ghs_ prefix) are transitioning to a new JWT-based format:
+  #   ghs_<APPID>_<JWT>
+  # where APPID is numeric and the JWT has three base64url-encoded dot-separated
+  # segments (header.payload.signature). Rollout began April 27, 2026 for
+  # GITHUB_TOKEN in Actions, expanding to all installation tokens mid-May to
+  # late June 2026. Affects GitHub.com (Cloud + Data Residency) only; GHES
+  # continues using the legacy ghs_[a-zA-Z0-9]{36} format (detected by np.github.3).
+  #
+  # Format: ghs_<numeric_app_id>_<base64url_header>.<base64url_payload>.<base64url_sig>
+  # Total length: ~520 chars (variable)
+  pattern: '\b(?P<token>ghs_[0-9]+_[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)\b'
+
+  categories: [api, secret]
+
+  references:
+  - https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-authentication-to-github
+  - https://github.blog/changelog/2026-04-24-upcoming-format-change-for-github_token-and-installation-access-tokens/
+  - https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation
+
+  examples:
+  - 'ghs_123456_eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJhcHBfaWQiLCJpYXQiOjE3MTQyMDgwMDAsImV4cCI6MTcxNDIwODMwMH0.EXAMPLE_SIGNATURE_BASE64URL'
+  - 'GITHUB_TOKEN=ghs_98765_eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpbnN0YWxsYXRpb25faWQiOjEyMzQ1Nn0.EXAMPLE_SIGNATURE_CHARS'
+
+  negative_examples:
+  - 'ghs_RguXIkihJjwHAP6eXEYxaPNvywurTr5IOAbg'  # Legacy format (36 chars, detected by np.github.3)
+  - 'ghs_abc_header.payload.sig'                  # Non-numeric app ID — not a valid JWT-format token
+  - 'ghs_123456_onlyone.part'                     # Only two dot-separated segments (JWT requires three)
+  - 'ghs_'                                        # Prefix only, no token body
+
+
 - name: GitHub Personal Access Token (fine-grained permissions)
   id: np.github.7
   base_score: 65

--- a/pkg/rule/rulesets/default.yml
+++ b/pkg/rule/rulesets/default.yml
@@ -91,6 +91,7 @@ rulesets:
   - np.github.4       # GitHub Refresh Token
   - np.github.6       # GitHub Secret Key
   - np.github.7       # GitHub Personal Access Token
+  - np.github.8       # GitHub App Installation Token (JWT format)
   - np.gitlab.1       # GitLab Runner Registration Token
   - np.gitlab.2       # GitLab Personal Access Token
   - np.gitlab.3       # GitLab Pipeline Trigger Token

--- a/pkg/validator/github_app.go
+++ b/pkg/validator/github_app.go
@@ -37,7 +37,7 @@ func (v *GitHubAppTokenValidator) Name() string {
 }
 
 func (v *GitHubAppTokenValidator) CanValidate(ruleID string) bool {
-	return ruleID == "np.github.3"
+	return ruleID == "np.github.3" || ruleID == "np.github.8"
 }
 
 func (v *GitHubAppTokenValidator) Validate(ctx context.Context, match *types.Match) (*types.ValidationResult, error) {

--- a/pkg/validator/github_app_test.go
+++ b/pkg/validator/github_app_test.go
@@ -18,9 +18,36 @@ func TestGitHubAppTokenValidator_Name(t *testing.T) {
 func TestGitHubAppTokenValidator_CanValidate(t *testing.T) {
 	v := NewGitHubAppTokenValidator()
 	assert.True(t, v.CanValidate("np.github.3"))
+	assert.True(t, v.CanValidate("np.github.8"))
 	assert.False(t, v.CanValidate("np.github.1"))
 	assert.False(t, v.CanValidate("np.github.2"))
 	assert.False(t, v.CanValidate("np.github.7"))
+}
+
+// TestGitHubAppTokenValidator_GHS_JWT_ExtractToken verifies that the validator
+// can extract the token named group from a np.github.8 (JWT-format) match.
+func TestGitHubAppTokenValidator_GHS_JWT_ExtractToken(t *testing.T) {
+	v := NewGitHubAppTokenValidator()
+	jwtToken := "ghs_123456_eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJhcHBfaWQifQ.signature_here"
+	match := &types.Match{
+		RuleID: "np.github.8",
+		NamedGroups: map[string][]byte{
+			"token": []byte(jwtToken),
+		},
+	}
+	assert.Equal(t, jwtToken, v.extractToken(match))
+	assert.True(t, hasPrefix(v.extractToken(match), "ghs_"), "JWT-format token should route to installation endpoint")
+}
+
+// TestGitHubAppTokenValidator_GHS_JWT_Validate_NoToken verifies undetermined
+// status when no token is present in a np.github.8 match.
+func TestGitHubAppTokenValidator_GHS_JWT_Validate_NoToken(t *testing.T) {
+	v := NewGitHubAppTokenValidator()
+	match := &types.Match{RuleID: "np.github.8"}
+
+	result, err := v.Validate(t.Context(), match)
+	require.NoError(t, err)
+	assert.Equal(t, types.StatusUndetermined, result.Status)
 }
 
 func TestGitHubAppTokenValidator_GHU_Valid(t *testing.T) {

--- a/testdata/secrets/github-tokens.txt
+++ b/testdata/secrets/github-tokens.txt
@@ -20,3 +20,8 @@ refresh_token: ghr_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 # GitHub Fine-grained PAT (np.github.7)
 # Pattern: \b(github_pat_[0-9a-zA-Z_]{82})\b
 FINE_GRAINED_TOKEN=github_pat_11AAAAAA0xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# GitHub App Installation Token - JWT format (np.github.8)
+# Pattern: \b(ghs_[0-9]+_[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)\b
+# New format announced April 24, 2026; rollout began April 27, 2026
+GITHUB_TOKEN=ghs_123456_eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJhcHBfaWQiLCJpYXQiOjE3MTQyMDgwMDAsImV4cCI6MTcxNDIwODMwMH0.EXAMPLE_SIGNATURE_BASE64URL


### PR DESCRIPTION
Implementing a new rule for the new GitHub App token format. See: https://github.blog/changelog/2026-04-24-notice-about-upcoming-new-format-for-github-app-installation-tokens/