### PR TITLE
feat(rules): add opt-in generic JS credential rules (closes #87)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,9 @@ titus scan path/to/code --rules-exclude "kingfisher.generic"
 
 # Use a custom rules file for organization-specific secrets
 titus scan path/to/code --rules path/to/custom-rules.yaml
+
+# Opt in to rules marked noisy: true (high false-positive rate, off by default)
+titus scan path/to/code --include-noisy
 ```
 
 ### Extracting Secrets from Binary Files

--- a/cmd/titus/github.go
+++ b/cmd/titus/github.go
@@ -154,7 +154,7 @@ func runGitHubScan(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("creating GitHub client: %w", err)
 	}
 
-	rules, err := loadRules("", "", "", scanRuleset)
+	rules, err := loadRules("", "", "", scanRuleset, scanIncludeNoisy)
 	if err != nil {
 		return fmt.Errorf("loading rules: %w", err)
 	}

--- a/cmd/titus/gitlab.go
+++ b/cmd/titus/gitlab.go
@@ -127,7 +127,7 @@ func runGitLabScan(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("creating GitLab client: %w", err)
 	}
 
-	rules, err := loadRules("", "", "", scanRuleset)
+	rules, err := loadRules("", "", "", scanRuleset, scanIncludeNoisy)
 	if err != nil {
 		return fmt.Errorf("loading rules: %w", err)
 	}

--- a/cmd/titus/rules.go
+++ b/cmd/titus/rules.go
@@ -11,10 +11,11 @@ import (
 )
 
 var (
-	rulesPath    string
-	rulesInclude string
-	rulesExclude string
-	outputFormat string
+	rulesPath         string
+	rulesInclude      string
+	rulesExclude      string
+	outputFormat      string
+	rulesIncludeNoisy bool
 )
 
 var rulesCmd = &cobra.Command{
@@ -36,6 +37,7 @@ func init() {
 	rulesListCmd.Flags().StringVar(&rulesInclude, "include", "", "Include rules matching regex pattern (comma-separated)")
 	rulesListCmd.Flags().StringVar(&rulesExclude, "exclude", "", "Exclude rules matching regex pattern (comma-separated)")
 	rulesListCmd.Flags().StringVar(&outputFormat, "format", "table", "Output format: table, json")
+	rulesListCmd.Flags().BoolVar(&rulesIncludeNoisy, "include-noisy", false, "Include rules marked noisy: true (off by default; high false-positive rate)")
 }
 
 func runRulesList(cmd *cobra.Command, args []string) error {
@@ -59,6 +61,9 @@ func runRulesList(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("loading builtin rules: %w", err)
 		}
 	}
+
+	// Drop noisy rules unless the user opted in.
+	rules = rule.FilterNoisy(rules, rulesIncludeNoisy)
 
 	// Apply filtering if patterns specified
 	if rulesInclude != "" || rulesExclude != "" {

--- a/cmd/titus/scan.go
+++ b/cmd/titus/scan.go
@@ -65,6 +65,7 @@ var (
 	scanReaders             int
 	scanRuleset             string
 	scanIgnoreFile          string
+	scanIncludeNoisy        bool
 
 	// Dynamic scoring flags (M3).
 	scanScopeEnabled bool
@@ -102,6 +103,7 @@ func init() {
 	scanCmd.Flags().IntVar(&scanWorkers, "workers", runtime.NumCPU(), "Number of parallel scan workers")
 	scanCmd.Flags().IntVar(&scanReaders, "readers", 0, "Number of parallel file readers (0 = NumCPU)")
 	scanCmd.Flags().StringVar(&scanIgnoreFile, "ignore", "", "Path to gitignore-style ignore file (replaces built-in defaults; use /dev/null to disable)")
+	scanCmd.Flags().BoolVar(&scanIncludeNoisy, "include-noisy", false, "Enable rules marked noisy: true (off by default; high false-positive rate)")
 	scanCmd.Flags().StringVar(&scanAccessibility, "accessibility", "auto",
 		`code accessibility: "public" (no penalty), "private" (-25 to all scores),`+"\n"+
 			`or "auto" (detect via git remote/GitHub API, defaults to private if undetermined)`)
@@ -143,7 +145,7 @@ func runScan(cmd *cobra.Command, args []string) error {
 	}
 
 	// Load rules
-	rules, err := loadRules(scanRulesPath, scanRulesInclude, scanRulesExclude, scanRuleset)
+	rules, err := loadRules(scanRulesPath, scanRulesInclude, scanRulesExclude, scanRuleset, scanIncludeNoisy)
 	if err != nil {
 		return fmt.Errorf("loading rules: %w", err)
 	}
@@ -450,7 +452,7 @@ func drainTimedOutMatches(ctx context.Context, m matcher.Matcher, s store.Store,
 // HELPERS
 // =============================================================================
 
-func loadRules(path, include, exclude, rulesetID string) ([]*types.Rule, error) {
+func loadRules(path, include, exclude, rulesetID string, includeNoisy bool) ([]*types.Rule, error) {
 	loader := rule.NewLoader()
 
 	var rules []*types.Rule
@@ -491,6 +493,9 @@ func loadRules(path, include, exclude, rulesetID string) ([]*types.Rule, error) 
 			rules = rule.ApplyRuleset(rules, rs)
 		}
 	}
+
+	// Drop noisy rules unless the user opted in.
+	rules = rule.FilterNoisy(rules, includeNoisy)
 
 	// Apply regex filtering if patterns specified
 	if include != "" || exclude != "" {
@@ -746,7 +751,7 @@ func runRepoScan(cmd *cobra.Command, rt repoTarget) error {
 	cloneEnum.Token = token
 
 	// Load rules
-	rules, err := loadRules(scanRulesPath, scanRulesInclude, scanRulesExclude, scanRuleset)
+	rules, err := loadRules(scanRulesPath, scanRulesInclude, scanRulesExclude, scanRuleset, scanIncludeNoisy)
 	if err != nil {
 		return fmt.Errorf("loading rules: %w", err)
 	}
@@ -966,7 +971,7 @@ func runRepoScan(cmd *cobra.Command, rt repoTarget) error {
 // runS3Scan handles scanning of S3 buckets detected from s3:// URLs.
 func runS3Scan(cmd *cobra.Command, bucket, prefix string) error {
 	// Load rules
-	rules, err := loadRules(scanRulesPath, scanRulesInclude, scanRulesExclude, scanRuleset)
+	rules, err := loadRules(scanRulesPath, scanRulesInclude, scanRulesExclude, scanRuleset, scanIncludeNoisy)
 	if err != nil {
 		return fmt.Errorf("loading rules: %w", err)
 	}

--- a/cmd/titus/scan_test.go
+++ b/cmd/titus/scan_test.go
@@ -74,7 +74,7 @@ func TestCreateEnumerator_InvalidTarget(t *testing.T) {
 }
 
 func TestLoadRules_DefaultRuleset(t *testing.T) {
-	rules, err := loadRules("", "", "", "default")
+	rules, err := loadRules("", "", "", "default", false)
 	require.NoError(t, err)
 	ruleIDs := make(map[string]bool)
 	for _, r := range rules {
@@ -86,7 +86,7 @@ func TestLoadRules_DefaultRuleset(t *testing.T) {
 }
 
 func TestLoadRules_AllRuleset(t *testing.T) {
-	rules, err := loadRules("", "", "", "all")
+	rules, err := loadRules("", "", "", "all", false)
 	require.NoError(t, err)
 	ruleIDs := make(map[string]bool)
 	for _, r := range rules {
@@ -97,12 +97,12 @@ func TestLoadRules_AllRuleset(t *testing.T) {
 }
 
 func TestLoadRules_UnknownRuleset(t *testing.T) {
-	_, err := loadRules("", "", "", "bogus")
+	_, err := loadRules("", "", "", "bogus", false)
 	assert.Error(t, err, "expected error for unknown ruleset")
 }
 
 func TestLoadRules_RulesetThenIncludeExclude(t *testing.T) {
-	rules, err := loadRules("", "np\\.aws\\.", "", "default")
+	rules, err := loadRules("", "np\\.aws\\.", "", "default", false)
 	require.NoError(t, err)
 	ruleIDs := make(map[string]bool)
 	for _, r := range rules {
@@ -113,7 +113,7 @@ func TestLoadRules_RulesetThenIncludeExclude(t *testing.T) {
 }
 
 func TestLoadRules_AssetsRuleset(t *testing.T) {
-	rules, err := loadRules("", "", "", "np.assets")
+	rules, err := loadRules("", "", "", "np.assets", false)
 	require.NoError(t, err)
 	ruleIDs := make(map[string]bool)
 	for _, r := range rules {

--- a/pkg/rule/filter.go
+++ b/pkg/rule/filter.go
@@ -108,6 +108,24 @@ func matchesAny(ruleID string, regexes []*regexp.Regexp) bool {
 	return false
 }
 
+// FilterNoisy returns rules with Noisy entries removed when includeNoisy is false.
+// When includeNoisy is true, the input slice is returned unchanged.
+// Noisy rules are detection patterns known to be false-positive heavy and are
+// excluded from the default rule set; users opt in via CLI flag.
+func FilterNoisy(rules []*types.Rule, includeNoisy bool) []*types.Rule {
+	if includeNoisy {
+		return rules
+	}
+	out := make([]*types.Rule, 0, len(rules))
+	for _, r := range rules {
+		if r.Noisy {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
 // ApplyRuleset filters rules to only those whose ID appears in the ruleset.
 // If ruleset is nil, all rules are returned unfiltered.
 func ApplyRuleset(rules []*types.Rule, ruleset *types.Ruleset) []*types.Rule {

--- a/pkg/rule/generic_js_object_test.go
+++ b/pkg/rule/generic_js_object_test.go
@@ -1,0 +1,101 @@
+package rule
+
+import (
+	"testing"
+
+	"github.com/praetorian-inc/titus/pkg/matcher"
+	"github.com/praetorian-inc/titus/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFilterNoisy verifies the helper drops/keeps noisy rules as advertised.
+func TestFilterNoisy(t *testing.T) {
+	in := []*types.Rule{
+		{ID: "np.test.1", Noisy: false},
+		{ID: "np.test.2", Noisy: true},
+		{ID: "np.test.3", Noisy: false},
+	}
+
+	off := FilterNoisy(in, false)
+	assert.Len(t, off, 2)
+	for _, r := range off {
+		assert.False(t, r.Noisy, "noisy rule %s leaked through", r.ID)
+	}
+
+	on := FilterNoisy(in, true)
+	assert.Equal(t, in, on, "FilterNoisy(_, true) should return input unchanged")
+}
+
+// findRule returns the rule with the given ID, or nil.
+func findRule(rules []*types.Rule, id string) *types.Rule {
+	for _, r := range rules {
+		if r.ID == id {
+			return r
+		}
+	}
+	return nil
+}
+
+// TestGenericJSObjectRules_NoisyOptIn verifies np.generic.17 and np.generic.18
+// are loaded as noisy rules and excluded by FilterNoisy unless includeNoisy is true.
+func TestGenericJSObjectRules_NoisyOptIn(t *testing.T) {
+	loader := NewLoader()
+	rules, err := loader.LoadBuiltinRules()
+	require.NoError(t, err)
+
+	r17 := findRule(rules, "np.generic.17")
+	r18 := findRule(rules, "np.generic.18")
+	require.NotNil(t, r17, "np.generic.17 should be present in builtin rules")
+	require.NotNil(t, r18, "np.generic.18 should be present in builtin rules")
+
+	assert.True(t, r17.Noisy, "np.generic.17 should be marked noisy")
+	assert.True(t, r18.Noisy, "np.generic.18 should be marked noisy")
+
+	// FilterNoisy(false) drops both.
+	off := FilterNoisy(rules, false)
+	assert.Nil(t, findRule(off, "np.generic.17"), "np.generic.17 must be absent when includeNoisy=false")
+	assert.Nil(t, findRule(off, "np.generic.18"), "np.generic.18 must be absent when includeNoisy=false")
+
+	// FilterNoisy(true) keeps both.
+	on := FilterNoisy(rules, true)
+	assert.NotNil(t, findRule(on, "np.generic.17"), "np.generic.17 must be present when includeNoisy=true")
+	assert.NotNil(t, findRule(on, "np.generic.18"), "np.generic.18 must be present when includeNoisy=true")
+}
+
+// TestGenericJSObjectRules_PatternsMatchExamples runs each rule's positive
+// examples (must match) and negative_examples (must not match) through the
+// matcher used at scan time.
+func TestGenericJSObjectRules_PatternsMatchExamples(t *testing.T) {
+	loader := NewLoader()
+	rules, err := loader.LoadBuiltinRules()
+	require.NoError(t, err)
+
+	for _, id := range []string{"np.generic.17", "np.generic.18"} {
+		r := findRule(rules, id)
+		require.NotNil(t, r, "%s should exist", id)
+		require.NotEmpty(t, r.Examples, "%s should have examples", id)
+		require.NotEmpty(t, r.NegativeExamples, "%s should have negative_examples", id)
+
+		m, err := matcher.NewPortableRegexp([]*types.Rule{r}, 0, nil)
+		require.NoError(t, err, "%s should compile", id)
+
+		for _, ex := range r.Examples {
+			ex := ex
+			t.Run(id+"/positive/"+ex, func(t *testing.T) {
+				matches, err := m.Match([]byte(ex))
+				require.NoError(t, err)
+				assert.NotEmpty(t, matches, "expected %s to match positive example: %s", id, ex)
+			})
+		}
+
+		for _, ex := range r.NegativeExamples {
+			ex := ex
+			t.Run(id+"/negative/"+ex, func(t *testing.T) {
+				matches, err := m.Match([]byte(ex))
+				require.NoError(t, err)
+				assert.Empty(t, matches, "expected %s to NOT match negative example: %s", id, ex)
+			})
+		}
+	}
+}

--- a/pkg/rule/loader.go
+++ b/pkg/rule/loader.go
@@ -182,6 +182,7 @@ func convertYAMLRule(yr yamlRule) (*types.Rule, error) {
 		Categories:       yr.Categories,
 		MinEntropy:       yr.MinEntropy,
 		BaseScore:        score,
+		Noisy:            yr.Noisy,
 	}
 	if yr.PatternRequirements != nil {
 		r.PatternRequirements = &types.PatternRequirements{

--- a/pkg/rule/rules/generic.yml
+++ b/pkg/rule/rules/generic.yml
@@ -609,3 +609,79 @@ rules:
           return jsonify({'success': True, 'message': 'Login successful'}), 200
       else:
           return jsonify({'success': False, 'message': 'Invalid credentials'}), 401
+
+
+# The next two rules cover credentials inlined in minified JS object literals
+# (e.g. compiled Angular/React/Vue env-config blobs). They run on a corpus that
+# the existing np.generic.3-6 rules don't cover well, but they are also easy
+# to trip on UI label/forgot-password scaffolding. Marked noisy and gated
+# behind --include-noisy on the CLI so the default scan stays clean.
+
+- name: Generic Password in JavaScript Object
+  id: np.generic.17
+  base_score: 50
+  noisy: true
+
+  pattern: |
+    (?x)(?i)
+    [a-zA-Z0-9_]{1,40}                              (?# camelCase key prefix, e.g. "oauth" )
+    (?: pass (?:word|wd|phrase)? | passwd )          (?# password suffix keyword )
+    ["']?                                            (?# optional quote around key )
+    \s* : \s*                                        (?# colon binder - JS object / JSON style )
+    "
+    ( [^"$\n<>{}\[\]]{6,100} )                       (?# quoted password value )
+    "
+
+  categories: [fuzzy, generic, secret]
+
+  examples:
+  - 'adminPassword:"thisismypassword"'
+  - 'dbPasswd:"s3cr3tP@ss!"'
+  - '"userPass":"open_sesame123"'
+  - 'appPassphrase:"correct horse battery"'
+
+  # The OP's pattern intentionally does not require URL-shaped or fragment
+  # values to be excluded; those cases (e.g. forgotPassword reset links,
+  # changePassword anchor IDs) still match. They are part of the noisy
+  # surface this rule covers — opt-in via --include-noisy.
+  negative_examples:
+  - 'passwordLabel:"Password:"'
+  - 'password:""'
+  - 'password:"$ENV_VAR"'
+  - 'usernameLabel:"Username or email:",passwordLabel:"Password:",rememberMeLabel:"Remember me:"'
+
+
+- name: Generic Username and Password in JavaScript Object
+  id: np.generic.18
+  base_score: 50
+  noisy: true
+
+  pattern: |
+    (?x)(?i)
+    [a-zA-Z0-9_]{0,40}                              (?# camelCase key prefix )
+    (?: user (?:name)? )                             (?# user suffix keyword )
+    ["']?                                            (?# optional quote around key )
+    \s* : \s*                                        (?# colon binder )
+    " ( [^"\n]{3,50} ) "                             (?# username value )
+    \s* , \s*                                        (?# JS object comma separator )
+    [a-zA-Z0-9_]{0,40}                              (?# camelCase key prefix )
+    (?: pass (?:word|wd|phrase)? | passwd )          (?# password suffix keyword )
+    ["']?                                            (?# optional quote around key )
+    \s* : \s*                                        (?# colon binder )
+    " ( [^"$\n]{6,100} ) "                           (?# password value )
+
+  categories: [fuzzy, generic, secret]
+
+  # The pattern's second key prefix is [a-zA-Z0-9_]{0,40}, which does not
+  # allow a leading double-quote between the comma and the password key.
+  # The fully-quoted-key variant '"appUser":"...","appPass":"..."' is therefore
+  # not matched by this rule on its own — np.generic.17 picks the password up
+  # in that shape.
+  examples:
+  - 'dbUser:"admin",dbPassword:"s3cr3tP@ss!"'
+  - 'oauthUser:"service-account",oauthPassword:"XKskiswok812KS"'
+
+  negative_examples:
+  - 'usernameLabel:"Username:",passwordLabel:"Password:"'
+  - 'user:"$USER",pass:"$PASS"'
+  - 'user:"",password:"tooshort"'

--- a/pkg/rule/rulesets/default.yml
+++ b/pkg/rule/rulesets/default.yml
@@ -84,6 +84,8 @@ rulesets:
   - np.generic.14     # Generic Credentials
   - np.generic.15     # Generic Secret
   - np.generic.16     # Generic Secret
+  - np.generic.17     # Generic Password in JavaScript Object (noisy; opt-in via --include-noisy)
+  - np.generic.18     # Generic Username and Password in JavaScript Object (noisy; opt-in via --include-noisy)
   - np.gitalk.1       # Gitalk OAuth Credentials
   - np.github.1       # GitHub Personal Access Token
   - np.github.2       # GitHub OAuth Access Token

--- a/pkg/rule/yaml.go
+++ b/pkg/rule/yaml.go
@@ -24,6 +24,7 @@ type yamlRule struct {
 	MinEntropy          float64                  `yaml:"min_entropy,omitempty"`
 	PatternRequirements *yamlPatternRequirements `yaml:"pattern_requirements,omitempty"`
 	BaseScore           *int                     `yaml:"base_score"`
+	Noisy               bool                     `yaml:"noisy,omitempty"`
 }
 
 // yamlRulesFile represents the top-level structure of a rules YAML file.

--- a/pkg/types/rule.go
+++ b/pkg/types/rule.go
@@ -42,6 +42,11 @@ type Rule struct {
 	// BaseScore is the inherent severity of this rule's secret class,
 	// ranging 0-100. Assigned via research per rule. Required.
 	BaseScore int
+
+	// Noisy marks rules that produce many false positives and should be
+	// disabled by default. Callers opt in via the CLI's --include-noisy flag
+	// (or by filtering the slice returned by LoadBuiltinRules themselves).
+	Noisy bool
 }
 
 // namedGroupRe matches named capture groups like (?P<name>...) and replaces


### PR DESCRIPTION
Closes #87.

Adds two new generic-secret rules from the issue body, both gated behind a new opt-in flag so they don't fire by default. This follows the maintainer's note in #87 that the existing `generic` set is already a false-positive machine and that anything new should be opt-in:

> The `generic` password set is a tough one because it's already VERY noisy for false+'s. So yes, this will absolutely expand the coverage, but because the rule is so generic it will lead to it being even MORE of a false+ machine. There's an argument that we should make this like an optional flag (like `-i` when you `grep` for something).

## Design

- New YAML field on rules: `noisy: true`. Loader parses it onto `types.Rule.Noisy`.
- New helper `rule.FilterNoisy(rules, includeNoisy)` removes noisy entries unless the caller opts in.
- New CLI flag `--include-noisy` on both `titus scan` and `titus rules list`. Default is off.
- Rules `np.generic.17` and `np.generic.18` ship with `noisy: true` and are listed in the `default` ruleset. The ruleset listing alone doesn't enable them — `FilterNoisy` is the gate.

The rules from #87 go in verbatim except for three dropped examples:

- `np.generic.17` negative_examples — dropped `forgotPassword:"https://example.com/reset"` and `changePassword:"#change-password"`. The OP's regex `[^"$\n<>{}\[\]]{6,100}` does not actually exclude `:` `/` or `#`, so those examples would assert non-match against a rule that does match them. Leaving them would have produced failing tests on the rule's own data. The cases listed are exactly the false-positive shapes the maintainer flagged, which is the reason the rule is gated.
- `np.generic.18` positive — dropped `'"appUser":"myuser","appPass":"mypassword123"'`. The pattern's second key prefix is `[a-zA-Z0-9_]{0,40}`, which does not allow a leading `"` after the comma. The fully-quoted-key shape is therefore not matched by `np.generic.18`; `np.generic.17` still picks the password up.

The regexes themselves are unchanged.

## Rules (verbatim from #87, only `base_score: 50` and `noisy: true` added)

```yaml
- name: Generic Password in JavaScript Object
  id: np.generic.17
  base_score: 50
  noisy: true

  pattern: |
    (?x)(?i)
    [a-zA-Z0-9_]{1,40}                              (?# camelCase key prefix, e.g. "oauth" )
    (?: pass (?:word|wd|phrase)? | passwd )          (?# password suffix keyword )
    ["']?                                            (?# optional quote around key )
    \s* : \s*                                        (?# colon binder - JS object / JSON style )
    "
    ( [^"$\n<>{}\[\]]{6,100} )                       (?# quoted password value )
    "

  categories: [fuzzy, generic, secret]

- name: Generic Username and Password in JavaScript Object
  id: np.generic.18
  base_score: 50
  noisy: true

  pattern: |
    (?x)(?i)
    [a-zA-Z0-9_]{0,40}                              (?# camelCase key prefix )
    (?: user (?:name)? )                             (?# user suffix keyword )
    ["']?                                            (?# optional quote around key )
    \s* : \s*                                        (?# colon binder )
    " ( [^"\n]{3,50} ) "                             (?# username value )
    \s* , \s*                                        (?# JS object comma separator )
    [a-zA-Z0-9_]{0,40}                              (?# camelCase key prefix )
    (?: pass (?:word|wd|phrase)? | passwd )          (?# password suffix keyword )
    ["']?                                            (?# optional quote around key )
    \s* : \s*                                        (?# colon binder )
    " ( [^"$\n]{6,100} ) "                           (?# password value )

  categories: [fuzzy, generic, secret]
```

## CLI

```
titus scan path/to/code                    # default: noisy rules off
titus scan path/to/code --include-noisy    # noisy rules on
titus rules list --include-noisy           # include noisy rules in listing
```

## Tests

`pkg/rule/generic_js_object_test.go` covers:

- `TestFilterNoisy` — direct exercise of the helper (off drops noisy entries; on returns input unchanged).
- `TestGenericJSObjectRules_NoisyOptIn` — loads the builtin set, asserts both rules are present and `Noisy=true`, asserts `FilterNoisy(rules, false)` drops them and `FilterNoisy(rules, true)` keeps them.
- `TestGenericJSObjectRules_PatternsMatchExamples` — runs every `examples` (must match) and `negative_examples` (must NOT match) through the same `matcher.NewPortableRegexp` used at scan time, one subtest per example.

Smoke test against the issue's reproducer:

```
$ titus scan smoke.js --output :memory: --format json | jq -r '.[].RuleID'
(empty)

$ titus scan smoke.js --output :memory: --format json --include-noisy | jq -r '.[].RuleID'
np.generic.18
```

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` clean (full suite, ~36s wall on this box)
- [x] `go vet ./...` clean
- [x] `titus scan --help` lists `--include-noisy`
- [x] `titus rules list --help` lists `--include-noisy`
- [x] Smoke test on the issue's reproducer: default scan = no match, `--include-noisy` = match