### PR TITLE
Added datastore positional argument parsing for titus explore.

### DIFF
--- a/cmd/titus/explore.go
+++ b/cmd/titus/explore.go
@@ -13,9 +13,12 @@ var (
 )
 
 var exploreCmd = &cobra.Command{
-	Use:   "explore",
+	Use:   "explore [datastore]",
 	Short: "Interactively explore scan results",
 	Long: `Launch an interactive TUI to browse findings from a scan datastore.
+
+The datastore path can be provided as a positional argument or via --datastore.
+If omitted, defaults to titus.ds in the current directory.
 
 Features:
   - Three-pane layout: filters, findings table, match details
@@ -24,6 +27,7 @@ Features:
   - Vi-style navigation (hjkl, Ctrl-f/b, g/G)
   - Source viewer for matched content
   - Sortable findings table`,
+	Args: cobra.MaximumNArgs(1),
 	RunE: runExplore,
 }
 
@@ -32,6 +36,13 @@ func init() {
 }
 
 func runExplore(cmd *cobra.Command, args []string) error {
+	if len(args) == 1 {
+		if cmd.Flags().Changed("datastore") {
+			return fmt.Errorf("cannot specify both a positional datastore argument and --datastore flag")
+		}
+		exploreDatastore = args[0]
+	}
+
 	model, err := explore.New(exploreDatastore)
 	if err != nil {
 		return fmt.Errorf("loading datastore: %w", err)

--- a/cmd/titus/explore_test.go
+++ b/cmd/titus/explore_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExploreCommand_Exists(t *testing.T) {
+	cmd, _, err := rootCmd.Find([]string{"explore"})
+	require.NoError(t, err)
+	assert.Equal(t, "explore", cmd.Name())
+}
+
+func TestExploreCommand_DefaultDatastore(t *testing.T) {
+	cmd, _, err := rootCmd.Find([]string{"explore"})
+	require.NoError(t, err)
+
+	flag := cmd.Flags().Lookup("datastore")
+	require.NotNil(t, flag, "--datastore flag should exist")
+	assert.Equal(t, "titus.ds", flag.DefValue)
+}
+
+func TestExploreCommand_RejectsTooManyArgs(t *testing.T) {
+	cmd, _, err := rootCmd.Find([]string{"explore"})
+	require.NoError(t, err)
+	assert.NotNil(t, cmd.Args, "Args validator should be set")
+	assert.Error(t, cmd.Args(cmd, []string{"one", "two"}))
+}
+
+func TestExploreCommand_PositionalArgOverridesDefault(t *testing.T) {
+	old := exploreDatastore
+	defer func() { exploreDatastore = old }()
+
+	exploreDatastore = "titus.ds"
+
+	err := runExplore(exploreCmd, []string{"/tmp/custom.ds"})
+	// runExplore will fail because the datastore doesn't exist,
+	// but exploreDatastore should have been set before the error.
+	assert.Error(t, err)
+	assert.Equal(t, "/tmp/custom.ds", exploreDatastore)
+}
+
+func TestExploreCommand_PositionalArgConflictsWithFlag(t *testing.T) {
+	old := exploreDatastore
+	defer func() { exploreDatastore = old }()
+
+	cmd, _, err := rootCmd.Find([]string{"explore"})
+	require.NoError(t, err)
+	require.NoError(t, cmd.Flags().Set("datastore", "/tmp/flagged.ds"))
+
+	err = runExplore(cmd, []string{"/tmp/positional.ds"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot specify both")
+}


### PR DESCRIPTION
Instead of needing to do `--datastore some-other-datastore.ds`, added a positional argument (and supporting tests) to take in a datastore.

For example,

`titus explorer not-titus.ds` 

is now equivalent to 

`titus explorer --datastore titus.ds`

Linear Ticket: ENG-3449