### PR TITLE
fix(release): use fetch-tags in checkout; guard grep against no prev tag

### DIFF
--- a/.github/workflows/release-new.yml
+++ b/.github/workflows/release-new.yml
@@ -419,6 +419,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        fetch-tags: true
 
     - name: Download all artifacts
       uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
@@ -450,9 +452,8 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        # Find the previous tag so GitHub can diff commits between them
-        git fetch --tags --quiet
-        PREV_TAG=$(git tag --sort=-version:refname | grep -v "^${{ env.VERSION }}$" | head -1)
+        # Find the previous tag (tags fetched by checkout with fetch-tags: true)
+        PREV_TAG=$(git tag --sort=-version:refname | grep -v "^${{ env.VERSION }}$" | head -1 || true)
 
         # Generate "What's Changed" changelog via GitHub API
         if [ -n "$PREV_TAG" ]; then


### PR DESCRIPTION
## Root cause

The release job's `actions/checkout` step runs with `fetch-depth: 1` and `fetch-tags: false` (defaults). This means only the current tag ref (`refs/tags/vX.Y.Z`) is fetched — all previous tags are absent from the local repo.

The "Generate release notes" step then ran `git fetch --tags --quiet` to compensate, but `git fetch --tags` exits 1 on a shallow clone that can't resolve all tag objects. Because the step runs under `bash -e`, that silent exit 1 immediately killed the step before any release notes were written.

Visible symptom: https://github.com/praetorian-inc/titus/actions/runs/25585098154/job/75112877712

## Fix

1. Add `fetch-tags: true` to the release job's checkout step — the correct, idiomatic way to ensure tags are available. No separate `git fetch --tags` step needed.
2. Add `|| true` to the `grep -v` pipeline so an absent previous tag (e.g. very first release) doesn't abort the script either.

## Test plan

- [ ] Push a tag and verify the release workflow completes the "Generate release notes" step without error
- [ ] Verify the resulting GitHub release body contains the "What's Changed" section with PR links