### PR TITLE
refactor(github,gitlab): migrate to shared pipeline + datastore output

### DIFF
--- a/cmd/titus/flags.go
+++ b/cmd/titus/flags.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"runtime"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// addRulesFlags registers rule-loading flags onto cmd.
+// Flags bind into scanRulesPath, scanRulesInclude, scanRulesExclude, scanRuleset
+// globals defined in scan.go and consumed by loadRules.
+func addRulesFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&scanRulesPath, "rules", "", "Path to custom rules file or directory (merged with builtins)")
+	cmd.Flags().StringVar(&scanRulesInclude, "rules-include", "", "Include rules matching regex pattern (comma-separated)")
+	cmd.Flags().StringVar(&scanRulesExclude, "rules-exclude", "", "Exclude rules matching regex pattern (comma-separated)")
+	cmd.Flags().StringVar(&scanRuleset, "ruleset", "default", "Ruleset to use: default, np.assets, np.hashes, all (all = no filtering)")
+}
+
+// addOutputFlags registers output-path and format flags onto cmd.
+// Flags bind into scanOutputPath and scanOutputFormat globals.
+//
+// Default output path is "titus.ds" (datastore directory). Subcommands that
+// historically defaulted to "titus.db" (a single sqlite file) opt in to the
+// datastore default by calling this helper. Override with cmd.Flags().Lookup
+// after the call if a different default is required.
+func addOutputFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&scanOutputPath, "output", "titus.ds", "Output datastore path (:memory: for in-memory, :auto: to derive from target name)")
+	cmd.Flags().StringVar(&scanOutputFormat, "format", "human", "Output format: json, sarif, human")
+}
+
+// addPipelineFlags registers all flags that runPipeline reads from package
+// globals: worker pool sizing, file-size/context limits, validation, scoring,
+// extraction limits, accessibility, ignore file, blob storage, incremental.
+func addPipelineFlags(cmd *cobra.Command) {
+	cmd.Flags().IntVar(&scanWorkers, "workers", runtime.NumCPU(), "Number of parallel scan workers")
+	cmd.Flags().IntVar(&scanReaders, "readers", 0, "Number of parallel file readers (0 = NumCPU)")
+	cmd.Flags().Int64Var(&scanMaxFileSize, "max-file-size", 10*1024*1024, "Maximum file size to scan (bytes)")
+	cmd.Flags().IntVar(&scanContextLines, "context-lines", 3, "Lines of context before/after matches (0 to disable)")
+	cmd.Flags().BoolVar(&scanIncremental, "incremental", false, "Skip already-scanned blobs")
+	cmd.Flags().BoolVar(&scanValidate, "validate", false, "Validate detected secrets against their source APIs")
+	cmd.Flags().IntVar(&scanValidateWorkers, "validate-workers", 4, "Number of concurrent validation workers")
+	cmd.Flags().BoolVar(&scanStoreBlobs, "store-blobs", false, "Store file contents in blobs/ directory")
+	cmd.Flags().StringVar(&scanAccessibility, "accessibility", "auto",
+		`code accessibility: "public" (no penalty), "private" (-25 to all scores),`+"\n"+
+			`or "auto" (detect via git remote/GitHub API, defaults to private if undetermined)`)
+	cmd.Flags().StringVar(&scanIgnoreFile, "ignore", "", "Path to gitignore-style ignore file (replaces built-in defaults; use /dev/null to disable)")
+	cmd.Flags().Var(&scanExtractArchivesFlag, "extract", "Extract text from binary files (extensions: xlsx,docx,pdf,zip or 'all')")
+	cmd.Flags().StringVar(&extractMaxSize, "extract-max-size", "10MB", "Max uncompressed size per extracted file")
+	cmd.Flags().StringVar(&extractMaxTotal, "extract-max-total", "100MB", "Max total bytes to extract from one archive")
+	cmd.Flags().IntVar(&extractMaxDepth, "extract-max-depth", 5, "Max nested archive depth")
+	cmd.Flags().IntVar(&scanSQLiteRowLimit, "sqlite-row-limit", 1000, "Max rows per table for SQLite extraction (0 for unlimited)")
+	cmd.Flags().BoolVar(&scanScopeEnabled, "score-scope", false, "Enable HTTP dynamic scoring modifiers")
+	cmd.Flags().DurationVar(&scanScoreTimeout, "score-timeout", 10*time.Second, "Per-modifier HTTP timeout for dynamic scoring")
+	cmd.Flags().DurationVar(&scanScoreBudget, "score-budget", 60*time.Second, "Per-finding overall scoring budget across all modifiers (0 = unlimited)")
+}

--- a/cmd/titus/github.go
+++ b/cmd/titus/github.go
@@ -170,6 +170,7 @@ func runGitHubScan(cmd *cobra.Command, args []string) error {
 			IgnoreFile:      scanIgnoreFile,
 			ExtractArchives: string(scanExtractArchivesFlag),
 			ExtractLimits:   limits,
+			NumReaders:      scanReaders,
 		})
 		cloneEnum.Git = githubGit
 		cloneEnum.Token = token

--- a/cmd/titus/github.go
+++ b/cmd/titus/github.go
@@ -14,16 +14,14 @@ import (
 )
 
 var (
-	githubToken        string
-	githubBaseURL      string
-	githubOrg          string
-	githubUser         string
-	githubOutputPath   string
-	githubOutputFormat string
-	githubNoClone      bool
-	githubGit          bool
-	githubSkipForks    bool
-	githubRateLimit    float64
+	githubToken     string
+	githubBaseURL   string
+	githubOrg       string
+	githubUser      string
+	githubNoClone   bool
+	githubGit       bool
+	githubSkipForks bool
+	githubRateLimit float64
 )
 
 var githubCmd = &cobra.Command{
@@ -65,37 +63,25 @@ Use --no-clone to fetch files via API instead of cloning (requires token).`,
 }
 
 func init() {
-	githubScanCmd.Flags().StringVar(&githubToken, "token", "", "GitHub API token (or GITHUB_TOKEN env; optional for public repos)")
-	githubScanCmd.Flags().StringVar(&githubBaseURL, "url", "", "GitHub Enterprise base URL (or GITHUB_BASE_URL env; e.g., https://github.example.com)")
-	githubScanCmd.Flags().StringVar(&githubOrg, "org", "", "Scan all repositories in organization")
-	githubScanCmd.Flags().StringVar(&githubUser, "user", "", "Scan all repositories for user")
-	githubScanCmd.Flags().StringVar(&githubOutputPath, "output", "titus.db", "Output database path (:memory: for in-memory, :auto: to derive from target name)")
-	githubScanCmd.Flags().StringVar(&githubOutputFormat, "format", "human", "Output format: json, human")
-	githubScanCmd.Flags().BoolVar(&githubNoClone, "no-clone", false, "Fetch files via API instead of cloning (requires token, no git history)")
-	githubScanCmd.Flags().BoolVar(&githubGit, "git", false, "Scan full git history (slower; default scans only current files)")
-	githubScanCmd.Flags().BoolVar(&githubSkipForks, "skip-forks", false, "Skip forked repositories when scanning orgs or users")
-	githubScanCmd.Flags().Float64Var(&githubRateLimit, "rate-limit", 0, "Delay in seconds between repository clones (e.g., 2 or 0.5; 0 = no delay)")
-	githubScanCmd.Flags().StringVar(&scanRulesPath, "rules", "", "Path to custom rules file or directory (merged with builtins)")
-	githubScanCmd.Flags().StringVar(&scanRulesInclude, "rules-include", "", "Include rules matching regex pattern (comma-separated)")
-	githubScanCmd.Flags().StringVar(&scanRulesExclude, "rules-exclude", "", "Exclude rules matching regex pattern (comma-separated)")
-	githubScanCmd.Flags().StringVar(&scanRuleset, "ruleset", "default", "Ruleset to use: default, np.assets, np.hashes, all (all = no filtering)")
-
-	githubCmd.Flags().StringVar(&githubToken, "token", "", "GitHub API token (or GITHUB_TOKEN env; optional for public repos)")
-	githubCmd.Flags().StringVar(&githubBaseURL, "url", "", "GitHub Enterprise base URL (or GITHUB_BASE_URL env; e.g., https://github.example.com)")
-	githubCmd.Flags().StringVar(&githubOrg, "org", "", "Scan all repositories in organization")
-	githubCmd.Flags().StringVar(&githubUser, "user", "", "Scan all repositories for user")
-	githubCmd.Flags().StringVar(&githubOutputPath, "output", "titus.db", "Output database path (:memory: for in-memory, :auto: to derive from target name)")
-	githubCmd.Flags().StringVar(&githubOutputFormat, "format", "human", "Output format: json, human")
-	githubCmd.Flags().BoolVar(&githubNoClone, "no-clone", false, "Fetch files via API instead of cloning (requires token, no git history)")
-	githubCmd.Flags().BoolVar(&githubGit, "git", false, "Scan full git history (slower; default scans only current files)")
-	githubCmd.Flags().BoolVar(&githubSkipForks, "skip-forks", false, "Skip forked repositories when scanning orgs or users")
-	githubCmd.Flags().Float64Var(&githubRateLimit, "rate-limit", 0, "Delay in seconds between repository clones (e.g., 2 or 0.5; 0 = no delay)")
-	githubCmd.Flags().StringVar(&scanRulesPath, "rules", "", "Path to custom rules file or directory (merged with builtins)")
-	githubCmd.Flags().StringVar(&scanRulesInclude, "rules-include", "", "Include rules matching regex pattern (comma-separated)")
-	githubCmd.Flags().StringVar(&scanRulesExclude, "rules-exclude", "", "Exclude rules matching regex pattern (comma-separated)")
-	githubCmd.Flags().StringVar(&scanRuleset, "ruleset", "default", "Ruleset to use: default, np.assets, np.hashes, all (all = no filtering)")
-
+	registerGitHubFlags(githubScanCmd)
+	registerGitHubFlags(githubCmd)
 	githubCmd.AddCommand(githubScanCmd)
+}
+
+// registerGitHubFlags binds every flag the github subcommand supports onto cmd.
+// Used for both `titus github` and `titus github scan`.
+func registerGitHubFlags(cmd *cobra.Command) {
+	addRulesFlags(cmd)
+	addOutputFlags(cmd)
+	addPipelineFlags(cmd)
+	cmd.Flags().StringVar(&githubToken, "token", "", "GitHub API token (or GITHUB_TOKEN env; optional for public repos)")
+	cmd.Flags().StringVar(&githubBaseURL, "url", "", "GitHub Enterprise base URL (or GITHUB_BASE_URL env; e.g., https://github.example.com)")
+	cmd.Flags().StringVar(&githubOrg, "org", "", "Scan all repositories in organization")
+	cmd.Flags().StringVar(&githubUser, "user", "", "Scan all repositories for user")
+	cmd.Flags().BoolVar(&githubNoClone, "no-clone", false, "Fetch files via API instead of cloning (requires token, no git history)")
+	cmd.Flags().BoolVar(&githubGit, "git", false, "Scan full git history (slower; default scans only current files)")
+	cmd.Flags().BoolVar(&githubSkipForks, "skip-forks", false, "Skip forked repositories when scanning orgs or users")
+	cmd.Flags().Float64Var(&githubRateLimit, "rate-limit", 0, "Delay in seconds between repository clones (e.g., 2 or 0.5; 0 = no delay)")
 }
 
 func runGitHubScan(cmd *cobra.Command, args []string) error {
@@ -138,8 +124,8 @@ func runGitHubScan(cmd *cobra.Command, args []string) error {
 		owner, repo = parts[0], parts[1]
 	}
 
-	if githubOutputPath == ":auto:" {
-		githubOutputPath = resolveAutoName(githubOrg, githubUser, repo)
+	if scanOutputPath == ":auto:" {
+		scanOutputPath = resolveAutoName(githubOrg, githubUser, repo)
 	}
 
 	if repo == "" && githubOrg == "" && githubUser == "" {
@@ -182,7 +168,7 @@ func runGitHubScan(cmd *cobra.Command, args []string) error {
 	defer func() { _ = m.Close() }()
 
 	s, err := store.New(store.Config{
-		Path: githubOutputPath,
+		Path: scanOutputPath,
 	})
 	if err != nil {
 		return fmt.Errorf("creating store: %w", err)
@@ -284,9 +270,9 @@ func runGitHubScan(cmd *cobra.Command, args []string) error {
 	}
 
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "GitHub scan complete: %d matches, %d findings\n", matchCount, findingCount)
-	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Results stored in: %s\n", githubOutputPath)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Results stored in: %s\n", scanOutputPath)
 
-	if githubOutputFormat == "json" {
+	if scanOutputFormat == "json" {
 		matches, err := s.GetAllMatches()
 		if err != nil {
 			return fmt.Errorf("retrieving matches: %w", err)

--- a/cmd/titus/github.go
+++ b/cmd/titus/github.go
@@ -190,11 +190,23 @@ func runGitHubScan(cmd *cobra.Command, args []string) error {
 	}
 
 	return runPipeline(ctx, cmd, enumerator, pipelineOpts{
-		Target:       target,
-		OutputPath:   scanOutputPath,
-		OutputFormat: scanOutputFormat,
-		Token:        token,
+		Target:        target,
+		OutputPath:    scanOutputPath,
+		OutputFormat:  scanOutputFormat,
+		Accessibility: resolveRemoteAccessibility(scanAccessibility),
 	})
+}
+
+// resolveRemoteAccessibility maps the --accessibility flag for subcommands that
+// scan remote-only targets (no local checkout to inspect). On "auto" we default
+// to public so that auto-detection's "fall back to private" behavior — designed
+// for local clones — does not silently apply a -25 penalty to every finding.
+// Explicit "public"/"private" are still honored.
+func resolveRemoteAccessibility(flag string) Accessibility {
+	if flag == "auto" || flag == "" {
+		return AccessibilityPublic
+	}
+	return ResolveAccessibility(flag, "", "")
 }
 
 // splitOwnerRepo splits "owner/repo" into ["owner", "repo"].

--- a/cmd/titus/github.go
+++ b/cmd/titus/github.go
@@ -186,7 +186,7 @@ func runGitHubScan(cmd *cobra.Command, args []string) error {
 		Target:       target,
 		OutputPath:   scanOutputPath,
 		OutputFormat: scanOutputFormat,
-		TokenEnvVar:  "GITHUB_TOKEN",
+		Token:        token,
 	})
 }
 

--- a/cmd/titus/github.go
+++ b/cmd/titus/github.go
@@ -161,9 +161,15 @@ func runGitHubScan(cmd *cobra.Command, args []string) error {
 		}
 		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Found %d repositories to scan\n\n", len(repos))
 
+		limits, err := resolveExtractionLimits()
+		if err != nil {
+			return err
+		}
 		cloneEnum := enum.NewCloneEnumerator(repos, enum.Config{
-			MaxFileSize: scanMaxFileSize,
-			IgnoreFile:  scanIgnoreFile,
+			MaxFileSize:     scanMaxFileSize,
+			IgnoreFile:      scanIgnoreFile,
+			ExtractArchives: string(scanExtractArchivesFlag),
+			ExtractLimits:   limits,
 		})
 		cloneEnum.Git = githubGit
 		cloneEnum.Token = token

--- a/cmd/titus/github.go
+++ b/cmd/titus/github.go
@@ -7,9 +7,6 @@ import (
 	"time"
 
 	"github.com/praetorian-inc/titus/pkg/enum"
-	"github.com/praetorian-inc/titus/pkg/matcher"
-	"github.com/praetorian-inc/titus/pkg/store"
-	"github.com/praetorian-inc/titus/pkg/types"
 	"github.com/spf13/cobra"
 )
 
@@ -141,49 +138,19 @@ func runGitHubScan(cmd *cobra.Command, args []string) error {
 		User:      githubUser,
 		SkipForks: githubSkipForks,
 		Config: enum.Config{
-			MaxFileSize: 10 * 1024 * 1024,
+			MaxFileSize: scanMaxFileSize,
 		},
 	})
 	if err != nil {
 		return fmt.Errorf("creating GitHub client: %w", err)
 	}
 
-	rules, err := loadRules(scanRulesPath, scanRulesInclude, scanRulesExclude, scanRuleset)
-	if err != nil {
-		return fmt.Errorf("loading rules: %w", err)
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
 	}
 
-	ruleMap := make(map[string]*types.Rule)
-	for _, r := range rules {
-		ruleMap[r.ID] = r
-	}
-
-	m, err := matcher.New(matcher.Config{
-		Rules:        rules,
-		ContextLines: 3,
-	})
-	if err != nil {
-		return fmt.Errorf("creating matcher: %w", err)
-	}
-	defer func() { _ = m.Close() }()
-
-	s, err := store.New(store.Config{
-		Path: scanOutputPath,
-	})
-	if err != nil {
-		return fmt.Errorf("creating store: %w", err)
-	}
-	defer func() { _ = s.Close() }()
-
-	for _, r := range rules {
-		if err := s.AddRule(r); err != nil {
-			return fmt.Errorf("storing rule: %w", err)
-		}
-	}
-
-	ctx := context.Background()
 	var enumerator enum.Enumerator
-
 	if githubNoClone {
 		enumerator = ghEnum
 	} else {
@@ -192,11 +159,11 @@ func runGitHubScan(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("listing repositories: %w", err)
 		}
-
 		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Found %d repositories to scan\n\n", len(repos))
 
 		cloneEnum := enum.NewCloneEnumerator(repos, enum.Config{
-			MaxFileSize: 10 * 1024 * 1024,
+			MaxFileSize: scanMaxFileSize,
+			IgnoreFile:  scanIgnoreFile,
 		})
 		cloneEnum.Git = githubGit
 		cloneEnum.Token = token
@@ -206,85 +173,21 @@ func runGitHubScan(cmd *cobra.Command, args []string) error {
 		enumerator = cloneEnum
 	}
 
-	matchCount := 0
-	findingCount := 0
+	target := repo
+	if githubOrg != "" {
+		target = githubOrg
+	} else if githubUser != "" {
+		target = githubUser
+	} else if owner != "" {
+		target = owner + "/" + repo
+	}
 
-	err = enumerator.Enumerate(ctx, func(content []byte, blobID types.BlobID, prov types.Provenance) error {
-		if err := s.AddBlob(blobID, int64(len(content))); err != nil {
-			return fmt.Errorf("storing blob: %w", err)
-		}
-
-		if err := s.AddProvenance(blobID, prov); err != nil {
-			return fmt.Errorf("storing provenance: %w", err)
-		}
-
-		matches, err := m.MatchWithBlobID(content, blobID)
-		if err != nil {
-			return fmt.Errorf("matching content: %w", err)
-		}
-
-		for _, match := range matches {
-			startLine, startCol := types.ComputeLineColumn(content, int(match.Location.Offset.Start))
-			endLine, endCol := types.ComputeLineColumn(content, int(match.Location.Offset.End))
-			match.Location.Source.Start.Line = startLine
-			match.Location.Source.Start.Column = startCol
-			match.Location.Source.End.Line = endLine
-			match.Location.Source.End.Column = endCol
-		}
-
-		for _, match := range matches {
-			matchCount++
-
-			if err := s.AddMatch(match); err != nil {
-				return fmt.Errorf("storing match: %w", err)
-			}
-
-			rule, ok := ruleMap[match.RuleID]
-			if !ok {
-				return fmt.Errorf("rule not found: %s", match.RuleID)
-			}
-			findingID := types.ComputeFindingID(rule.StructuralID, match.Groups)
-			exists, err := s.FindingExists(findingID)
-			if err != nil {
-				return fmt.Errorf("checking finding: %w", err)
-			}
-
-			if !exists {
-				findingCount++
-				finding := &types.Finding{
-					ID:     findingID,
-					RuleID: match.RuleID,
-					Groups: match.Groups,
-				}
-				if err := s.AddFinding(finding); err != nil {
-					return fmt.Errorf("storing finding: %w", err)
-				}
-			}
-		}
-
-		return nil
+	return runPipeline(ctx, cmd, enumerator, pipelineOpts{
+		Target:       target,
+		OutputPath:   scanOutputPath,
+		OutputFormat: scanOutputFormat,
+		TokenEnvVar:  "GITHUB_TOKEN",
 	})
-
-	if err != nil {
-		return fmt.Errorf("scanning GitHub: %w", err)
-	}
-
-	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "GitHub scan complete: %d matches, %d findings\n", matchCount, findingCount)
-	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Results stored in: %s\n", scanOutputPath)
-
-	if scanOutputFormat == "json" {
-		matches, err := s.GetAllMatches()
-		if err != nil {
-			return fmt.Errorf("retrieving matches: %w", err)
-		}
-		return outputMatches(cmd, matches)
-	}
-
-	findings, err := s.GetFindings()
-	if err != nil {
-		return fmt.Errorf("retrieving findings: %w", err)
-	}
-	return outputFindings(cmd, findings)
 }
 
 // splitOwnerRepo splits "owner/repo" into ["owner", "repo"].

--- a/cmd/titus/github_test.go
+++ b/cmd/titus/github_test.go
@@ -93,3 +93,31 @@ func TestSplitOwnerRepo(t *testing.T) {
 		})
 	}
 }
+
+func TestGitHubScanCmd_DefaultOutputIsDatastore(t *testing.T) {
+	flag := githubScanCmd.Flags().Lookup("output")
+	if flag == nil {
+		t.Fatal("--output flag missing")
+	}
+	if flag.DefValue != "titus.ds" {
+		t.Errorf("expected default 'titus.ds', got %q", flag.DefValue)
+	}
+}
+
+func TestGitHubScanCmd_HasPipelineFlags(t *testing.T) {
+	for _, name := range []string{"workers", "validate", "accessibility", "store-blobs", "ignore"} {
+		if githubScanCmd.Flags().Lookup(name) == nil {
+			t.Errorf("github scan: missing pipeline flag --%s", name)
+		}
+	}
+}
+
+func TestGitHubScanCmd_WorkersFlagAcceptsValues(t *testing.T) {
+	flag := githubScanCmd.Flags().Lookup("workers")
+	if flag == nil {
+		t.Fatal("--workers flag missing")
+	}
+	if flag.Value.Type() != "int" {
+		t.Errorf("expected int flag, got %s", flag.Value.Type())
+	}
+}

--- a/cmd/titus/gitlab.go
+++ b/cmd/titus/gitlab.go
@@ -7,9 +7,6 @@ import (
 	"time"
 
 	"github.com/praetorian-inc/titus/pkg/enum"
-	"github.com/praetorian-inc/titus/pkg/matcher"
-	"github.com/praetorian-inc/titus/pkg/store"
-	"github.com/praetorian-inc/titus/pkg/types"
 	"github.com/spf13/cobra"
 )
 
@@ -91,17 +88,13 @@ func runGitLabScan(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if scanOutputPath == ":auto:" {
-		var project string
-		if len(args) > 0 {
-			project = args[0]
-		}
-		scanOutputPath = resolveAutoName(gitlabGroup, gitlabUser, project)
-	}
-
 	var project string
 	if len(args) > 0 {
 		project = args[0]
+	}
+
+	if scanOutputPath == ":auto:" {
+		scanOutputPath = resolveAutoName(gitlabGroup, gitlabUser, project)
 	}
 
 	if project == "" && gitlabGroup == "" && gitlabUser == "" {
@@ -115,44 +108,19 @@ func runGitLabScan(cmd *cobra.Command, args []string) error {
 		Group:   gitlabGroup,
 		User:    gitlabUser,
 		Config: enum.Config{
-			MaxFileSize: 10 * 1024 * 1024,
+			MaxFileSize: scanMaxFileSize,
 		},
 	})
 	if err != nil {
 		return fmt.Errorf("creating GitLab client: %w", err)
 	}
 
-	rules, err := loadRules(scanRulesPath, scanRulesInclude, scanRulesExclude, scanRuleset)
-	if err != nil {
-		return fmt.Errorf("loading rules: %w", err)
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
 	}
 
-	ruleMap := make(map[string]*types.Rule)
-	for _, r := range rules {
-		ruleMap[r.ID] = r
-	}
-
-	m, err := matcher.New(matcher.Config{Rules: rules})
-	if err != nil {
-		return fmt.Errorf("creating matcher: %w", err)
-	}
-	defer func() { _ = m.Close() }()
-
-	s, err := store.New(store.Config{Path: scanOutputPath})
-	if err != nil {
-		return fmt.Errorf("creating store: %w", err)
-	}
-	defer func() { _ = s.Close() }()
-
-	for _, r := range rules {
-		if err := s.AddRule(r); err != nil {
-			return fmt.Errorf("storing rule: %w", err)
-		}
-	}
-
-	ctx := context.Background()
 	var enumerator enum.Enumerator
-
 	if gitlabNoClone {
 		enumerator = glEnum
 	} else {
@@ -161,11 +129,11 @@ func runGitLabScan(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("listing projects: %w", err)
 		}
-
 		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Found %d projects to scan\n\n", len(projects))
 
 		cloneEnum := enum.NewCloneEnumerator(projects, enum.Config{
-			MaxFileSize: 10 * 1024 * 1024,
+			MaxFileSize: scanMaxFileSize,
+			IgnoreFile:  scanIgnoreFile,
 		})
 		cloneEnum.Git = gitlabGit
 		cloneEnum.Token = token
@@ -175,83 +143,17 @@ func runGitLabScan(cmd *cobra.Command, args []string) error {
 		enumerator = cloneEnum
 	}
 
-	matchCount := 0
-	findingCount := 0
+	target := project
+	if gitlabGroup != "" {
+		target = gitlabGroup
+	} else if gitlabUser != "" {
+		target = gitlabUser
+	}
 
-	err = enumerator.Enumerate(ctx, func(content []byte, blobID types.BlobID, prov types.Provenance) error {
-		if err := s.AddBlob(blobID, int64(len(content))); err != nil {
-			return fmt.Errorf("storing blob: %w", err)
-		}
-
-		if err := s.AddProvenance(blobID, prov); err != nil {
-			return fmt.Errorf("storing provenance: %w", err)
-		}
-
-		matches, err := m.MatchWithBlobID(content, blobID)
-		if err != nil {
-			return fmt.Errorf("matching content: %w", err)
-		}
-
-		for _, match := range matches {
-			startLine, startCol := types.ComputeLineColumn(content, int(match.Location.Offset.Start))
-			endLine, endCol := types.ComputeLineColumn(content, int(match.Location.Offset.End))
-			match.Location.Source.Start.Line = startLine
-			match.Location.Source.Start.Column = startCol
-			match.Location.Source.End.Line = endLine
-			match.Location.Source.End.Column = endCol
-		}
-
-		for _, match := range matches {
-			matchCount++
-
-			if err := s.AddMatch(match); err != nil {
-				return fmt.Errorf("storing match: %w", err)
-			}
-
-			rule, ok := ruleMap[match.RuleID]
-			if !ok {
-				return fmt.Errorf("rule not found: %s", match.RuleID)
-			}
-			findingID := types.ComputeFindingID(rule.StructuralID, match.Groups)
-			exists, err := s.FindingExists(findingID)
-			if err != nil {
-				return fmt.Errorf("checking finding: %w", err)
-			}
-
-			if !exists {
-				findingCount++
-				finding := &types.Finding{
-					ID:     findingID,
-					RuleID: match.RuleID,
-					Groups: match.Groups,
-				}
-				if err := s.AddFinding(finding); err != nil {
-					return fmt.Errorf("storing finding: %w", err)
-				}
-			}
-		}
-
-		return nil
+	return runPipeline(ctx, cmd, enumerator, pipelineOpts{
+		Target:       target,
+		OutputPath:   scanOutputPath,
+		OutputFormat: scanOutputFormat,
+		TokenEnvVar:  "GITLAB_TOKEN",
 	})
-
-	if err != nil {
-		return fmt.Errorf("scanning: %w", err)
-	}
-
-	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "GitLab scan complete: %d matches, %d findings\n", matchCount, findingCount)
-	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Results stored in: %s\n", scanOutputPath)
-
-	if scanOutputFormat == "json" {
-		matches, err := s.GetAllMatches()
-		if err != nil {
-			return fmt.Errorf("retrieving matches: %w", err)
-		}
-		return outputMatches(cmd, matches)
-	}
-
-	findings, err := s.GetFindings()
-	if err != nil {
-		return fmt.Errorf("retrieving findings: %w", err)
-	}
-	return outputFindings(cmd, findings)
 }

--- a/cmd/titus/gitlab.go
+++ b/cmd/titus/gitlab.go
@@ -158,9 +158,9 @@ func runGitLabScan(cmd *cobra.Command, args []string) error {
 	}
 
 	return runPipeline(ctx, cmd, enumerator, pipelineOpts{
-		Target:       target,
-		OutputPath:   scanOutputPath,
-		OutputFormat: scanOutputFormat,
-		Token:        token,
+		Target:        target,
+		OutputPath:    scanOutputPath,
+		OutputFormat:  scanOutputFormat,
+		Accessibility: resolveRemoteAccessibility(scanAccessibility),
 	})
 }

--- a/cmd/titus/gitlab.go
+++ b/cmd/titus/gitlab.go
@@ -154,6 +154,6 @@ func runGitLabScan(cmd *cobra.Command, args []string) error {
 		Target:       target,
 		OutputPath:   scanOutputPath,
 		OutputFormat: scanOutputFormat,
-		TokenEnvVar:  "GITLAB_TOKEN",
+		Token:        token,
 	})
 }

--- a/cmd/titus/gitlab.go
+++ b/cmd/titus/gitlab.go
@@ -140,6 +140,7 @@ func runGitLabScan(cmd *cobra.Command, args []string) error {
 			IgnoreFile:      scanIgnoreFile,
 			ExtractArchives: string(scanExtractArchivesFlag),
 			ExtractLimits:   limits,
+			NumReaders:      scanReaders,
 		})
 		cloneEnum.Git = gitlabGit
 		cloneEnum.Token = token

--- a/cmd/titus/gitlab.go
+++ b/cmd/titus/gitlab.go
@@ -131,9 +131,15 @@ func runGitLabScan(cmd *cobra.Command, args []string) error {
 		}
 		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Found %d projects to scan\n\n", len(projects))
 
+		limits, err := resolveExtractionLimits()
+		if err != nil {
+			return err
+		}
 		cloneEnum := enum.NewCloneEnumerator(projects, enum.Config{
-			MaxFileSize: scanMaxFileSize,
-			IgnoreFile:  scanIgnoreFile,
+			MaxFileSize:     scanMaxFileSize,
+			IgnoreFile:      scanIgnoreFile,
+			ExtractArchives: string(scanExtractArchivesFlag),
+			ExtractLimits:   limits,
 		})
 		cloneEnum.Git = gitlabGit
 		cloneEnum.Token = token

--- a/cmd/titus/gitlab.go
+++ b/cmd/titus/gitlab.go
@@ -14,15 +14,13 @@ import (
 )
 
 var (
-	gitlabToken        string
-	gitlabGroup        string
-	gitlabUser         string
-	gitlabBaseURL      string
-	gitlabOutputPath   string
-	gitlabOutputFormat string
-	gitlabNoClone      bool
-	gitlabGit          bool
-	gitlabRateLimit    float64
+	gitlabToken     string
+	gitlabGroup     string
+	gitlabUser      string
+	gitlabBaseURL   string
+	gitlabNoClone   bool
+	gitlabGit       bool
+	gitlabRateLimit float64
 )
 
 var gitlabCmd = &cobra.Command{
@@ -48,35 +46,24 @@ Use --git to also scan full git history.`,
 }
 
 func init() {
-	gitlabScanCmd.Flags().StringVar(&gitlabToken, "token", "", "GitLab token (or GITLAB_TOKEN env; optional for public projects)")
-	gitlabScanCmd.Flags().StringVar(&gitlabGroup, "group", "", "Scan all projects in group")
-	gitlabScanCmd.Flags().StringVar(&gitlabUser, "user", "", "Scan all projects for user")
-	gitlabScanCmd.Flags().StringVar(&gitlabBaseURL, "url", "", "GitLab base URL (default: gitlab.com)")
-	gitlabScanCmd.Flags().StringVar(&gitlabOutputPath, "output", "titus.db", "Output database path (:memory: for in-memory, :auto: to derive from target name)")
-	gitlabScanCmd.Flags().StringVar(&gitlabOutputFormat, "format", "human", "Output format: json, human")
-	gitlabScanCmd.Flags().BoolVar(&gitlabNoClone, "no-clone", false, "Fetch files via API instead of cloning (requires token, no git history)")
-	gitlabScanCmd.Flags().BoolVar(&gitlabGit, "git", false, "Scan full git history (slower; default scans only current files)")
-	gitlabScanCmd.Flags().Float64Var(&gitlabRateLimit, "rate-limit", 0, "Delay in seconds between project clones (e.g., 2 or 0.5; 0 = no delay)")
-	gitlabScanCmd.Flags().StringVar(&scanRulesPath, "rules", "", "Path to custom rules file or directory (merged with builtins)")
-	gitlabScanCmd.Flags().StringVar(&scanRulesInclude, "rules-include", "", "Include rules matching regex pattern (comma-separated)")
-	gitlabScanCmd.Flags().StringVar(&scanRulesExclude, "rules-exclude", "", "Exclude rules matching regex pattern (comma-separated)")
-	gitlabScanCmd.Flags().StringVar(&scanRuleset, "ruleset", "default", "Ruleset to use: default, np.assets, np.hashes, all (all = no filtering)")
-
-	gitlabCmd.Flags().StringVar(&gitlabToken, "token", "", "GitLab token (or GITLAB_TOKEN env; optional for public projects)")
-	gitlabCmd.Flags().StringVar(&gitlabGroup, "group", "", "Scan all projects in group")
-	gitlabCmd.Flags().StringVar(&gitlabUser, "user", "", "Scan all projects for user")
-	gitlabCmd.Flags().StringVar(&gitlabBaseURL, "url", "", "GitLab base URL (default: gitlab.com)")
-	gitlabCmd.Flags().StringVar(&gitlabOutputPath, "output", "titus.db", "Output database path (:memory: for in-memory, :auto: to derive from target name)")
-	gitlabCmd.Flags().StringVar(&gitlabOutputFormat, "format", "human", "Output format: json, human")
-	gitlabCmd.Flags().BoolVar(&gitlabNoClone, "no-clone", false, "Fetch files via API instead of cloning (requires token, no git history)")
-	gitlabCmd.Flags().BoolVar(&gitlabGit, "git", false, "Scan full git history (slower; default scans only current files)")
-	gitlabCmd.Flags().Float64Var(&gitlabRateLimit, "rate-limit", 0, "Delay in seconds between project clones (e.g., 2 or 0.5; 0 = no delay)")
-	gitlabCmd.Flags().StringVar(&scanRulesPath, "rules", "", "Path to custom rules file or directory (merged with builtins)")
-	gitlabCmd.Flags().StringVar(&scanRulesInclude, "rules-include", "", "Include rules matching regex pattern (comma-separated)")
-	gitlabCmd.Flags().StringVar(&scanRulesExclude, "rules-exclude", "", "Exclude rules matching regex pattern (comma-separated)")
-	gitlabCmd.Flags().StringVar(&scanRuleset, "ruleset", "default", "Ruleset to use: default, np.assets, np.hashes, all (all = no filtering)")
-
+	registerGitLabFlags(gitlabScanCmd)
+	registerGitLabFlags(gitlabCmd)
 	gitlabCmd.AddCommand(gitlabScanCmd)
+}
+
+// registerGitLabFlags binds every flag the gitlab subcommand supports onto cmd.
+// Used for both `titus gitlab` and `titus gitlab scan`.
+func registerGitLabFlags(cmd *cobra.Command) {
+	addRulesFlags(cmd)
+	addOutputFlags(cmd)
+	addPipelineFlags(cmd)
+	cmd.Flags().StringVar(&gitlabToken, "token", "", "GitLab token (or GITLAB_TOKEN env; optional for public projects)")
+	cmd.Flags().StringVar(&gitlabGroup, "group", "", "Scan all projects in group")
+	cmd.Flags().StringVar(&gitlabUser, "user", "", "Scan all projects for user")
+	cmd.Flags().StringVar(&gitlabBaseURL, "url", "", "GitLab base URL (default: gitlab.com)")
+	cmd.Flags().BoolVar(&gitlabNoClone, "no-clone", false, "Fetch files via API instead of cloning (requires token, no git history)")
+	cmd.Flags().BoolVar(&gitlabGit, "git", false, "Scan full git history (slower; default scans only current files)")
+	cmd.Flags().Float64Var(&gitlabRateLimit, "rate-limit", 0, "Delay in seconds between project clones (e.g., 2 or 0.5; 0 = no delay)")
 }
 
 func runGitLabScan(cmd *cobra.Command, args []string) error {
@@ -104,12 +91,12 @@ func runGitLabScan(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if gitlabOutputPath == ":auto:" {
+	if scanOutputPath == ":auto:" {
 		var project string
 		if len(args) > 0 {
 			project = args[0]
 		}
-		gitlabOutputPath = resolveAutoName(gitlabGroup, gitlabUser, project)
+		scanOutputPath = resolveAutoName(gitlabGroup, gitlabUser, project)
 	}
 
 	var project string
@@ -151,7 +138,7 @@ func runGitLabScan(cmd *cobra.Command, args []string) error {
 	}
 	defer func() { _ = m.Close() }()
 
-	s, err := store.New(store.Config{Path: gitlabOutputPath})
+	s, err := store.New(store.Config{Path: scanOutputPath})
 	if err != nil {
 		return fmt.Errorf("creating store: %w", err)
 	}
@@ -252,9 +239,9 @@ func runGitLabScan(cmd *cobra.Command, args []string) error {
 	}
 
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "GitLab scan complete: %d matches, %d findings\n", matchCount, findingCount)
-	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Results stored in: %s\n", gitlabOutputPath)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Results stored in: %s\n", scanOutputPath)
 
-	if gitlabOutputFormat == "json" {
+	if scanOutputFormat == "json" {
 		matches, err := s.GetAllMatches()
 		if err != nil {
 			return fmt.Errorf("retrieving matches: %w", err)

--- a/cmd/titus/gitlab_test.go
+++ b/cmd/titus/gitlab_test.go
@@ -84,8 +84,8 @@ func TestGitLabScanCmd_FlagDefaults(t *testing.T) {
 	flags := gitlabScanCmd.Flags()
 
 	outputFlag := flags.Lookup("output")
-	if outputFlag != nil && outputFlag.DefValue != "titus.db" {
-		t.Errorf("expected output default='titus.db', got %q", outputFlag.DefValue)
+	if outputFlag != nil && outputFlag.DefValue != "titus.ds" {
+		t.Errorf("expected output default='titus.ds', got %q", outputFlag.DefValue)
 	}
 
 	formatFlag := flags.Lookup("format")

--- a/cmd/titus/gitlab_test.go
+++ b/cmd/titus/gitlab_test.go
@@ -137,43 +137,43 @@ func TestResolveAutoName(t *testing.T) {
 		{
 			name:     "group with nested path",
 			group:    "ctp1/tmna-ct/tmna-ev",
-			expected: "tmna-ev.db",
+			expected: "tmna-ev.ds",
 		},
 		{
 			name:     "simple group",
 			group:    "mygroup",
-			expected: "mygroup.db",
+			expected: "mygroup.ds",
 		},
 		{
 			name:     "user",
 			user:     "octocat",
-			expected: "octocat.db",
+			expected: "octocat.ds",
 		},
 		{
 			name:     "project with owner",
 			project:  "owner/repo",
-			expected: "repo.db",
+			expected: "repo.ds",
 		},
 		{
 			name:     "project without owner",
 			project:  "myrepo",
-			expected: "myrepo.db",
+			expected: "myrepo.ds",
 		},
 		{
 			name:     "group takes priority over user",
 			group:    "mygroup",
 			user:     "myuser",
-			expected: "mygroup.db",
+			expected: "mygroup.ds",
 		},
 		{
 			name:     "nothing provided",
-			expected: "output.db",
+			expected: "output.ds",
 		},
 		{
 			name:     "user takes priority over project",
 			user:     "myuser",
 			project:  "owner/repo",
-			expected: "myuser.db",
+			expected: "myuser.ds",
 		},
 	}
 

--- a/cmd/titus/gitlab_test.go
+++ b/cmd/titus/gitlab_test.go
@@ -184,3 +184,31 @@ func TestResolveAutoName(t *testing.T) {
 		})
 	}
 }
+
+func TestGitLabScanCmd_DefaultOutputIsDatastore(t *testing.T) {
+	flag := gitlabScanCmd.Flags().Lookup("output")
+	if flag == nil {
+		t.Fatal("--output flag missing")
+	}
+	if flag.DefValue != "titus.ds" {
+		t.Errorf("expected default 'titus.ds', got %q", flag.DefValue)
+	}
+}
+
+func TestGitLabScanCmd_HasPipelineFlags(t *testing.T) {
+	for _, name := range []string{"workers", "validate", "accessibility", "store-blobs", "ignore"} {
+		if gitlabScanCmd.Flags().Lookup(name) == nil {
+			t.Errorf("gitlab scan: missing pipeline flag --%s", name)
+		}
+	}
+}
+
+func TestGitLabScanCmd_WorkersFlagAcceptsValues(t *testing.T) {
+	flag := gitlabScanCmd.Flags().Lookup("workers")
+	if flag == nil {
+		t.Fatal("--workers flag missing")
+	}
+	if flag.Value.Type() != "int" {
+		t.Errorf("expected int flag, got %s", flag.Value.Type())
+	}
+}

--- a/cmd/titus/pipeline.go
+++ b/cmd/titus/pipeline.go
@@ -1,0 +1,279 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"sync/atomic"
+	"time"
+
+	"github.com/praetorian-inc/titus/pkg/enum"
+	"github.com/praetorian-inc/titus/pkg/matcher"
+	"github.com/praetorian-inc/titus/pkg/store"
+	"github.com/praetorian-inc/titus/pkg/types"
+	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
+)
+
+// pipelineOpts captures the per-call inputs for runPipeline. All other
+// configuration is read from package-level scan* globals (set by cobra flags).
+type pipelineOpts struct {
+	Target       string // for accessibility detection + log messages
+	OutputPath   string // already :auto:-resolved by caller
+	OutputFormat string // "json" | "sarif" | "human"
+	TokenEnvVar  string // env var name for accessibility token; "" = filesystem/no token
+}
+
+// runPipeline executes the full scan pipeline (rules -> matcher -> store ->
+// producer/consumer workers -> drain -> output) for an arbitrary enumerator.
+// It is the shared core extracted from runScan; URL routing and :auto:
+// resolution remain in the caller.
+func runPipeline(ctx context.Context, cmd *cobra.Command, enumerator enum.Enumerator, opts pipelineOpts) error {
+	// Load rules
+	rules, err := loadRules(scanRulesPath, scanRulesInclude, scanRulesExclude, scanRuleset)
+	if err != nil {
+		return fmt.Errorf("loading rules: %w", err)
+	}
+
+	// Create rule map for finding ID computation
+	ruleMap := make(map[string]*types.Rule)
+	for _, r := range rules {
+		ruleMap[r.ID] = r
+	}
+
+	// Create matcher
+	m, err := matcher.New(matcher.Config{
+		Rules:        rules,
+		ContextLines: scanContextLines,
+		WarnFunc: func(format string, args ...any) {
+			fmt.Fprintf(os.Stderr, format, args...)
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("creating matcher: %w", err)
+	}
+	defer m.Close()
+
+	// Create store (memory or datastore)
+	s, ds, err := openScanStore(opts.OutputPath, scanStoreBlobs)
+	if err != nil {
+		return err
+	}
+	if ds != nil {
+		defer ds.Close()
+	} else {
+		defer s.Close()
+	}
+
+	// Store rules for foreign key constraints
+	for _, r := range rules {
+		if err := s.AddRule(r); err != nil {
+			return fmt.Errorf("storing rule: %w", err)
+		}
+	}
+
+	// Initialize validation engine (nil if validation disabled)
+	validationEngine := initValidationEngine()
+
+	// Wire validator awareness into the matcher's built-in deduplicator
+	if validationEngine != nil {
+		matcher.SetCanValidate(m, validationEngine.CanValidate)
+	}
+
+	// Build the scoring engine once per scan.
+	engine, err := buildScoringEngine()
+	if err != nil {
+		return fmt.Errorf("initializing scoring engine: %w", err)
+	}
+	if scanScopeEnabled && !scanValidate {
+		fmt.Fprintf(os.Stderr, "[warn] --score-scope set without --validate; dynamic modifiers will use unvalidated credentials (results may be less accurate)\n")
+	}
+
+	// Resolve code accessibility for score adjustment.
+	var token string
+	if opts.TokenEnvVar != "" {
+		token = os.Getenv(opts.TokenEnvVar)
+	}
+	accessibility := ResolveAccessibility(scanAccessibility, opts.Target, token)
+
+	// Scan with parallel workers
+	var matchCount atomic.Int64
+	var findingCount atomic.Int64
+	var skippedCount atomic.Int64
+	var totalBytes atomic.Int64
+	var blobCount atomic.Int64
+	startTime := time.Now()
+
+	numWorkers := scanWorkers
+	if numWorkers < 1 {
+		numWorkers = 1
+	}
+
+	if verbose {
+		fmt.Fprintf(os.Stderr, "[scan] Starting scan with %d workers and %d rules\n", numWorkers, len(rules))
+	}
+
+	jobs := make(chan blobJob, 2*numWorkers)
+
+	g, ctx := errgroup.WithContext(ctx)
+
+	// Producer: enumerate blobs and send to workers (NO DB writes)
+	g.Go(func() error {
+		defer close(jobs)
+		if verbose {
+			fmt.Fprintf(os.Stderr, "[enumerate] Starting enumeration of %s\n", opts.Target)
+		}
+		return enumerator.Enumerate(ctx, func(content []byte, blobID types.BlobID, prov types.Provenance) error {
+			totalBytes.Add(int64(len(content)))
+			count := blobCount.Add(1)
+			if verbose && count%1000 == 0 {
+				fmt.Fprintf(os.Stderr, "[enumerate] %d files discovered (%d bytes)\n", count, totalBytes.Load())
+			}
+
+			// Check for incremental scanning
+			if scanIncremental {
+				exists, err := s.BlobExists(blobID)
+				if err != nil {
+					return fmt.Errorf("checking blob: %w", err)
+				}
+				if exists {
+					skippedCount.Add(1)
+					return nil
+				}
+			}
+
+			select {
+			case jobs <- blobJob{content: content, blobID: blobID, prov: prov}:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		})
+	})
+
+	// Consumer workers: match, compute line/col, validate, write to DB in batches
+	const batchSize = 64
+	for i := 0; i < numWorkers; i++ {
+		g.Go(func() error {
+			type batchItem struct {
+				blobID  types.BlobID
+				prov    types.Provenance
+				size    int64
+				matches []*types.Match
+			}
+			var batch []batchItem
+
+			flush := func() error {
+				if len(batch) == 0 {
+					return nil
+				}
+				err := s.ExecBatch(func(tx store.Store) error {
+					for _, item := range batch {
+						if err := tx.AddBlob(item.blobID, item.size); err != nil {
+							return fmt.Errorf("storing blob: %w", err)
+						}
+						if err := tx.AddProvenance(item.blobID, item.prov); err != nil {
+							return fmt.Errorf("storing provenance: %w", err)
+						}
+						for _, match := range item.matches {
+							if err := tx.AddMatch(match); err != nil {
+								return fmt.Errorf("storing match: %w", err)
+							}
+							rule, ok := ruleMap[match.RuleID]
+							if !ok {
+								return fmt.Errorf("rule not found: %s", match.RuleID)
+							}
+							findingID := types.ComputeFindingID(rule.StructuralID, match.Groups)
+							exists, err := tx.FindingExists(findingID)
+							if err != nil {
+								return fmt.Errorf("checking finding: %w", err)
+							}
+							if !exists {
+								findingCount.Add(1)
+								f := &types.Finding{
+									ID:     findingID,
+									RuleID: match.RuleID,
+									Groups: match.Groups,
+								}
+								f.Score = engine.Score(ctx, f, []*types.Match{match}, rule)
+								if accessibility == AccessibilityPrivate {
+									ApplyAccessibilityModifier(f.Score)
+								}
+								if err := tx.AddFinding(f); err != nil {
+									return fmt.Errorf("storing finding: %w", err)
+								}
+							}
+						}
+					}
+					return nil
+				})
+				batch = batch[:0]
+				return err
+			}
+
+			for job := range jobs {
+				matches, err := m.MatchWithBlobID(job.content, job.blobID)
+				if err != nil {
+					// Log warning but continue scanning other files
+					fmt.Fprintf(os.Stderr, "[warn] match error (skipping blob %s): %v\n", job.blobID.Hex(), err)
+					continue
+				}
+
+				for _, match := range matches {
+					startLine, startCol := types.ComputeLineColumn(job.content, int(match.Location.Offset.Start))
+					endLine, endCol := types.ComputeLineColumn(job.content, int(match.Location.Offset.End))
+					match.Location.Source.Start.Line = startLine
+					match.Location.Source.Start.Column = startCol
+					match.Location.Source.End.Line = endLine
+					match.Location.Source.End.Column = endCol
+				}
+
+				validateMatches(ctx, validationEngine, matches, verbose)
+				matchCount.Add(int64(len(matches)))
+
+				batch = append(batch, batchItem{
+					blobID:  job.blobID,
+					prov:    job.prov,
+					size:    int64(len(job.content)),
+					matches: matches,
+				})
+				if len(batch) >= batchSize {
+					if err := flush(); err != nil {
+						return err
+					}
+				}
+			}
+			return flush()
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		if ctx.Err() != nil && errors.Is(err, context.Canceled) {
+			// Normal shutdown, not an error
+		} else {
+			return fmt.Errorf("scanning: %w", err)
+		}
+	}
+
+	// Retry any blobs that timed out during the parallel pass.
+	if err := drainTimedOutMatches(ctx, m, s, ruleMap, engine, &findingCount, &matchCount, accessibility); err != nil {
+		return fmt.Errorf("retrying timed-out blobs: %w", err)
+	}
+
+	// Emit aggregate dynamic modifier stats if any errors occurred.
+	if st := engine.Stats(); st.Any() {
+		fmt.Fprintf(os.Stderr, "[scoring] Dynamic modifiers: %d timeouts, %d rate-limited, %d server errors, %d network errors\n",
+			st.Timeouts, st.RateLimited, st.ServerErrors, st.NetworkErrors)
+	}
+
+	if verbose {
+		fmt.Fprintf(os.Stderr, "[scan] Scan complete: %d blobs, %d matches, %d findings\n", blobCount.Load(), matchCount.Load(), findingCount.Load())
+	}
+
+	duration := time.Since(startTime)
+	printScanStats(cmd, opts.OutputFormat, opts.OutputPath,
+		totalBytes.Load(), blobCount.Load(), matchCount.Load(), skippedCount.Load(), duration)
+
+	return outputScanResults(cmd, s, rules, ruleMap)
+}

--- a/cmd/titus/pipeline.go
+++ b/cmd/titus/pipeline.go
@@ -19,10 +19,10 @@ import (
 // pipelineOpts captures the per-call inputs for runPipeline. All other
 // configuration is read from package-level scan* globals (set by cobra flags).
 type pipelineOpts struct {
-	Target       string // for accessibility detection + log messages
-	OutputPath   string // already :auto:-resolved by caller
-	OutputFormat string // "json" | "sarif" | "human"
-	Token        string // resolved API token for accessibility detection; "" if none
+	Target        string        // log messages only
+	OutputPath    string        // already :auto:-resolved by caller
+	OutputFormat  string        // "json" | "sarif" | "human"
+	Accessibility Accessibility // resolved by caller; controls per-finding accessibility penalty
 }
 
 // runPipeline executes the full scan pipeline (rules -> matcher -> store ->
@@ -90,8 +90,7 @@ func runPipeline(ctx context.Context, cmd *cobra.Command, enumerator enum.Enumer
 		fmt.Fprintf(os.Stderr, "[warn] --score-scope set without --validate; dynamic modifiers will use unvalidated credentials (results may be less accurate)\n")
 	}
 
-	// Resolve code accessibility for score adjustment.
-	accessibility := ResolveAccessibility(scanAccessibility, opts.Target, opts.Token)
+	accessibility := opts.Accessibility
 
 	// Scan with parallel workers
 	var matchCount atomic.Int64

--- a/cmd/titus/pipeline.go
+++ b/cmd/titus/pipeline.go
@@ -116,7 +116,11 @@ func runPipeline(ctx context.Context, cmd *cobra.Command, enumerator enum.Enumer
 
 	jobs := make(chan blobJob, 2*numWorkers)
 
-	g, ctx := errgroup.WithContext(ctx)
+	// errgroup.WithContext cancels the derived ctx when g.Wait() returns, so
+	// keep parentCtx aside for post-Wait work (drainTimedOutMatches scores
+	// retry findings via engine.Score, which short-circuits on a canceled ctx).
+	parentCtx := ctx
+	g, ctx := errgroup.WithContext(parentCtx)
 
 	// Producer: enumerate blobs and send to workers (NO DB writes)
 	g.Go(func() error {
@@ -180,29 +184,12 @@ func runPipeline(ctx context.Context, cmd *cobra.Command, enumerator enum.Enumer
 							if err := tx.AddMatch(match); err != nil {
 								return fmt.Errorf("storing match: %w", err)
 							}
-							rule, ok := ruleMap[match.RuleID]
-							if !ok {
-								return fmt.Errorf("rule not found: %s", match.RuleID)
-							}
-							findingID := types.ComputeFindingID(rule.StructuralID, match.Groups)
-							exists, err := tx.FindingExists(findingID)
+							added, err := upsertFinding(ctx, tx, match, ruleMap, engine, accessibility)
 							if err != nil {
-								return fmt.Errorf("checking finding: %w", err)
+								return err
 							}
-							if !exists {
+							if added {
 								findingCount.Add(1)
-								f := &types.Finding{
-									ID:     findingID,
-									RuleID: match.RuleID,
-									Groups: match.Groups,
-								}
-								f.Score = engine.Score(ctx, f, []*types.Match{match}, rule)
-								if accessibility == AccessibilityPrivate {
-									ApplyAccessibilityModifier(f.Score)
-								}
-								if err := tx.AddFinding(f); err != nil {
-									return fmt.Errorf("storing finding: %w", err)
-								}
 							}
 						}
 					}
@@ -256,8 +243,9 @@ func runPipeline(ctx context.Context, cmd *cobra.Command, enumerator enum.Enumer
 		}
 	}
 
-	// Retry any blobs that timed out during the parallel pass.
-	if err := drainTimedOutMatches(ctx, m, s, ruleMap, engine, &findingCount, &matchCount, accessibility); err != nil {
+	// Retry any blobs that timed out during the parallel pass. Use parentCtx
+	// because the errgroup-derived ctx is canceled by g.Wait().
+	if err := drainTimedOutMatches(parentCtx, m, s, ruleMap, engine, &findingCount, &matchCount, accessibility); err != nil {
 		return fmt.Errorf("retrying timed-out blobs: %w", err)
 	}
 
@@ -276,4 +264,36 @@ func runPipeline(ctx context.Context, cmd *cobra.Command, enumerator enum.Enumer
 		totalBytes.Load(), blobCount.Load(), matchCount.Load(), skippedCount.Load(), duration)
 
 	return outputScanResults(cmd, s, rules, ruleMap)
+}
+
+// upsertFinding adds a finding for match if no finding with the same
+// structural ID already exists. Returns true when a new finding was inserted.
+// Shared between runPipeline's worker flush and drainTimedOutMatches so
+// scoring + accessibility semantics cannot drift between the two paths.
+func upsertFinding(ctx context.Context, tx store.Store, match *types.Match, ruleMap map[string]*types.Rule, engine scoringEngineInterface, accessibility Accessibility) (bool, error) {
+	rule, ok := ruleMap[match.RuleID]
+	if !ok {
+		return false, fmt.Errorf("rule not found: %s", match.RuleID)
+	}
+	findingID := types.ComputeFindingID(rule.StructuralID, match.Groups)
+	exists, err := tx.FindingExists(findingID)
+	if err != nil {
+		return false, fmt.Errorf("checking finding: %w", err)
+	}
+	if exists {
+		return false, nil
+	}
+	f := &types.Finding{
+		ID:     findingID,
+		RuleID: match.RuleID,
+		Groups: match.Groups,
+	}
+	f.Score = engine.Score(ctx, f, []*types.Match{match}, rule)
+	if accessibility == AccessibilityPrivate {
+		ApplyAccessibilityModifier(f.Score)
+	}
+	if err := tx.AddFinding(f); err != nil {
+		return false, fmt.Errorf("storing finding: %w", err)
+	}
+	return true, nil
 }

--- a/cmd/titus/pipeline.go
+++ b/cmd/titus/pipeline.go
@@ -22,7 +22,7 @@ type pipelineOpts struct {
 	Target       string // for accessibility detection + log messages
 	OutputPath   string // already :auto:-resolved by caller
 	OutputFormat string // "json" | "sarif" | "human"
-	TokenEnvVar  string // env var name for accessibility token; "" = filesystem/no token
+	Token        string // resolved API token for accessibility detection; "" if none
 }
 
 // runPipeline executes the full scan pipeline (rules -> matcher -> store ->
@@ -91,11 +91,7 @@ func runPipeline(ctx context.Context, cmd *cobra.Command, enumerator enum.Enumer
 	}
 
 	// Resolve code accessibility for score adjustment.
-	var token string
-	if opts.TokenEnvVar != "" {
-		token = os.Getenv(opts.TokenEnvVar)
-	}
-	accessibility := ResolveAccessibility(scanAccessibility, opts.Target, token)
+	accessibility := ResolveAccessibility(scanAccessibility, opts.Target, opts.Token)
 
 	// Scan with parallel workers
 	var matchCount atomic.Int64
@@ -236,17 +232,21 @@ func runPipeline(ctx context.Context, cmd *cobra.Command, enumerator enum.Enumer
 	}
 
 	if err := g.Wait(); err != nil {
-		if ctx.Err() != nil && errors.Is(err, context.Canceled) {
-			// Normal shutdown, not an error
-		} else {
-			return fmt.Errorf("scanning: %w", err)
+		if errors.Is(err, context.Canceled) {
+			// Normal shutdown (parent canceled or producer exited early via
+			// ctx.Done). Skip drain — its scoring would short-circuit anyway.
+			return nil
 		}
+		return fmt.Errorf("scanning: %w", err)
 	}
 
 	// Retry any blobs that timed out during the parallel pass. Use parentCtx
-	// because the errgroup-derived ctx is canceled by g.Wait().
-	if err := drainTimedOutMatches(parentCtx, m, s, ruleMap, engine, &findingCount, &matchCount, accessibility); err != nil {
-		return fmt.Errorf("retrying timed-out blobs: %w", err)
+	// because the errgroup-derived ctx is canceled by g.Wait(). If the parent
+	// itself was canceled, skip drain.
+	if parentCtx.Err() == nil {
+		if err := drainTimedOutMatches(parentCtx, m, s, ruleMap, engine, &findingCount, &matchCount, accessibility); err != nil {
+			return fmt.Errorf("retrying timed-out blobs: %w", err)
+		}
 	}
 
 	// Emit aggregate dynamic modifier stats if any errors occurred.

--- a/cmd/titus/scan.go
+++ b/cmd/titus/scan.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -23,7 +22,6 @@ import (
 	"github.com/praetorian-inc/titus/pkg/types"
 	"github.com/praetorian-inc/titus/pkg/validator"
 	"github.com/spf13/cobra"
-	"golang.org/x/sync/errgroup"
 )
 
 // extensionsValue is a custom flag type that displays as "extensions" in help
@@ -537,65 +535,6 @@ func runRepoScan(cmd *cobra.Command, rt repoTarget) error {
 
 // runS3Scan handles scanning of S3 buckets detected from s3:// URLs.
 func runS3Scan(cmd *cobra.Command, bucket, prefix string) error {
-	// Load rules
-	rules, err := loadRules(scanRulesPath, scanRulesInclude, scanRulesExclude, scanRuleset)
-	if err != nil {
-		return fmt.Errorf("loading rules: %w", err)
-	}
-
-	ruleMap := make(map[string]*types.Rule)
-	for _, r := range rules {
-		ruleMap[r.ID] = r
-	}
-
-	// Create matcher
-	m, err := matcher.New(matcher.Config{
-		Rules:        rules,
-		ContextLines: scanContextLines,
-		WarnFunc: func(format string, args ...any) {
-			fmt.Fprintf(os.Stderr, format, args...)
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("creating matcher: %w", err)
-	}
-	defer m.Close()
-
-	// Create store
-	s, ds, err := openScanStore(scanOutputPath, scanStoreBlobs)
-	if err != nil {
-		return err
-	}
-	if ds != nil {
-		defer ds.Close()
-	} else {
-		defer s.Close()
-	}
-
-	// Store rules for foreign key constraints
-	for _, r := range rules {
-		if err := s.AddRule(r); err != nil {
-			return fmt.Errorf("storing rule: %w", err)
-		}
-	}
-
-	validationEngine := initValidationEngine()
-	if validationEngine != nil {
-		matcher.SetCanValidate(m, validationEngine.CanValidate)
-	}
-
-	// Build the scoring engine before workers start so the main worker pass
-	// can score findings (not just the drain-path retries).
-	s3Engine, err := buildScoringEngine()
-	if err != nil {
-		return fmt.Errorf("initializing scoring engine: %w", err)
-	}
-
-	// S3 objects have no git remote; resolve accessibility from the flag only
-	// (auto falls back to private, which is the conservative default).
-	s3Accessibility := ResolveAccessibility(scanAccessibility, "", "")
-
-	// Parse extraction limits
 	limits := enum.DefaultExtractionLimits()
 	if extractMaxSize != "" {
 		size, err := parseSize(extractMaxSize)
@@ -620,174 +559,16 @@ func runS3Scan(cmd *cobra.Command, bucket, prefix string) error {
 		ExtractLimits:   limits,
 	})
 
-	ctx := context.Background()
-	var matchCount atomic.Int64
-	var findingCount atomic.Int64
-	var skippedCount atomic.Int64
-	var totalBytes atomic.Int64
-	var blobCount atomic.Int64
-	startTime := time.Now()
-
-	numWorkers := scanWorkers
-	if numWorkers < 1 {
-		numWorkers = 1
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
 	}
-
-	if verbose {
-		fmt.Fprintf(os.Stderr, "[scan] Starting S3 scan of s3://%s/%s with %d workers and %d rules\n", bucket, prefix, numWorkers, len(rules))
-	}
-
-	jobs := make(chan blobJob, 2*numWorkers)
-
-	g, ctx := errgroup.WithContext(ctx)
-
-	// Producer
-	g.Go(func() error {
-		defer close(jobs)
-		return s3Enum.Enumerate(ctx, func(content []byte, blobID types.BlobID, prov types.Provenance) error {
-			totalBytes.Add(int64(len(content)))
-			count := blobCount.Add(1)
-			if verbose && count%1000 == 0 {
-				fmt.Fprintf(os.Stderr, "[enumerate] %d objects processed (%d bytes)\n", count, totalBytes.Load())
-			}
-
-			if scanIncremental {
-				exists, err := s.BlobExists(blobID)
-				if err != nil {
-					return fmt.Errorf("checking blob: %w", err)
-				}
-				if exists {
-					skippedCount.Add(1)
-					return nil
-				}
-			}
-
-			select {
-			case jobs <- blobJob{content: content, blobID: blobID, prov: prov}:
-				return nil
-			case <-ctx.Done():
-				return ctx.Err()
-			}
-		})
+	return runPipeline(ctx, cmd, s3Enum, pipelineOpts{
+		Target:       "s3://" + bucket + "/" + prefix,
+		OutputPath:   scanOutputPath,
+		OutputFormat: scanOutputFormat,
+		TokenEnvVar:  "", // S3 has no git remote
 	})
-
-	// Consumer workers
-	const batchSize = 64
-	for i := 0; i < numWorkers; i++ {
-		g.Go(func() error {
-			type batchItem struct {
-				blobID  types.BlobID
-				prov    types.Provenance
-				size    int64
-				matches []*types.Match
-			}
-			var batch []batchItem
-
-			flush := func() error {
-				if len(batch) == 0 {
-					return nil
-				}
-				err := s.ExecBatch(func(tx store.Store) error {
-					for _, item := range batch {
-						if err := tx.AddBlob(item.blobID, item.size); err != nil {
-							return fmt.Errorf("storing blob: %w", err)
-						}
-						if err := tx.AddProvenance(item.blobID, item.prov); err != nil {
-							return fmt.Errorf("storing provenance: %w", err)
-						}
-						for _, match := range item.matches {
-							if err := tx.AddMatch(match); err != nil {
-								return fmt.Errorf("storing match: %w", err)
-							}
-							rule, ok := ruleMap[match.RuleID]
-							if !ok {
-								return fmt.Errorf("rule not found: %s", match.RuleID)
-							}
-							findingID := types.ComputeFindingID(rule.StructuralID, match.Groups)
-							exists, err := tx.FindingExists(findingID)
-							if err != nil {
-								return fmt.Errorf("checking finding: %w", err)
-							}
-							if !exists {
-								findingCount.Add(1)
-								f := &types.Finding{
-									ID:     findingID,
-									RuleID: match.RuleID,
-									Groups: match.Groups,
-								}
-								f.Score = s3Engine.Score(ctx, f, []*types.Match{match}, rule)
-								if s3Accessibility == AccessibilityPrivate {
-									ApplyAccessibilityModifier(f.Score)
-								}
-								if err := tx.AddFinding(f); err != nil {
-									return fmt.Errorf("storing finding: %w", err)
-								}
-							}
-						}
-					}
-					return nil
-				})
-				batch = batch[:0]
-				return err
-			}
-
-			for job := range jobs {
-				matches, err := m.MatchWithBlobID(job.content, job.blobID)
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "[warn] match error (skipping blob %s): %v\n", job.blobID.Hex(), err)
-					continue
-				}
-
-				for _, match := range matches {
-					startLine, startCol := types.ComputeLineColumn(job.content, int(match.Location.Offset.Start))
-					endLine, endCol := types.ComputeLineColumn(job.content, int(match.Location.Offset.End))
-					match.Location.Source.Start.Line = startLine
-					match.Location.Source.Start.Column = startCol
-					match.Location.Source.End.Line = endLine
-					match.Location.Source.End.Column = endCol
-				}
-
-				validateMatches(ctx, validationEngine, matches, verbose)
-				matchCount.Add(int64(len(matches)))
-
-				batch = append(batch, batchItem{
-					blobID:  job.blobID,
-					prov:    job.prov,
-					size:    int64(len(job.content)),
-					matches: matches,
-				})
-				if len(batch) >= batchSize {
-					if err := flush(); err != nil {
-						return err
-					}
-				}
-			}
-			return flush()
-		})
-	}
-
-	if err := g.Wait(); err != nil {
-		// Suppress context.Canceled errors during shutdown
-		if ctx.Err() != nil && errors.Is(err, context.Canceled) {
-			// Normal shutdown via Ctrl+C, not an error
-		} else {
-			return fmt.Errorf("scanning: %w", err)
-		}
-	}
-
-	if err := drainTimedOutMatches(ctx, m, s, ruleMap, s3Engine, &findingCount, &matchCount, s3Accessibility); err != nil {
-		return fmt.Errorf("retrying timed-out blobs: %w", err)
-	}
-
-	if verbose {
-		fmt.Fprintf(os.Stderr, "[scan] S3 scan complete: %d objects, %d matches, %d findings\n", blobCount.Load(), matchCount.Load(), findingCount.Load())
-	}
-
-	duration := time.Since(startTime)
-	printScanStats(cmd, scanOutputFormat, scanOutputPath,
-		totalBytes.Load(), blobCount.Load(), matchCount.Load(), skippedCount.Load(), duration)
-
-	return outputScanResults(cmd, s, rules, ruleMap)
 }
 
 // outputNoseyParkerSummary outputs findings in noseyparker table format

--- a/cmd/titus/scan.go
+++ b/cmd/titus/scan.go
@@ -494,20 +494,18 @@ func parseRepoURL(target string) (repoTarget, bool) {
 
 // runRepoScan handles scanning of GitHub/GitLab repositories detected from URL-like targets.
 func runRepoScan(cmd *cobra.Command, rt repoTarget) error {
-	// Resolve token from environment
-	var token string
+	var tokenEnv string
 	switch rt.Platform {
 	case "github":
-		token = os.Getenv("GITHUB_TOKEN")
+		tokenEnv = "GITHUB_TOKEN"
 	case "gitlab":
-		token = os.Getenv("GITLAB_TOKEN")
+		tokenEnv = "GITLAB_TOKEN"
 	}
-
+	token := os.Getenv(tokenEnv)
 	if token == "" {
 		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Note: No %s token provided. Using unauthenticated access (public repos only).\n\n", rt.Platform)
 	}
 
-	// Build clone URL
 	var cloneURL string
 	switch rt.Platform {
 	case "github":
@@ -516,234 +514,25 @@ func runRepoScan(cmd *cobra.Command, rt repoTarget) error {
 		cloneURL = "https://gitlab.com/" + rt.FullPath + ".git"
 	}
 
-	repos := []enum.RepoInfo{{
-		Name:     rt.FullPath,
-		CloneURL: cloneURL,
-	}}
-
-	cloneEnum := enum.NewCloneEnumerator(repos, enum.Config{
-		MaxFileSize: scanMaxFileSize,
-		IgnoreFile:  scanIgnoreFile,
-	})
+	cloneEnum := enum.NewCloneEnumerator(
+		[]enum.RepoInfo{{Name: rt.FullPath, CloneURL: cloneURL}},
+		enum.Config{
+			MaxFileSize: scanMaxFileSize,
+			IgnoreFile:  scanIgnoreFile,
+		})
 	cloneEnum.Git = scanGit
 	cloneEnum.Token = token
 
-	// Load rules
-	rules, err := loadRules(scanRulesPath, scanRulesInclude, scanRulesExclude, scanRuleset)
-	if err != nil {
-		return fmt.Errorf("loading rules: %w", err)
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
 	}
-
-	ruleMap := make(map[string]*types.Rule)
-	for _, r := range rules {
-		ruleMap[r.ID] = r
-	}
-
-	// Create matcher
-	m, err := matcher.New(matcher.Config{
-		Rules:        rules,
-		ContextLines: scanContextLines,
-		WarnFunc: func(format string, args ...any) {
-			fmt.Fprintf(os.Stderr, format, args...)
-		},
+	return runPipeline(ctx, cmd, cloneEnum, pipelineOpts{
+		Target:       rt.FullPath,
+		OutputPath:   scanOutputPath,
+		OutputFormat: scanOutputFormat,
+		TokenEnvVar:  tokenEnv,
 	})
-	if err != nil {
-		return fmt.Errorf("creating matcher: %w", err)
-	}
-	defer m.Close()
-
-	// Create store
-	s, ds, err := openScanStore(scanOutputPath, scanStoreBlobs)
-	if err != nil {
-		return err
-	}
-	if ds != nil {
-		defer ds.Close()
-	} else {
-		defer s.Close()
-	}
-
-	for _, r := range rules {
-		if err := s.AddRule(r); err != nil {
-			return fmt.Errorf("storing rule: %w", err)
-		}
-	}
-
-	validationEngine := initValidationEngine()
-
-	// Wire validator awareness into the matcher's built-in deduplicator
-	if validationEngine != nil {
-		matcher.SetCanValidate(m, validationEngine.CanValidate)
-	}
-
-	// Build the scoring engine before workers start so the main worker pass
-	// can score findings (not just the drain-path retries).
-	repoEngine, err := buildScoringEngine()
-	if err != nil {
-		return fmt.Errorf("initializing scoring engine: %w", err)
-	}
-
-	// Resolve accessibility for score penalty (same logic as runScan).
-	ghToken := os.Getenv("GITHUB_TOKEN")
-	if rt.Platform == "gitlab" {
-		ghToken = os.Getenv("GITLAB_TOKEN")
-	}
-	repoAccessibility := ResolveAccessibility(scanAccessibility, rt.FullPath, ghToken)
-
-	ctx := context.Background()
-	var matchCount atomic.Int64
-	var findingCount atomic.Int64
-	var skippedCount atomic.Int64
-	var totalBytes atomic.Int64
-	var blobCount atomic.Int64
-	startTime := time.Now()
-
-	numWorkers := scanWorkers
-	if numWorkers < 1 {
-		numWorkers = 1
-	}
-	jobs := make(chan blobJob, 2*numWorkers)
-
-	g, ctx := errgroup.WithContext(ctx)
-
-	// Producer
-	g.Go(func() error {
-		defer close(jobs)
-		return cloneEnum.Enumerate(ctx, func(content []byte, blobID types.BlobID, prov types.Provenance) error {
-			totalBytes.Add(int64(len(content)))
-			blobCount.Add(1)
-
-			if scanIncremental {
-				exists, err := s.BlobExists(blobID)
-				if err != nil {
-					return fmt.Errorf("checking blob: %w", err)
-				}
-				if exists {
-					skippedCount.Add(1)
-					return nil
-				}
-			}
-
-			select {
-			case jobs <- blobJob{content: content, blobID: blobID, prov: prov}:
-				return nil
-			case <-ctx.Done():
-				return ctx.Err()
-			}
-		})
-	})
-
-	// Consumer workers (same as runScan)
-	const batchSize = 64
-	for i := 0; i < numWorkers; i++ {
-		g.Go(func() error {
-			type batchItem struct {
-				blobID  types.BlobID
-				prov    types.Provenance
-				size    int64
-				matches []*types.Match
-			}
-			var batch []batchItem
-
-			flush := func() error {
-				if len(batch) == 0 {
-					return nil
-				}
-				err := s.ExecBatch(func(tx store.Store) error {
-					for _, item := range batch {
-						if err := tx.AddBlob(item.blobID, item.size); err != nil {
-							return fmt.Errorf("storing blob: %w", err)
-						}
-						if err := tx.AddProvenance(item.blobID, item.prov); err != nil {
-							return fmt.Errorf("storing provenance: %w", err)
-						}
-						for _, match := range item.matches {
-							if err := tx.AddMatch(match); err != nil {
-								return fmt.Errorf("storing match: %w", err)
-							}
-							rule, ok := ruleMap[match.RuleID]
-							if !ok {
-								return fmt.Errorf("rule not found: %s", match.RuleID)
-							}
-							findingID := types.ComputeFindingID(rule.StructuralID, match.Groups)
-							exists, err := tx.FindingExists(findingID)
-							if err != nil {
-								return fmt.Errorf("checking finding: %w", err)
-							}
-							if !exists {
-								findingCount.Add(1)
-								f := &types.Finding{
-									ID:     findingID,
-									RuleID: match.RuleID,
-									Groups: match.Groups,
-								}
-								f.Score = repoEngine.Score(ctx, f, []*types.Match{match}, rule)
-								if repoAccessibility == AccessibilityPrivate {
-									ApplyAccessibilityModifier(f.Score)
-								}
-								if err := tx.AddFinding(f); err != nil {
-									return fmt.Errorf("storing finding: %w", err)
-								}
-							}
-						}
-					}
-					return nil
-				})
-				batch = batch[:0]
-				return err
-			}
-
-			for job := range jobs {
-				matches, err := m.MatchWithBlobID(job.content, job.blobID)
-				if err != nil {
-					return fmt.Errorf("matching content: %w", err)
-				}
-
-				for _, match := range matches {
-					startLine, startCol := types.ComputeLineColumn(job.content, int(match.Location.Offset.Start))
-					endLine, endCol := types.ComputeLineColumn(job.content, int(match.Location.Offset.End))
-					match.Location.Source.Start.Line = startLine
-					match.Location.Source.Start.Column = startCol
-					match.Location.Source.End.Line = endLine
-					match.Location.Source.End.Column = endCol
-				}
-
-				validateMatches(ctx, validationEngine, matches, verbose)
-				matchCount.Add(int64(len(matches)))
-
-				batch = append(batch, batchItem{
-					blobID:  job.blobID,
-					prov:    job.prov,
-					size:    int64(len(job.content)),
-					matches: matches,
-				})
-				if len(batch) >= batchSize {
-					if err := flush(); err != nil {
-						return err
-					}
-				}
-			}
-			return flush()
-		})
-	}
-
-	if err := g.Wait(); err != nil {
-		if ctx.Err() != nil && errors.Is(err, context.Canceled) {
-			// Normal shutdown via Ctrl+C, not an error
-		} else {
-			return fmt.Errorf("scanning: %w", err)
-		}
-	}
-
-	if err := drainTimedOutMatches(ctx, m, s, ruleMap, repoEngine, &findingCount, &matchCount, repoAccessibility); err != nil {
-		return fmt.Errorf("retrying timed-out blobs: %w", err)
-	}
-
-	duration := time.Since(startTime)
-	printScanStats(cmd, scanOutputFormat, scanOutputPath,
-		totalBytes.Load(), blobCount.Load(), matchCount.Load(), skippedCount.Load(), duration)
-
-	return outputScanResults(cmd, s, rules, ruleMap)
 }
 
 // runS3Scan handles scanning of S3 buckets detected from s3:// URLs.

--- a/cmd/titus/scan.go
+++ b/cmd/titus/scan.go
@@ -127,7 +127,7 @@ func runScan(cmd *cobra.Command, args []string) error {
 		Target:       target,
 		OutputPath:   scanOutputPath,
 		OutputFormat: scanOutputFormat,
-		Token:        os.Getenv("GITHUB_TOKEN"),
+		Token:        "", // filesystem targets have no remote token
 	})
 }
 

--- a/cmd/titus/scan.go
+++ b/cmd/titus/scan.go
@@ -111,7 +111,10 @@ func runScan(cmd *cobra.Command, args []string) error {
 
 	// Filesystem
 	if _, err := os.Stat(target); err != nil {
-		return fmt.Errorf("target does not exist: %s", target)
+		if os.IsNotExist(err) {
+			return fmt.Errorf("target does not exist: %s", target)
+		}
+		return fmt.Errorf("stat target %s: %w", target, err)
 	}
 
 	enumerator, err := createEnumerator(target, scanGit)
@@ -149,13 +152,13 @@ func drainTimedOutMatches(ctx context.Context, m matcher.Matcher, s store.Store,
 			if err := tx.AddMatch(match); err != nil {
 				return fmt.Errorf("storing retry match: %w", err)
 			}
+			matchCount.Add(1)
 			added, err := upsertFinding(ctx, tx, match, ruleMap, engine, resolvedAccess)
 			if err != nil {
 				return err
 			}
 			if added {
 				findingCount.Add(1)
-				matchCount.Add(1)
 			}
 		}
 		return nil
@@ -379,28 +382,37 @@ func parseSize(sizeStr string) (int64, error) {
 	return val * multiplier, nil
 }
 
-func createEnumerator(target string, useGit bool) (enum.Enumerator, error) {
-	// Parse extraction limits
+// resolveExtractionLimits builds enum.ExtractionLimits from the package-level
+// scan flags. Shared by every code path that constructs an enum.Config so
+// --extract-max-size / --extract-max-total / --extract-max-depth /
+// --sqlite-row-limit apply uniformly across filesystem, S3, and clone
+// enumerators.
+func resolveExtractionLimits() (enum.ExtractionLimits, error) {
 	limits := enum.DefaultExtractionLimits()
-
 	if extractMaxSize != "" {
 		size, err := parseSize(extractMaxSize)
 		if err != nil {
-			return nil, fmt.Errorf("parsing extract-max-size: %w", err)
+			return limits, fmt.Errorf("parsing extract-max-size: %w", err)
 		}
 		limits.MaxSize = size
 	}
-
 	if extractMaxTotal != "" {
 		size, err := parseSize(extractMaxTotal)
 		if err != nil {
-			return nil, fmt.Errorf("parsing extract-max-total: %w", err)
+			return limits, fmt.Errorf("parsing extract-max-total: %w", err)
 		}
 		limits.MaxTotal = size
 	}
-
 	limits.MaxDepth = extractMaxDepth
 	limits.SQLiteRowLimit = scanSQLiteRowLimit
+	return limits, nil
+}
+
+func createEnumerator(target string, useGit bool) (enum.Enumerator, error) {
+	limits, err := resolveExtractionLimits()
+	if err != nil {
+		return nil, err
+	}
 
 	config := enum.Config{
 		Root:            target,
@@ -493,11 +505,17 @@ func runRepoScan(cmd *cobra.Command, rt repoTarget) error {
 		cloneURL = "https://gitlab.com/" + rt.FullPath + ".git"
 	}
 
+	limits, err := resolveExtractionLimits()
+	if err != nil {
+		return err
+	}
 	cloneEnum := enum.NewCloneEnumerator(
 		[]enum.RepoInfo{{Name: rt.FullPath, CloneURL: cloneURL}},
 		enum.Config{
-			MaxFileSize: scanMaxFileSize,
-			IgnoreFile:  scanIgnoreFile,
+			MaxFileSize:     scanMaxFileSize,
+			IgnoreFile:      scanIgnoreFile,
+			ExtractArchives: string(scanExtractArchivesFlag),
+			ExtractLimits:   limits,
 		})
 	cloneEnum.Git = scanGit
 	cloneEnum.Token = token
@@ -516,23 +534,10 @@ func runRepoScan(cmd *cobra.Command, rt repoTarget) error {
 
 // runS3Scan handles scanning of S3 buckets detected from s3:// URLs.
 func runS3Scan(cmd *cobra.Command, bucket, prefix string) error {
-	limits := enum.DefaultExtractionLimits()
-	if extractMaxSize != "" {
-		size, err := parseSize(extractMaxSize)
-		if err != nil {
-			return fmt.Errorf("parsing extract-max-size: %w", err)
-		}
-		limits.MaxSize = size
+	limits, err := resolveExtractionLimits()
+	if err != nil {
+		return err
 	}
-	if extractMaxTotal != "" {
-		size, err := parseSize(extractMaxTotal)
-		if err != nil {
-			return fmt.Errorf("parsing extract-max-total: %w", err)
-		}
-		limits.MaxTotal = size
-	}
-	limits.MaxDepth = extractMaxDepth
-	limits.SQLiteRowLimit = scanSQLiteRowLimit
 
 	s3Enum := enum.NewS3Enumerator(bucket, prefix, enum.Config{
 		MaxFileSize:     scanMaxFileSize,

--- a/cmd/titus/scan.go
+++ b/cmd/titus/scan.go
@@ -127,7 +127,7 @@ func runScan(cmd *cobra.Command, args []string) error {
 		Target:       target,
 		OutputPath:   scanOutputPath,
 		OutputFormat: scanOutputFormat,
-		TokenEnvVar:  "GITHUB_TOKEN",
+		Token:        os.Getenv("GITHUB_TOKEN"),
 	})
 }
 
@@ -474,14 +474,13 @@ func parseRepoURL(target string) (repoTarget, bool) {
 
 // runRepoScan handles scanning of GitHub/GitLab repositories detected from URL-like targets.
 func runRepoScan(cmd *cobra.Command, rt repoTarget) error {
-	var tokenEnv string
+	var token string
 	switch rt.Platform {
 	case "github":
-		tokenEnv = "GITHUB_TOKEN"
+		token = os.Getenv("GITHUB_TOKEN")
 	case "gitlab":
-		tokenEnv = "GITLAB_TOKEN"
+		token = os.Getenv("GITLAB_TOKEN")
 	}
-	token := os.Getenv(tokenEnv)
 	if token == "" {
 		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Note: No %s token provided. Using unauthenticated access (public repos only).\n\n", rt.Platform)
 	}
@@ -511,7 +510,7 @@ func runRepoScan(cmd *cobra.Command, rt repoTarget) error {
 		Target:       rt.FullPath,
 		OutputPath:   scanOutputPath,
 		OutputFormat: scanOutputFormat,
-		TokenEnvVar:  tokenEnv,
+		Token:        token,
 	})
 }
 
@@ -549,7 +548,7 @@ func runS3Scan(cmd *cobra.Command, bucket, prefix string) error {
 		Target:       "s3://" + bucket + "/" + prefix,
 		OutputPath:   scanOutputPath,
 		OutputFormat: scanOutputFormat,
-		TokenEnvVar:  "", // S3 has no git remote
+		Token:        "", // S3 has no git remote
 	})
 }
 

--- a/cmd/titus/scan.go
+++ b/cmd/titus/scan.go
@@ -133,10 +133,9 @@ func runScan(cmd *cobra.Command, args []string) error {
 
 // drainTimedOutMatches replays blobs that timed out during the parallel scan
 // pass using the matcher's single-threaded retry queue, then writes the
-// resulting matches and findings to the store. It is called after g.Wait() in
-// each of the scan entry points (runScan, runRepoScan, runS3Scan).
-// The resolvedAccess parameter ensures that retried findings receive the same
-// accessibility penalty as findings scored on the normal path.
+// resulting matches and findings to the store. Called from runPipeline after
+// the worker errgroup completes; resolvedAccess ensures retried findings get
+// the same accessibility penalty as ones scored on the normal path.
 func drainTimedOutMatches(ctx context.Context, m matcher.Matcher, s store.Store, ruleMap map[string]*types.Rule, engine scoringEngineInterface, findingCount, matchCount *atomic.Int64, resolvedAccess Accessibility) error {
 	retryMatches, err := m.DrainTimedOut()
 	if err != nil {
@@ -150,30 +149,13 @@ func drainTimedOutMatches(ctx context.Context, m matcher.Matcher, s store.Store,
 			if err := tx.AddMatch(match); err != nil {
 				return fmt.Errorf("storing retry match: %w", err)
 			}
-			rule, ok := ruleMap[match.RuleID]
-			if !ok {
-				return fmt.Errorf("rule not found: %s", match.RuleID)
-			}
-			findingID := types.ComputeFindingID(rule.StructuralID, match.Groups)
-			exists, err := tx.FindingExists(findingID)
+			added, err := upsertFinding(ctx, tx, match, ruleMap, engine, resolvedAccess)
 			if err != nil {
-				return fmt.Errorf("checking retry finding: %w", err)
+				return err
 			}
-			if !exists {
+			if added {
 				findingCount.Add(1)
 				matchCount.Add(1)
-				f := &types.Finding{
-					ID:     findingID,
-					RuleID: match.RuleID,
-					Groups: match.Groups,
-				}
-				f.Score = engine.Score(ctx, f, []*types.Match{match}, rule)
-				if resolvedAccess == AccessibilityPrivate {
-					ApplyAccessibilityModifier(f.Score)
-				}
-				if err := tx.AddFinding(f); err != nil {
-					return fmt.Errorf("storing retry finding: %w", err)
-				}
 			}
 		}
 		return nil

--- a/cmd/titus/scan.go
+++ b/cmd/titus/scan.go
@@ -771,17 +771,17 @@ func resolveAutoName(group, user, project string) string {
 	if group != "" {
 		// Use last segment of group path (e.g. "ctp1/tmna-ct/tmna-ev" → "tmna-ev")
 		parts := strings.Split(group, "/")
-		return parts[len(parts)-1] + ".db"
+		return parts[len(parts)-1] + ".ds"
 	}
 	if user != "" {
-		return user + ".db"
+		return user + ".ds"
 	}
 	if project != "" {
 		// project may be "owner/repo" — take repo part
 		parts := strings.Split(project, "/")
-		return parts[len(parts)-1] + ".db"
+		return parts[len(parts)-1] + ".ds"
 	}
-	return "output.db"
+	return "output.ds"
 }
 
 // resolveAutoOutput derives a datastore name from a scan target.

--- a/cmd/titus/scan.go
+++ b/cmd/titus/scan.go
@@ -516,6 +516,7 @@ func runRepoScan(cmd *cobra.Command, rt repoTarget) error {
 			IgnoreFile:      scanIgnoreFile,
 			ExtractArchives: string(scanExtractArchivesFlag),
 			ExtractLimits:   limits,
+			NumReaders:      scanReaders,
 		})
 	cloneEnum.Git = scanGit
 	cloneEnum.Token = token
@@ -543,6 +544,7 @@ func runS3Scan(cmd *cobra.Command, bucket, prefix string) error {
 		MaxFileSize:     scanMaxFileSize,
 		ExtractArchives: string(scanExtractArchivesFlag),
 		ExtractLimits:   limits,
+		NumReaders:      scanReaders,
 	})
 
 	ctx := cmd.Context()

--- a/cmd/titus/scan.go
+++ b/cmd/titus/scan.go
@@ -127,10 +127,10 @@ func runScan(cmd *cobra.Command, args []string) error {
 		ctx = context.Background()
 	}
 	return runPipeline(ctx, cmd, enumerator, pipelineOpts{
-		Target:       target,
-		OutputPath:   scanOutputPath,
-		OutputFormat: scanOutputFormat,
-		Token:        "", // filesystem targets have no remote token
+		Target:        target,
+		OutputPath:    scanOutputPath,
+		OutputFormat:  scanOutputFormat,
+		Accessibility: ResolveAccessibility(scanAccessibility, target, os.Getenv("GITHUB_TOKEN")),
 	})
 }
 
@@ -526,10 +526,10 @@ func runRepoScan(cmd *cobra.Command, rt repoTarget) error {
 		ctx = context.Background()
 	}
 	return runPipeline(ctx, cmd, cloneEnum, pipelineOpts{
-		Target:       rt.FullPath,
-		OutputPath:   scanOutputPath,
-		OutputFormat: scanOutputFormat,
-		Token:        token,
+		Target:        rt.FullPath,
+		OutputPath:    scanOutputPath,
+		OutputFormat:  scanOutputFormat,
+		Accessibility: ResolveAccessibility(scanAccessibility, rt.FullPath, token),
 	})
 }
 
@@ -552,10 +552,10 @@ func runS3Scan(cmd *cobra.Command, bucket, prefix string) error {
 		ctx = context.Background()
 	}
 	return runPipeline(ctx, cmd, s3Enum, pipelineOpts{
-		Target:       "s3://" + bucket + "/" + prefix,
-		OutputPath:   scanOutputPath,
-		OutputFormat: scanOutputFormat,
-		Token:        "", // S3 has no git remote
+		Target:        "s3://" + bucket + "/" + prefix,
+		OutputPath:    scanOutputPath,
+		OutputFormat:  scanOutputFormat,
+		Accessibility: ResolveAccessibility(scanAccessibility, "", ""),
 	})
 }
 

--- a/cmd/titus/scan.go
+++ b/cmd/titus/scan.go
@@ -101,274 +101,36 @@ func runScan(cmd *cobra.Command, args []string) error {
 		scanOutputPath = resolveAutoOutput(target)
 	}
 
-	// Check if target is a GitHub or GitLab URL
+	// GitHub/GitLab repo URL
 	if repoTarget, ok := parseRepoURL(target); ok {
 		return runRepoScan(cmd, repoTarget)
 	}
 
-	// Check if target is an S3 URL
+	// S3 URL
 	if bucket, prefix, ok := enum.ParseS3URL(target); ok {
 		return runS3Scan(cmd, bucket, prefix)
 	}
 
-	// Validate target exists (filesystem path)
+	// Filesystem
 	if _, err := os.Stat(target); err != nil {
 		return fmt.Errorf("target does not exist: %s", target)
 	}
 
-	// Load rules
-	rules, err := loadRules(scanRulesPath, scanRulesInclude, scanRulesExclude, scanRuleset)
-	if err != nil {
-		return fmt.Errorf("loading rules: %w", err)
-	}
-
-	// Create rule map for finding ID computation
-	ruleMap := make(map[string]*types.Rule)
-	for _, r := range rules {
-		ruleMap[r.ID] = r
-	}
-
-	// Create matcher
-	m, err := matcher.New(matcher.Config{
-		Rules:        rules,
-		ContextLines: scanContextLines,
-		WarnFunc: func(format string, args ...any) {
-			fmt.Fprintf(os.Stderr, format, args...)
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("creating matcher: %w", err)
-	}
-	defer m.Close()
-
-	// Create store (memory or datastore)
-	s, ds, err := openScanStore(scanOutputPath, scanStoreBlobs)
-	if err != nil {
-		return err
-	}
-	if ds != nil {
-		defer ds.Close()
-	} else {
-		defer s.Close()
-	}
-
-	// Store rules for foreign key constraints
-	for _, r := range rules {
-		if err := s.AddRule(r); err != nil {
-			return fmt.Errorf("storing rule: %w", err)
-		}
-	}
-
-	// Initialize validation engine (nil if validation disabled)
-	validationEngine := initValidationEngine()
-
-	// Wire validator awareness into the matcher's built-in deduplicator
-	if validationEngine != nil {
-		matcher.SetCanValidate(m, validationEngine.CanValidate)
-	}
-
-	// Build the scoring engine once per scan.
-	engine, err := buildScoringEngine()
-	if err != nil {
-		return fmt.Errorf("initializing scoring engine: %w", err)
-	}
-	if scanScopeEnabled && !scanValidate {
-		fmt.Fprintf(os.Stderr, "[warn] --score-scope set without --validate; dynamic modifiers will use unvalidated credentials (results may be less accurate)\n")
-	}
-
-	// Resolve code accessibility for score adjustment.
-	// Use GITHUB_TOKEN env var for auto-detection; the user can also pass --accessibility directly.
-	ghToken := os.Getenv("GITHUB_TOKEN")
-	accessibility := ResolveAccessibility(scanAccessibility, target, ghToken)
-
-	// Create enumerator
 	enumerator, err := createEnumerator(target, scanGit)
 	if err != nil {
 		return fmt.Errorf("creating enumerator: %w", err)
 	}
 
-	// Scan with parallel workers
-	ctx := context.Background()
-	var matchCount atomic.Int64
-	var findingCount atomic.Int64
-	var skippedCount atomic.Int64
-	var totalBytes atomic.Int64
-	var blobCount atomic.Int64
-	startTime := time.Now()
-
-	numWorkers := scanWorkers
-	if numWorkers < 1 {
-		numWorkers = 1
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
 	}
-
-	if verbose {
-		fmt.Fprintf(os.Stderr, "[scan] Starting scan with %d workers and %d rules\n", numWorkers, len(rules))
-	}
-
-	jobs := make(chan blobJob, 2*numWorkers)
-
-	g, ctx := errgroup.WithContext(ctx)
-
-	// Producer: enumerate blobs and send to workers (NO DB writes)
-	g.Go(func() error {
-		defer close(jobs)
-		if verbose {
-			fmt.Fprintf(os.Stderr, "[enumerate] Starting enumeration of %s\n", target)
-		}
-		return enumerator.Enumerate(ctx, func(content []byte, blobID types.BlobID, prov types.Provenance) error {
-			totalBytes.Add(int64(len(content)))
-			count := blobCount.Add(1)
-			if verbose && count%1000 == 0 {
-				fmt.Fprintf(os.Stderr, "[enumerate] %d files discovered (%d bytes)\n", count, totalBytes.Load())
-			}
-
-			// Check for incremental scanning
-			if scanIncremental {
-				exists, err := s.BlobExists(blobID)
-				if err != nil {
-					return fmt.Errorf("checking blob: %w", err)
-				}
-				if exists {
-					skippedCount.Add(1)
-					return nil
-				}
-			}
-
-			select {
-			case jobs <- blobJob{content: content, blobID: blobID, prov: prov}:
-				return nil
-			case <-ctx.Done():
-				return ctx.Err()
-			}
-		})
+	return runPipeline(ctx, cmd, enumerator, pipelineOpts{
+		Target:       target,
+		OutputPath:   scanOutputPath,
+		OutputFormat: scanOutputFormat,
+		TokenEnvVar:  "GITHUB_TOKEN",
 	})
-
-	// Consumer workers: match, compute line/col, validate, write to DB in batches
-	const batchSize = 64
-	for i := 0; i < numWorkers; i++ {
-		g.Go(func() error {
-			type batchItem struct {
-				blobID  types.BlobID
-				prov    types.Provenance
-				size    int64
-				matches []*types.Match
-			}
-			var batch []batchItem
-
-			flush := func() error {
-				if len(batch) == 0 {
-					return nil
-				}
-				err := s.ExecBatch(func(tx store.Store) error {
-					for _, item := range batch {
-						if err := tx.AddBlob(item.blobID, item.size); err != nil {
-							return fmt.Errorf("storing blob: %w", err)
-						}
-						if err := tx.AddProvenance(item.blobID, item.prov); err != nil {
-							return fmt.Errorf("storing provenance: %w", err)
-						}
-						for _, match := range item.matches {
-							if err := tx.AddMatch(match); err != nil {
-								return fmt.Errorf("storing match: %w", err)
-							}
-							rule, ok := ruleMap[match.RuleID]
-							if !ok {
-								return fmt.Errorf("rule not found: %s", match.RuleID)
-							}
-							findingID := types.ComputeFindingID(rule.StructuralID, match.Groups)
-							exists, err := tx.FindingExists(findingID)
-							if err != nil {
-								return fmt.Errorf("checking finding: %w", err)
-							}
-							if !exists {
-								findingCount.Add(1)
-								f := &types.Finding{
-									ID:     findingID,
-									RuleID: match.RuleID,
-									Groups: match.Groups,
-								}
-								f.Score = engine.Score(ctx, f, []*types.Match{match}, rule)
-								if accessibility == AccessibilityPrivate {
-									ApplyAccessibilityModifier(f.Score)
-								}
-								if err := tx.AddFinding(f); err != nil {
-									return fmt.Errorf("storing finding: %w", err)
-								}
-							}
-						}
-					}
-					return nil
-				})
-				batch = batch[:0]
-				return err
-			}
-
-			for job := range jobs {
-				matches, err := m.MatchWithBlobID(job.content, job.blobID)
-				if err != nil {
-					// Log warning but continue scanning other files
-					fmt.Fprintf(os.Stderr, "[warn] match error (skipping blob %s): %v\n", job.blobID.Hex(), err)
-					continue
-				}
-
-				for _, match := range matches {
-					startLine, startCol := types.ComputeLineColumn(job.content, int(match.Location.Offset.Start))
-					endLine, endCol := types.ComputeLineColumn(job.content, int(match.Location.Offset.End))
-					match.Location.Source.Start.Line = startLine
-					match.Location.Source.Start.Column = startCol
-					match.Location.Source.End.Line = endLine
-					match.Location.Source.End.Column = endCol
-				}
-
-				validateMatches(ctx, validationEngine, matches, verbose)
-				matchCount.Add(int64(len(matches)))
-
-				batch = append(batch, batchItem{
-					blobID:  job.blobID,
-					prov:    job.prov,
-					size:    int64(len(job.content)),
-					matches: matches,
-				})
-				if len(batch) >= batchSize {
-					if err := flush(); err != nil {
-						return err
-					}
-				}
-			}
-			return flush()
-		})
-	}
-
-	if err := g.Wait(); err != nil {
-		if ctx.Err() != nil && errors.Is(err, context.Canceled) {
-			// Normal shutdown, not an error
-		} else {
-			return fmt.Errorf("scanning: %w", err)
-		}
-	}
-
-	// Retry any blobs that timed out during the parallel pass.
-	// This runs single-threaded so there is no CPU contention, resolving
-	// starvation-caused false timeouts while still catching real backtracking.
-	if err := drainTimedOutMatches(ctx, m, s, ruleMap, engine, &findingCount, &matchCount, accessibility); err != nil {
-		return fmt.Errorf("retrying timed-out blobs: %w", err)
-	}
-
-	// Emit aggregate dynamic modifier stats if any errors occurred.
-	if s := engine.Stats(); s.Any() {
-		fmt.Fprintf(os.Stderr, "[scoring] Dynamic modifiers: %d timeouts, %d rate-limited, %d server errors, %d network errors\n",
-			s.Timeouts, s.RateLimited, s.ServerErrors, s.NetworkErrors)
-	}
-
-	if verbose {
-		fmt.Fprintf(os.Stderr, "[scan] Scan complete: %d blobs, %d matches, %d findings\n", blobCount.Load(), matchCount.Load(), findingCount.Load())
-	}
-
-	duration := time.Since(startTime)
-	printScanStats(cmd, scanOutputFormat, scanOutputPath,
-		totalBytes.Load(), blobCount.Load(), matchCount.Load(), skippedCount.Load(), duration)
-
-	return outputScanResults(cmd, s, rules, ruleMap)
 }
 
 // drainTimedOutMatches replays blobs that timed out during the parallel scan

--- a/cmd/titus/scan.go
+++ b/cmd/titus/scan.go
@@ -8,7 +8,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -82,36 +81,10 @@ var scanCmd = &cobra.Command{
 }
 
 func init() {
-	scanCmd.Flags().StringVar(&scanRulesPath, "rules", "", "Path to custom rules file or directory")
-	scanCmd.Flags().StringVar(&scanRulesInclude, "rules-include", "", "Include rules matching regex pattern (comma-separated)")
-	scanCmd.Flags().StringVar(&scanRulesExclude, "rules-exclude", "", "Exclude rules matching regex pattern (comma-separated)")
-	scanCmd.Flags().StringVar(&scanRuleset, "ruleset", "default", "Ruleset to use: default, np.assets, np.hashes, all (all = no filtering)")
-	scanCmd.Flags().StringVar(&scanOutputPath, "output", "titus.ds", "Output datastore path (:memory: for in-memory, :auto: to derive from target name)")
-	scanCmd.Flags().StringVar(&scanOutputFormat, "format", "human", "Output format: json, sarif, human")
+	addRulesFlags(scanCmd)
+	addOutputFlags(scanCmd)
+	addPipelineFlags(scanCmd)
 	scanCmd.Flags().BoolVar(&scanGit, "git", false, "Treat target as git repository (enumerate git history)")
-	scanCmd.Flags().Int64Var(&scanMaxFileSize, "max-file-size", 10*1024*1024, "Maximum file size to scan (bytes)")
-	scanCmd.Flags().IntVar(&scanContextLines, "context-lines", 3, "Lines of context before/after matches (0 to disable)")
-	scanCmd.Flags().BoolVar(&scanIncremental, "incremental", false, "Skip already-scanned blobs")
-	scanCmd.Flags().BoolVar(&scanValidate, "validate", false, "validate detected secrets against their source APIs")
-	scanCmd.Flags().IntVar(&scanValidateWorkers, "validate-workers", 4, "number of concurrent validation workers")
-	scanCmd.Flags().BoolVar(&scanStoreBlobs, "store-blobs", false, "Store file contents in blobs/ directory")
-	scanCmd.Flags().Var(&scanExtractArchivesFlag, "extract", "Extract text from binary files (extensions: xlsx,docx,pdf,zip or 'all')")
-	scanCmd.Flags().StringVar(&extractMaxSize, "extract-max-size", "10MB", "Max uncompressed size per extracted file")
-	scanCmd.Flags().StringVar(&extractMaxTotal, "extract-max-total", "100MB", "Max total bytes to extract from one archive")
-	scanCmd.Flags().IntVar(&extractMaxDepth, "extract-max-depth", 5, "Max nested archive depth")
-	scanCmd.Flags().IntVar(&scanSQLiteRowLimit, "sqlite-row-limit", 1000, "Max rows per table for SQLite extraction (0 for unlimited)")
-	scanCmd.Flags().IntVar(&scanWorkers, "workers", runtime.NumCPU(), "Number of parallel scan workers")
-	scanCmd.Flags().IntVar(&scanReaders, "readers", 0, "Number of parallel file readers (0 = NumCPU)")
-	scanCmd.Flags().StringVar(&scanIgnoreFile, "ignore", "", "Path to gitignore-style ignore file (replaces built-in defaults; use /dev/null to disable)")
-	scanCmd.Flags().StringVar(&scanAccessibility, "accessibility", "auto",
-		`code accessibility: "public" (no penalty), "private" (-25 to all scores),`+"\n"+
-			`or "auto" (detect via git remote/GitHub API, defaults to private if undetermined)`)
-	scanCmd.Flags().BoolVar(&scanScopeEnabled, "score-scope", false,
-		"enable HTTP dynamic scoring modifiers (calls external APIs to determine secret scope/permissions)")
-	scanCmd.Flags().DurationVar(&scanScoreTimeout, "score-timeout", 10*time.Second,
-		"per-modifier HTTP timeout for dynamic scoring (default 10s)")
-	scanCmd.Flags().DurationVar(&scanScoreBudget, "score-budget", 60*time.Second,
-		"per-finding overall scoring budget across all modifiers (default 60s; 0 = unlimited)")
 }
 
 // blobJob represents a unit of work for the worker pool.

--- a/cmd/titus/scan_test.go
+++ b/cmd/titus/scan_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,6 +16,49 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestRunPipeline_FilesystemEquivalence(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "leak.txt"),
+		[]byte("AKIAIOSFODNN7EXAMPLE\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reset relevant globals to known defaults.
+	scanWorkers = 2
+	scanMaxFileSize = 10 * 1024 * 1024
+	scanContextLines = 3
+	scanRulesPath = ""
+	scanRulesInclude = ""
+	scanRulesExclude = ""
+	scanRuleset = "default"
+	scanAccessibility = "public"
+	scanOutputPath = filepath.Join(t.TempDir(), "out.ds")
+	scanOutputFormat = "human"
+
+	enumerator, err := createEnumerator(dir, false)
+	if err != nil {
+		t.Fatalf("createEnumerator: %v", err)
+	}
+
+	cmd := &cobra.Command{Use: "x"}
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	if err := runPipeline(context.Background(), cmd, enumerator, pipelineOpts{
+		Target:       dir,
+		OutputPath:   scanOutputPath,
+		OutputFormat: scanOutputFormat,
+	}); err != nil {
+		t.Fatalf("runPipeline: %v", err)
+	}
+
+	for _, sub := range []string{"clones", "scratch", ".gitignore"} {
+		if _, err := os.Stat(filepath.Join(scanOutputPath, sub)); err != nil {
+			t.Errorf("missing %s in datastore: %v", sub, err)
+		}
+	}
+}
 
 func TestScanCommand_Exists(t *testing.T) {
 	cmd, _, err := rootCmd.Find([]string{"scan"})

--- a/cmd/titus/scan_test.go
+++ b/cmd/titus/scan_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/praetorian-inc/titus/pkg/enum"
 	"github.com/praetorian-inc/titus/pkg/rule"
 	"github.com/praetorian-inc/titus/pkg/types"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -208,6 +209,43 @@ func TestResolveAutoOutput(t *testing.T) {
 			got := resolveAutoOutput(tt.target)
 			assert.Equal(t, tt.expected, got)
 		})
+	}
+}
+
+func TestAddRulesFlags_RegistersAllFour(t *testing.T) {
+	cmd := &cobra.Command{Use: "x"}
+	addRulesFlags(cmd)
+	for _, name := range []string{"rules", "rules-include", "rules-exclude", "ruleset"} {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Errorf("addRulesFlags did not register --%s", name)
+		}
+	}
+}
+
+func TestAddOutputFlags_RegistersOutputAndFormat(t *testing.T) {
+	cmd := &cobra.Command{Use: "x"}
+	addOutputFlags(cmd)
+	for _, name := range []string{"output", "format"} {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Errorf("addOutputFlags did not register --%s", name)
+		}
+	}
+}
+
+func TestAddPipelineFlags_RegistersAllPipelineFlags(t *testing.T) {
+	cmd := &cobra.Command{Use: "x"}
+	addPipelineFlags(cmd)
+	expected := []string{
+		"workers", "readers", "max-file-size", "context-lines",
+		"incremental", "validate", "validate-workers", "store-blobs",
+		"accessibility", "ignore", "extract", "extract-max-size",
+		"extract-max-total", "extract-max-depth", "sqlite-row-limit",
+		"score-scope", "score-timeout", "score-budget",
+	}
+	for _, name := range expected {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Errorf("addPipelineFlags did not register --%s", name)
+		}
 	}
 }
 

--- a/cmd/titus/scan_test.go
+++ b/cmd/titus/scan_test.go
@@ -25,24 +25,27 @@ func resetPipelineGlobals(t *testing.T) {
 	saved := struct {
 		workers, readers, contextLines, validateWorkers, sqliteRowLimit, extractMaxDepth int
 		maxFileSize                                                                      int64
-		incremental, validate, storeBlobs, scopeEnabled                                  bool
+		incremental, validate, storeBlobs, scopeEnabled, git                             bool
 		rulesPath, rulesInclude, rulesExclude, ruleset, accessibility, ignoreFile        string
 		outputPath, outputFormat, extractMaxSize, extractMaxTotal                        string
+		extractArchives                                                                  extensionsValue
 		scoreTimeout, scoreBudget                                                        time.Duration
 	}{
 		scanWorkers, scanReaders, scanContextLines, scanValidateWorkers, scanSQLiteRowLimit, extractMaxDepth,
 		scanMaxFileSize,
-		scanIncremental, scanValidate, scanStoreBlobs, scanScopeEnabled,
+		scanIncremental, scanValidate, scanStoreBlobs, scanScopeEnabled, scanGit,
 		scanRulesPath, scanRulesInclude, scanRulesExclude, scanRuleset, scanAccessibility, scanIgnoreFile,
 		scanOutputPath, scanOutputFormat, extractMaxSize, extractMaxTotal,
+		scanExtractArchivesFlag,
 		scanScoreTimeout, scanScoreBudget,
 	}
 	t.Cleanup(func() {
 		scanWorkers, scanReaders, scanContextLines, scanValidateWorkers, scanSQLiteRowLimit, extractMaxDepth = saved.workers, saved.readers, saved.contextLines, saved.validateWorkers, saved.sqliteRowLimit, saved.extractMaxDepth
 		scanMaxFileSize = saved.maxFileSize
-		scanIncremental, scanValidate, scanStoreBlobs, scanScopeEnabled = saved.incremental, saved.validate, saved.storeBlobs, saved.scopeEnabled
+		scanIncremental, scanValidate, scanStoreBlobs, scanScopeEnabled, scanGit = saved.incremental, saved.validate, saved.storeBlobs, saved.scopeEnabled, saved.git
 		scanRulesPath, scanRulesInclude, scanRulesExclude, scanRuleset, scanAccessibility, scanIgnoreFile = saved.rulesPath, saved.rulesInclude, saved.rulesExclude, saved.ruleset, saved.accessibility, saved.ignoreFile
 		scanOutputPath, scanOutputFormat, extractMaxSize, extractMaxTotal = saved.outputPath, saved.outputFormat, saved.extractMaxSize, saved.extractMaxTotal
+		scanExtractArchivesFlag = saved.extractArchives
 		scanScoreTimeout, scanScoreBudget = saved.scoreTimeout, saved.scoreBudget
 	})
 
@@ -57,6 +60,8 @@ func resetPipelineGlobals(t *testing.T) {
 	scanValidate = false
 	scanStoreBlobs = false
 	scanScopeEnabled = false
+	scanGit = false
+	scanExtractArchivesFlag = ""
 	scanRulesPath = ""
 	scanRulesInclude = ""
 	scanRulesExclude = ""

--- a/cmd/titus/scan_test.go
+++ b/cmd/titus/scan_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/praetorian-inc/titus/pkg/enum"
 	"github.com/praetorian-inc/titus/pkg/rule"
@@ -17,6 +18,59 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// resetPipelineGlobals snapshots and resets every scan* global runPipeline
+// reads, then restores via t.Cleanup. Keeps tests isolated from each other.
+func resetPipelineGlobals(t *testing.T) {
+	t.Helper()
+	saved := struct {
+		workers, readers, contextLines, validateWorkers, sqliteRowLimit, extractMaxDepth int
+		maxFileSize                                                                      int64
+		incremental, validate, storeBlobs, scopeEnabled                                  bool
+		rulesPath, rulesInclude, rulesExclude, ruleset, accessibility, ignoreFile        string
+		outputPath, outputFormat, extractMaxSize, extractMaxTotal                        string
+		scoreTimeout, scoreBudget                                                        time.Duration
+	}{
+		scanWorkers, scanReaders, scanContextLines, scanValidateWorkers, scanSQLiteRowLimit, extractMaxDepth,
+		scanMaxFileSize,
+		scanIncremental, scanValidate, scanStoreBlobs, scanScopeEnabled,
+		scanRulesPath, scanRulesInclude, scanRulesExclude, scanRuleset, scanAccessibility, scanIgnoreFile,
+		scanOutputPath, scanOutputFormat, extractMaxSize, extractMaxTotal,
+		scanScoreTimeout, scanScoreBudget,
+	}
+	t.Cleanup(func() {
+		scanWorkers, scanReaders, scanContextLines, scanValidateWorkers, scanSQLiteRowLimit, extractMaxDepth = saved.workers, saved.readers, saved.contextLines, saved.validateWorkers, saved.sqliteRowLimit, saved.extractMaxDepth
+		scanMaxFileSize = saved.maxFileSize
+		scanIncremental, scanValidate, scanStoreBlobs, scanScopeEnabled = saved.incremental, saved.validate, saved.storeBlobs, saved.scopeEnabled
+		scanRulesPath, scanRulesInclude, scanRulesExclude, scanRuleset, scanAccessibility, scanIgnoreFile = saved.rulesPath, saved.rulesInclude, saved.rulesExclude, saved.ruleset, saved.accessibility, saved.ignoreFile
+		scanOutputPath, scanOutputFormat, extractMaxSize, extractMaxTotal = saved.outputPath, saved.outputFormat, saved.extractMaxSize, saved.extractMaxTotal
+		scanScoreTimeout, scanScoreBudget = saved.scoreTimeout, saved.scoreBudget
+	})
+
+	scanWorkers = 2
+	scanReaders = 0
+	scanMaxFileSize = 10 * 1024 * 1024
+	scanContextLines = 3
+	scanValidateWorkers = 4
+	scanSQLiteRowLimit = 1000
+	extractMaxDepth = 5
+	scanIncremental = false
+	scanValidate = false
+	scanStoreBlobs = false
+	scanScopeEnabled = false
+	scanRulesPath = ""
+	scanRulesInclude = ""
+	scanRulesExclude = ""
+	scanRuleset = "default"
+	scanAccessibility = "public"
+	scanIgnoreFile = ""
+	scanOutputPath = ""
+	scanOutputFormat = "human"
+	extractMaxSize = "10MB"
+	extractMaxTotal = "100MB"
+	scanScoreTimeout = 10 * time.Second
+	scanScoreBudget = 60 * time.Second
+}
+
 func TestRunPipeline_FilesystemEquivalence(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "leak.txt"),
@@ -24,17 +78,8 @@ func TestRunPipeline_FilesystemEquivalence(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Reset relevant globals to known defaults.
-	scanWorkers = 2
-	scanMaxFileSize = 10 * 1024 * 1024
-	scanContextLines = 3
-	scanRulesPath = ""
-	scanRulesInclude = ""
-	scanRulesExclude = ""
-	scanRuleset = "default"
-	scanAccessibility = "public"
+	resetPipelineGlobals(t)
 	scanOutputPath = filepath.Join(t.TempDir(), "out.ds")
-	scanOutputFormat = "human"
 
 	enumerator, err := createEnumerator(dir, false)
 	if err != nil {


### PR DESCRIPTION
## Summary

Stacked on #223. Migrates `titus github` and `titus gitlab` to the shared `runPipeline` introduced there. Both subcommands now inherit parallel workers, scoring, validation, accessibility detection, retry drain, batched writes, `--store-blobs`, clone cache, and the full extract/score flag set.

Closes the missing `DrainTimedOut()` call that previously caused the matcher's retry queue to grow unbounded across an org scan — a likely cause of OOM kills on large organizations (#TODO if there's a tracking issue).

Drops the duplicated flag registration on `gitlabCmd`/`gitlabScanCmd` and `githubCmd`/`githubScanCmd`. Each subcommand now wires init() through a single `registerGitHubFlags` / `registerGitLabFlags` helper that calls the shared `addRulesFlags` + `addOutputFlags` + `addPipelineFlags`. No more flag drift between subcommands.

## Breaking change

Default `--output` for `titus github` and `titus gitlab` flips from `titus.db` (sqlite file) to `titus.ds` (datastore directory, NoseyParker-style). Existing `.db` files remain readable via `titus report`. Pass `--output titus.db` to keep the old name (will create a directory named `titus.db`, not a file).

`--max-file-size` and `--context-lines` previously hardcoded at 10 MiB / 3 lines for github/gitlab are now flags inherited from the shared pipeline and respect user overrides.

## Note for reviewers

This PR is stacked on #223. Please review #223 first; the diff here makes most sense once that's in. If reviewing in parallel, the relevant new symbols (`runPipeline`, `pipelineOpts`, `addRulesFlags`, `addOutputFlags`, `addPipelineFlags`) all come from #223.

## Test plan

- [x] `go test ./cmd/titus/ -race -count=1` passes.
- [x] New tests assert `titus.ds` default + pipeline-flag inheritance (workers, validate, accessibility, store-blobs, ignore) on both `github scan` and `gitlab scan`.
- [x] Manual smoke: `titus github --help` shows the full inherited pipeline flag set; `titus gitlab --help` likewise.