### PR TITLE
fix(explore): show match details for custom-rule findings

### DIFF
--- a/cmd/titus/report.go
+++ b/cmd/titus/report.go
@@ -403,6 +403,9 @@ func filterRejected(s store.Store, findings []*types.Finding, matches []*types.M
 
 // buildFindingMatchMap groups matches by finding ID using content-based computation.
 // It uses structural ID matching with a fallback to RuleID + Groups matching.
+//
+// Mirrored by pkg/explore.groupMatchesByFinding; keep the two in sync.
+// (cmd/titus is package main and cannot be imported, so the logic is duplicated.)
 func buildFindingMatchMap(findings []*types.Finding, matches []*types.Match, ruleMap map[string]*types.Rule) map[string][]*types.Match {
 	matchesByFinding := make(map[string][]*types.Match)
 	for _, m := range matches {

--- a/pkg/explore/data.go
+++ b/pkg/explore/data.go
@@ -63,15 +63,9 @@ func loadData(storePath string) (*exploreData, error) {
 		return nil, fmt.Errorf("retrieving matches: %w", err)
 	}
 
-	// Group matches by finding ID (same as report.go:buildFindingMatchMap)
-	matchesByFinding := make(map[string][]*types.Match)
-	for _, m := range matches {
-		r, ok := ruleMap[m.RuleID]
-		if ok {
-			findingID := types.ComputeFindingID(r.StructuralID, m.Groups)
-			matchesByFinding[findingID] = append(matchesByFinding[findingID], m)
-		}
-	}
+	// Group matches by finding ID, with a fallback for custom rules
+	// not present in ruleMap. See groupMatchesByFinding for details.
+	matchesByFinding := groupMatchesByFinding(findings, matches, ruleMap)
 
 	// Build view models
 	rows := make([]*findingRow, 0, len(findings))
@@ -88,6 +82,51 @@ func loadData(storePath string) (*exploreData, error) {
 	}, nil
 }
 
+// groupMatchesByFinding groups matches by finding ID using content-based
+// computation. It first tries the structural-ID fast path (rule present in
+// ruleMap), then falls back to matching by RuleID + Groups byte-equality
+// for any finding still without matches. The fallback handles custom rules
+// loaded via --rules at scan time, which are not in LoadBuiltinRules() and
+// therefore absent from ruleMap.
+//
+// This mirrors cmd/titus/report.go:buildFindingMatchMap. The two copies
+// must be kept in sync; cmd/titus is package main and cannot be imported,
+// so the logic is intentionally duplicated.
+func groupMatchesByFinding(findings []*types.Finding, matches []*types.Match, ruleMap map[string]*types.Rule) map[string][]*types.Match {
+	matchesByFinding := make(map[string][]*types.Match)
+	for _, m := range matches {
+		r, ok := ruleMap[m.RuleID]
+		if ok {
+			findingID := types.ComputeFindingID(r.StructuralID, m.Groups)
+			matchesByFinding[findingID] = append(matchesByFinding[findingID], m)
+		}
+	}
+
+	// Fallback for rules not in builtin rules (custom rules from --rules).
+	for _, f := range findings {
+		if _, exists := matchesByFinding[f.ID]; exists {
+			continue
+		}
+		for _, m := range matches {
+			if m.RuleID != f.RuleID || len(m.Groups) != len(f.Groups) {
+				continue
+			}
+			groupsMatch := true
+			for i := range m.Groups {
+				if string(m.Groups[i]) != string(f.Groups[i]) {
+					groupsMatch = false
+					break
+				}
+			}
+			if groupsMatch {
+				matchesByFinding[f.ID] = append(matchesByFinding[f.ID], m)
+			}
+		}
+	}
+
+	return matchesByFinding
+}
+
 // buildFindingRow creates a findingRow from a Finding and its matches.
 func buildFindingRow(f *types.Finding, matches []*types.Match, ruleMap map[string]*types.Rule, s store.Store) *findingRow {
 	row := &findingRow{
@@ -102,6 +141,10 @@ func buildFindingRow(f *types.Finding, matches []*types.Match, ruleMap map[strin
 	if r, ok := ruleMap[f.RuleID]; ok {
 		row.RuleName = r.Name
 		row.Categories = r.Categories
+	} else if len(matches) > 0 && matches[0].RuleName != "" {
+		// Custom rule not in ruleMap: fall back to the friendly name
+		// persisted on the match record.
+		row.RuleName = matches[0].RuleName
 	}
 
 	// Aggregate validation status from matches

--- a/pkg/explore/data_test.go
+++ b/pkg/explore/data_test.go
@@ -146,3 +146,92 @@ func TestRenderAnnotationStatus(t *testing.T) {
 	renderAnnotationStatus("reject")
 	renderAnnotationStatus("")
 }
+
+// TestGroupMatchesByFinding_CustomRule verifies that matches for custom
+// rules (not present in ruleMap) are still grouped onto their findings via
+// the RuleID + Groups fallback. Regression test for the bug where the
+// explore TUI rendered "No matches" for custom-rule findings.
+func TestGroupMatchesByFinding_CustomRule(t *testing.T) {
+	// Custom rule: deliberately NOT inserted into ruleMap, mimicking a
+	// rule loaded via --rules at scan time.
+	finding := &types.Finding{
+		ID:     "finding-custom-1",
+		RuleID: "ps.cred.1",
+		Groups: [][]byte{[]byte("supersecret")},
+	}
+
+	matches := []*types.Match{
+		{
+			StructuralID: "match-a",
+			RuleID:       "ps.cred.1",
+			RuleName:     "PowerShell Hardcoded Credential",
+			Groups:       [][]byte{[]byte("supersecret")},
+		},
+		{
+			StructuralID: "match-b",
+			RuleID:       "ps.cred.1",
+			RuleName:     "PowerShell Hardcoded Credential",
+			Groups:       [][]byte{[]byte("supersecret")},
+		},
+		{
+			// Different groups — must not be paired with the finding.
+			StructuralID: "match-c",
+			RuleID:       "ps.cred.1",
+			RuleName:     "PowerShell Hardcoded Credential",
+			Groups:       [][]byte{[]byte("other")},
+		},
+	}
+
+	ruleMap := map[string]*types.Rule{} // empty: custom rule not in builtins
+
+	got := groupMatchesByFinding([]*types.Finding{finding}, matches, ruleMap)
+
+	paired := got[finding.ID]
+	if len(paired) != 2 {
+		t.Fatalf("expected 2 matches paired with custom-rule finding, got %d", len(paired))
+	}
+	if paired[0].StructuralID != "match-a" || paired[1].StructuralID != "match-b" {
+		t.Errorf("unexpected matches paired: %+v", paired)
+	}
+
+	// Sanity: buildFindingRow surfaces the friendly name from m.RuleName
+	// when the rule is missing from ruleMap.
+	row := buildFindingRow(finding, paired, ruleMap, nil)
+	if row.RuleName != "PowerShell Hardcoded Credential" {
+		t.Errorf("expected RuleName fallback to match-record RuleName, got %q", row.RuleName)
+	}
+	if row.MatchCount != 2 {
+		t.Errorf("expected MatchCount=2, got %d", row.MatchCount)
+	}
+}
+
+// TestGroupMatchesByFinding_BuiltinFastPath verifies that builtin rules
+// (present in ruleMap) continue to flow through the structural-ID fast
+// path and are grouped correctly.
+func TestGroupMatchesByFinding_BuiltinFastPath(t *testing.T) {
+	r := &types.Rule{
+		ID:   "np.aws.1",
+		Name: "AWS API Key",
+	}
+	r.StructuralID = r.ComputeStructuralID()
+	ruleMap := map[string]*types.Rule{r.ID: r}
+
+	groups := [][]byte{[]byte("AKIAIOSFODNN7EXAMPLE")}
+	findingID := types.ComputeFindingID(r.StructuralID, groups)
+
+	finding := &types.Finding{
+		ID:     findingID,
+		RuleID: r.ID,
+		Groups: groups,
+	}
+
+	matches := []*types.Match{
+		{StructuralID: "m1", RuleID: r.ID, RuleName: r.Name, Groups: groups},
+		{StructuralID: "m2", RuleID: r.ID, RuleName: r.Name, Groups: groups},
+	}
+
+	got := groupMatchesByFinding([]*types.Finding{finding}, matches, ruleMap)
+	if len(got[finding.ID]) != 2 {
+		t.Fatalf("expected 2 matches via fast path, got %d", len(got[finding.ID]))
+	}
+}


### PR DESCRIPTION
## Summary

`titus explore` showed `No matches` in the Details pane for findings produced by custom rules loaded via `--rules <file>`, even though `titus report` printed full details for the same findings. The explore loader only looked up rules in the builtin rule map, so matches from custom rules were silently dropped. This PR adds the same `RuleID + Groups` fallback that `titus report` already uses, bringing the two commands to parity.

3 files changed, +144 / −9. Builtin-rule findings are unaffected.

## Problem

Run a scan with a custom rule:

```bash
$ titus scan ./scratch --rules acme-rules.yaml --output /tmp/ds
$ titus explore --datastore /tmp/ds
```

In the TUI, the finding appears in the list with the correct match count, but selecting it shows:

```
Finding 1/1
Rule: acme.api_token.1

No matches
```

`titus report --datastore /tmp/ds` against the same datastore prints the full file path, blob ID, line range, and snippet — so the data is in the datastore. Only `explore` is broken.

There is also a cosmetic symptom: the Rule column shows the bare ID (`acme.api_token.1`) instead of the human-readable `name` from the rule YAML (e.g. `ACME API Token`).

A minimal rule that triggers the bug:

```yaml
# acme-rules.yaml
rules:
  - name: ACME API Token
    id: acme.api_token.1
    pattern: |
      (?xi)
      (?: acme[_-]?api[_-]?(?:token|key) )
      \s* [:=] \s*
      ['"]?
      (?P<token>[A-Z0-9]{32})
      ['"]?
    description: Hardcoded ACME API token assignment.
    categories: [api, secret]
    examples:
      - 'ACME_API_TOKEN = "ABCDEFGHIJKLMNOPQRSTUVWXYZ012345"'
```

## Root cause

`pkg/explore/data.go:loadData` builds its `ruleMap` from `loader.LoadBuiltinRules()` only. Custom rules are loaded at scan time and are not in this map. When grouping matches into findings, the loader looks up `ruleMap[m.RuleID]` and silently drops the match if the rule isn't there. So the finding row shows up (it comes from the datastore), but its match list is empty.

`cmd/titus/report.go:buildFindingMatchMap` already handles this case with a two-pass strategy: structural-ID fast path first, then a fallback that pairs leftover findings to matches by `RuleID == RuleID` and byte-equal `Groups`. That second pass is why `report` works for custom rules and `explore` doesn't.

## Fix

Mirror the report loader's two-pass logic in the explore loader.

- **`pkg/explore/data.go`** — extract grouping into a new private helper `groupMatchesByFinding(findings, matches, ruleMap)` that runs the structural-ID fast path, then a `RuleID + Groups` fallback for any finding still without matches. `loadData` calls the helper.
- **`pkg/explore/data.go` (`buildFindingRow`)** — when the rule is missing from `ruleMap`, fall back to `matches[0].RuleName` for the displayed name. The friendly name is already persisted on each match record, so no schema change is needed.
- **`pkg/explore/data_test.go`** — `TestGroupMatchesByFinding_CustomRule` (regression: custom rule absent from `ruleMap`, plus a non-matching `Groups` case to ensure unrelated matches aren't pulled in, plus an assertion on the rule-name fallback) and `TestGroupMatchesByFinding_BuiltinFastPath` (confirms the unchanged fast path).
- **`cmd/titus/report.go`** — three-line doc comment on `buildFindingMatchMap` cross-referencing `pkg/explore.groupMatchesByFinding`. No behavior change.

The grouping logic is duplicated rather than shared because `cmd/titus` is `package main` and can't be imported. Cross-reference comments on both copies note this and ask future readers to keep them in sync.

## Result

Same datastore, same binary, before and after this PR.

**Before:**

```
Finding 1/1
Rule: acme.api_token.1

No matches
```

**After:**

```
Finding 1/1 (id 968d2db3ab0791beb1b17cb1dee62c1dd16c6f86)
Score: 45/100 (medium)
Rule: acme.api_token.1
Group 1: ABCDEFGHIJKLMNOPQRSTUVWXYZ012345

    Match 1/1 (id 647ae8d06fd8ffd8860a94fd51af52e9c5c6cce5)
    File: scratch/config.txt
    Blob: c968580945e4e36fabbd94473280c6f77ce27db4
    Lines: 1:1-1:51

        ACME_API_TOKEN = "ABCDEFGHIJKLMNOPQRSTUVWXYZ012345"
```

(IDs and blob hash are illustrative.)

The findings list also shows the friendly name `ACME API Token` instead of the bare `acme.api_token.1`. Builtin-rule findings render unchanged.

## Test plan

- [x] `make test` (vectorscan, CGO=1) — all packages OK.
- [x] `make test-race` — all packages OK.
- [x] `GOWORK=off CGO_ENABLED=0 go vet ./...` and `GOWORK=off CGO_ENABLED=1 go vet -tags vectorscan ./...` — both clean.
- [x] `GOWORK=off CGO_ENABLED=0 go test -count=1 ./...` — all packages OK (build-tag parity).
- [x] New tests:
  - `TestGroupMatchesByFinding_CustomRule` — regression for the bug.
  - `TestGroupMatchesByFinding_BuiltinFastPath` — guards the unchanged fast path.
- [x] **Red-before-fix verified:** stashing the production edits made the new tests fail to compile (`undefined: groupMatchesByFinding`); restoring returned the package to green.
- [x] `make build` and `make build-pure` — both binaries compile and `./dist/titus version` / `./dist/titus rules list` run without error.
- [x] **End-to-end smoke** on both binaries: scan a synthetic fixture with a custom rules file, then `./dist/titus explore --datastore <ds>` shows file/blob/lines/snippet for the custom-rule finding (the bug's repro is fixed). `./dist/titus report --datastore <ds>` continues to show the same details.
- [x] `gofmt -l` clean on the three modified files.

## Notes

- Additive: no exported API is modified or removed. `groupMatchesByFinding` is unexported; the only edit to `cmd/titus/report.go` is a doc comment.
- No new dependencies.
- The fallback only runs for findings whose match list is empty after the fast path, so it cannot affect builtin-rule findings. Worst-case cost is `O(F_custom × M)` — the same pattern already shipping in `cmd/titus/report.go`.
- Test fixtures use synthetic in-memory `*types.Finding` / `*types.Match` values; no real secrets, no on-disk I/O in the new unit tests.
- Licensed under Apache-2.0 per `CONTRIBUTING.md`.
