### PR TITLE
fix(rules): add np.stripe.3 for publishable API keys (pk_live_/pk_test_)

### DIFF
--- a/pkg/rule/rules/stripe.yml
+++ b/pkg/rule/rules/stripe.yml
@@ -1,7 +1,54 @@
 rules:
 
-# FIXME: also add an entry for stripe "Publishable Keys"? Those are public, but having it along with the secret key would be problematic.
-# Example: STRIPE_PUBLISHABLE_KEY=pk_test_aQbfVWeaCesES5FRSY7iIjk9
+- name: Stripe Publishable API Key
+  id: np.stripe.3
+  base_score: 5
+
+  # Publishable keys (pk_live_*, pk_test_*) are intentionally designed to be embedded
+  # in client-side code (browsers, mobile apps). They identify a merchant account for
+  # display and payment-form purposes only — they cannot initiate charges, access user
+  # data, or perform any sensitive server-side operation. Stripe and other payment
+  # processors (e.g. Moonpay) use the same pk_live_ / pk_test_ prefix convention.
+  #
+  # Detection is informational only. The finding should not be treated as a credential
+  # leak; its presence in source code is expected and intentional.
+  #
+  # The pattern includes the same apikey/access_key keyword context as np.generic.2 so
+  # cross-rule deduplication clusters both matches and selects this more specific rule
+  # (longer pattern, named capture group) over the generic one.
+  pattern: |
+    (?x)(?i)
+    (?: publishable_key | publishablekey
+      | api_key | apikey | access_key | accesskey )
+    .{0,3}
+    [\ \t]* (?: : | = | := | => | , | ' | " ) [\ \t]*
+    .{0,3}
+    (?P<key> pk_ (?:live|test) _ [a-z0-9]{24,} )
+
+  categories:
+  - api
+  - informational
+
+  references:
+  - https://stripe.com/docs/keys
+  - https://dev.moonpay.com/docs/api-authentication
+
+  examples:
+  - 'apiKey=pk_live_51H2Bv2eZvKYlo2C0qTNQN6z'
+  - 'STRIPE_PUBLISHABLE_KEY=pk_test_aQbfVWeaCesES5FRSY7iIjk9'
+  - 'publishable_key: "pk_live_AbCdEfGhIjKlMnOpQrStUvWx"'
+
+  negative_examples:
+  - 'apiKey=sk_live_dhhfUUyfrAace5dBAZ10JrAD'   # secret key — caught by np.stripe.1
+  - 'pk_live_short'                              # too short — not a valid publishable key
+
+  description: |
+    Stripe (and compatible) publishable API key found in source code. Publishable keys
+    are intentionally public — they are designed to be embedded in browser or mobile
+    app code to associate payment forms with a merchant account. They cannot be used
+    to initiate charges, read transaction data, or perform any sensitive operation.
+    This finding is informational and typically does not require remediation unless
+    the key appears alongside a secret key (sk_live_*) in the same context.
 
 - name: Stripe API Key
   id: np.stripe.1

--- a/pkg/rule/rulesets/default.yml
+++ b/pkg/rule/rulesets/default.yml
@@ -196,6 +196,7 @@ rulesets:
   - np.stackhawk.1    # StackHawk API Key
   - np.stripe.1       # Stripe API Key
   - np.stripe.2       # Stripe API Test Key
+  - np.stripe.3       # Stripe Publishable API Key
   - np.tavily.1       # Tavily API Key
   - np.teamcity.1     # TeamCity API Token
   - np.telegram.1     # Telegram Bot Token


### PR DESCRIPTION
Fixes #214

## Problem

Stripe (and Moonpay) publishable keys (`pk_live_*`, `pk_test_*`) were flagged by `np.generic.2` (Generic API Key) when found in contexts like `apiKey=pk_live_...`. These keys are intentionally public — designed to be embedded in browser/mobile code. They cannot initiate charges or access user data. Treating them as secrets generates noise.

`stripe.yml` already had a `FIXME` acknowledging this gap.

## Approach

Add explicit `np.stripe.3` (base_score: 5 — info tier) rather than suppressing the pattern in the generic rule. Explicit beats implicit.

The rule:
- Requires the `pk_live_`/`pk_test_` prefix explicitly
- Includes the same keyword context (`api_key`, `apikey`, etc.) as `np.generic.2` so both rules fire in the same scenario
- Has a longer, more specific pattern → cross-rule dedup's `patternLen` tiebreaker selects this rule, labelling the finding **"Stripe Publishable API Key"** rather than "Generic API Key"
- Named capture group `key` captures the same bytes as `np.generic.2`'s positional capture → they're clustered for dedup

## Result

```
Rule: Stripe Publishable API Key (np.stripe.3)
Score: 5/100 — info
```

The finding description tells operators this is expected and normally not worth remediating unless found alongside a `sk_live_*` key.

## Test plan

- [x] `go test ./pkg/rule/...` — 131 tests pass
- [x] `make test` — all packages green  
- [x] `titus-score-lint` — all rules valid