### PR TITLE
test(custom-rules): edge cases for explore, scan, scoring interactions

### DIFF
--- a/cmd/titus/scan_test.go
+++ b/cmd/titus/scan_test.go
@@ -378,3 +378,64 @@ func ruleIDs(rules []*types.Rule) []string {
 	}
 	return ids
 }
+
+// TestLoadRules_CustomPathMergedWithBuiltins verifies that supplying a custom
+// rules file via --rules appends the custom rule to (not replaces) the builtin
+// ruleset. Both the custom rule ID and at least one known builtin must be
+// present in the returned slice.
+func TestLoadRules_CustomPathMergedWithBuiltins(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "custom-*.yaml")
+	require.NoError(t, err)
+	_, err = f.WriteString(`rules:
+  - name: Custom Merge Test Rule
+    id: custom.test.merge.1
+    pattern: "(?P<token>CUSTOMMRG[A-Z0-9]{8})"
+    description: synthetic rule for merge test
+    base_score: 50
+`)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	rules, err := loadRules(f.Name(), "", "", "default", false)
+	require.NoError(t, err)
+
+	// Custom rule must be present
+	var foundCustom bool
+	var foundBuiltin bool
+	for _, r := range rules {
+		if r.ID == "custom.test.merge.1" {
+			foundCustom = true
+		}
+		// np.aws.2 is a known builtin secret rule present in all rulesets
+		if r.ID == "np.aws.2" {
+			foundBuiltin = true
+		}
+	}
+	if !foundCustom {
+		t.Error("custom rule 'custom.test.merge.1' not present in merged rule set")
+	}
+	if !foundBuiltin {
+		t.Error("builtin rule 'np.aws.2' should still be present after merging custom rules")
+	}
+}
+
+// TestLoadRules_CustomRuleMissingBaseScore_Rejected verifies that a custom rule
+// file missing the required base_score field causes loadRules to return an error
+// at load time rather than silently producing an unscored (score=0) finding.
+func TestLoadRules_CustomRuleMissingBaseScore_Rejected(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "invalid-*.yaml")
+	require.NoError(t, err)
+	_, err = f.WriteString(`rules:
+  - name: Missing Base Score
+    id: custom.no.score.1
+    pattern: "(?P<token>TOKEN[A-Z0-9]{8})"
+    description: rule without base_score
+`)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	_, err = loadRules(f.Name(), "", "", "default", false)
+	if err == nil {
+		t.Error("expected error for custom rule missing base_score, got nil")
+	}
+}

--- a/pkg/explore/data_test.go
+++ b/pkg/explore/data_test.go
@@ -1,8 +1,10 @@
 package explore
 
 import (
+	"path/filepath"
 	"testing"
 
+	"github.com/praetorian-inc/titus/pkg/store"
 	"github.com/praetorian-inc/titus/pkg/types"
 )
 
@@ -233,5 +235,213 @@ func TestGroupMatchesByFinding_BuiltinFastPath(t *testing.T) {
 	got := groupMatchesByFinding([]*types.Finding{finding}, matches, ruleMap)
 	if len(got[finding.ID]) != 2 {
 		t.Fatalf("expected 2 matches via fast path, got %d", len(got[finding.ID]))
+	}
+}
+
+// TestGroupMatchesByFinding_SameCustomRuleDifferentGroups verifies that when two
+// findings share the same custom RuleID but have distinct captured groups, each
+// finding is paired only with its own matches — not the other finding's matches.
+func TestGroupMatchesByFinding_SameCustomRuleDifferentGroups(t *testing.T) {
+	findingA := &types.Finding{
+		ID:     "finding-a",
+		RuleID: "custom.token.1",
+		Groups: [][]byte{[]byte("secret-a")},
+	}
+	findingB := &types.Finding{
+		ID:     "finding-b",
+		RuleID: "custom.token.1",
+		Groups: [][]byte{[]byte("secret-b")},
+	}
+
+	matches := []*types.Match{
+		{StructuralID: "m-a1", RuleID: "custom.token.1", RuleName: "Custom Token", Groups: [][]byte{[]byte("secret-a")}},
+		{StructuralID: "m-a2", RuleID: "custom.token.1", RuleName: "Custom Token", Groups: [][]byte{[]byte("secret-a")}},
+		{StructuralID: "m-b1", RuleID: "custom.token.1", RuleName: "Custom Token", Groups: [][]byte{[]byte("secret-b")}},
+	}
+
+	ruleMap := map[string]*types.Rule{} // custom rule not in builtins
+
+	got := groupMatchesByFinding([]*types.Finding{findingA, findingB}, matches, ruleMap)
+
+	pairedA := got[findingA.ID]
+	pairedB := got[findingB.ID]
+
+	if len(pairedA) != 2 {
+		t.Errorf("findingA: expected 2 matches, got %d", len(pairedA))
+	}
+	if len(pairedB) != 1 {
+		t.Errorf("findingB: expected 1 match, got %d", len(pairedB))
+	}
+	// findingA must not contain findingB's match
+	for _, m := range pairedA {
+		if m.StructuralID == "m-b1" {
+			t.Error("findingA incorrectly contains findingB's match")
+		}
+	}
+}
+
+// TestGroupMatchesByFinding_OrphanedCustomFinding verifies that a custom-rule
+// finding with no corresponding matches returns an empty (not nil) slice and
+// does not panic. This covers the case where matches were deleted or an
+// incomplete scan produced findings without associated matches.
+func TestGroupMatchesByFinding_OrphanedCustomFinding(t *testing.T) {
+	finding := &types.Finding{
+		ID:     "orphaned-finding",
+		RuleID: "custom.orphan.1",
+		Groups: [][]byte{[]byte("some-value")},
+	}
+	// No match has the same RuleID — orphaned finding
+	matches := []*types.Match{
+		{StructuralID: "m1", RuleID: "other.rule.1", RuleName: "Other Rule", Groups: [][]byte{[]byte("some-value")}},
+	}
+	ruleMap := map[string]*types.Rule{}
+
+	got := groupMatchesByFinding([]*types.Finding{finding}, matches, ruleMap)
+
+	paired := got[finding.ID]
+	if len(paired) != 0 {
+		t.Errorf("orphaned finding should have 0 matches, got %d", len(paired))
+	}
+}
+
+// TestBuildFindingRow_CustomRule_NoMatches verifies that buildFindingRow does
+// not panic when given a custom rule finding with no matches, and that it falls
+// back to the RuleID as the RuleName.
+func TestBuildFindingRow_CustomRule_NoMatches(t *testing.T) {
+	finding := &types.Finding{
+		ID:     "custom-finding-no-matches",
+		RuleID: "custom.nodata.1",
+		Groups: [][]byte{[]byte("value")},
+	}
+	ruleMap := map[string]*types.Rule{} // custom rule absent
+
+	// Must not panic; rule name should fall back to RuleID
+	row := buildFindingRow(finding, nil, ruleMap, nil)
+
+	if row == nil {
+		t.Fatal("buildFindingRow returned nil")
+	}
+	if row.RuleName != "custom.nodata.1" {
+		t.Errorf("expected RuleName fallback to RuleID, got %q", row.RuleName)
+	}
+	if row.MatchCount != 0 {
+		t.Errorf("expected MatchCount 0, got %d", row.MatchCount)
+	}
+	if len(row.Matches) != 0 {
+		t.Errorf("expected 0 match rows, got %d", len(row.Matches))
+	}
+}
+
+// TestBuildFindingRow_CustomRule_EmptyMatchRuleName verifies that when a match
+// record carries an empty RuleName (possible in older datastores), the finding
+// row's RuleName falls back to the RuleID rather than returning an empty string.
+func TestBuildFindingRow_CustomRule_EmptyMatchRuleName(t *testing.T) {
+	finding := &types.Finding{
+		ID:     "finding-empty-rulename",
+		RuleID: "custom.norulename.1",
+		Groups: [][]byte{[]byte("token")},
+	}
+	matches := []*types.Match{
+		{
+			StructuralID: "m1",
+			RuleID:       "custom.norulename.1",
+			RuleName:     "", // empty — older datastore or bug
+			Groups:       [][]byte{[]byte("token")},
+		},
+	}
+	ruleMap := map[string]*types.Rule{}
+
+	row := buildFindingRow(finding, matches, ruleMap, nil)
+
+	// Rule name must never be empty — should fall back to RuleID at minimum
+	if row.RuleName == "" {
+		t.Error("RuleName should never be empty; expected fallback to RuleID")
+	}
+	if row.MatchCount != 1 {
+		t.Errorf("expected MatchCount 1, got %d", row.MatchCount)
+	}
+}
+
+// TestLoadData_CustomRuleFindingHasMatches is the regression test for PR #232.
+// It creates a real SQLite datastore with a custom-rule finding and verifies
+// that loadData (the explore TUI entry point) correctly pairs the finding with
+// its match. Before the fix, custom-rule findings appeared as "No matches" in
+// the TUI because groupMatchesByFinding only used the builtin-rule fast path.
+func TestLoadData_CustomRuleFindingHasMatches(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "datastore.db")
+
+	s, err := store.New(store.Config{Path: dbPath})
+	if err != nil {
+		t.Fatalf("creating store: %v", err)
+	}
+
+	// Custom rule — NOT a builtin; won't be in explore's ruleMap
+	customRule := &types.Rule{
+		ID:        "acme.api.1",
+		Name:      "ACME API Token",
+		BaseScore: 70,
+	}
+	customRule.StructuralID = customRule.ComputeStructuralID()
+
+	if err := s.AddRule(customRule); err != nil {
+		t.Fatalf("AddRule: %v", err)
+	}
+
+	groups := [][]byte{[]byte("ABCDEFGHIJKLMNOP1234567890ABCDEF")}
+
+	blobID := types.BlobID{}
+	if err := s.AddBlob(blobID, 100); err != nil {
+		t.Fatalf("AddBlob: %v", err)
+	}
+
+	match := &types.Match{
+		BlobID:       blobID,
+		StructuralID: "match-structural-id",
+		RuleID:       customRule.ID,
+		RuleName:     customRule.Name,
+		Groups:       groups,
+	}
+	if err := s.AddMatch(match); err != nil {
+		t.Fatalf("AddMatch: %v", err)
+	}
+
+	findingID := types.ComputeFindingID(customRule.StructuralID, groups)
+	finding := &types.Finding{
+		ID:     findingID,
+		RuleID: customRule.ID,
+		Groups: groups,
+	}
+	if err := s.AddFinding(finding); err != nil {
+		t.Fatalf("AddFinding: %v", err)
+	}
+	_ = s.Close()
+
+	// Load via explore's loadData — this is the actual bug regression path
+	data, err := loadData(dbPath)
+	if err != nil {
+		t.Fatalf("loadData: %v", err)
+	}
+	defer data.store.Close()
+
+	if len(data.findings) != 1 {
+		t.Fatalf("expected 1 finding row, got %d", len(data.findings))
+	}
+
+	row := data.findings[0]
+
+	// The fix (PR #232): custom rule finding must have its match populated
+	if row.MatchCount != 1 {
+		t.Errorf("expected MatchCount 1 (regression: was 0 before fix), got %d", row.MatchCount)
+	}
+	if len(row.Matches) != 1 {
+		t.Errorf("expected 1 match row, got %d", len(row.Matches))
+	}
+	// Rule name must come from match record (not ruleMap, since custom)
+	if row.RuleName != "ACME API Token" {
+		t.Errorf("expected RuleName 'ACME API Token' from match record, got %q", row.RuleName)
+	}
+	if row.RuleID != "acme.api.1" {
+		t.Errorf("expected RuleID 'acme.api.1', got %q", row.RuleID)
 	}
 }

--- a/pkg/scoring/engine_test.go
+++ b/pkg/scoring/engine_test.go
@@ -319,3 +319,30 @@ func TestEngine_ConditionError_SkipsModifier_ContinuesScoring(t *testing.T) {
 	assert.Contains(t, warnings[0], "broken")
 	assert.Contains(t, warnings[0], "synthetic error")
 }
+
+// TestEngine_CustomRuleID_UsesBaseScore verifies that a finding whose RuleID
+// matches no registered scorer receives exactly the rule's BaseScore as both
+// Base and Final, with no applied modifiers. This is the expected contract for
+// custom rules loaded via --rules: they receive BaseScore without modification
+// because no YAML scorer covers their ID.
+func TestEngine_CustomRuleID_UsesBaseScore(t *testing.T) {
+	customRule := &types.Rule{
+		ID:        "acme.custom.99",
+		BaseScore: 72,
+	}
+
+	// No scorers registered — simulates a custom rule with no matching YAML scorer
+	engine := NewEngine([]*Scorer{}, EngineConfig{ScopeEnabled: false})
+
+	finding := &types.Finding{
+		ID:     "test-finding",
+		RuleID: customRule.ID,
+	}
+	match := &types.Match{RuleID: customRule.ID}
+
+	score := engine.Score(context.Background(), finding, []*types.Match{match}, customRule)
+
+	assert.Equal(t, 72, score.Base, "Base score must equal rule BaseScore")
+	assert.Equal(t, 72, score.Final, "Final score must equal BaseScore when no scorers match")
+	assert.Empty(t, score.Applied, "No modifiers should be applied for a custom rule with no scorer")
+}


### PR DESCRIPTION
## Summary

- Adds 8 new tests covering custom rule behavior across all paths where custom rules interact with the system (explore, scan, scoring)
- Tests are regression-focused: each verifies a specific observable behavior, not just that a function ran
- No production code changes — tests only

## Tests Added

### `pkg/explore/data_test.go` (5 new tests)

- `TestGroupMatchesByFinding_SameCustomRuleDifferentGroups` — two findings from the same custom RuleID but distinct captured groups are each paired only with their own matches
- `TestGroupMatchesByFinding_OrphanedCustomFinding` — finding with no corresponding matches returns empty slice without panic
- `TestBuildFindingRow_CustomRule_NoMatches` — no-panic guarantee; RuleName falls back to RuleID when no matches and rule absent from ruleMap
- `TestBuildFindingRow_CustomRule_EmptyMatchRuleName` — when match carries empty RuleName (older datastore edge case), RuleName falls back to RuleID rather than empty string
- `TestLoadData_CustomRuleFindingHasMatches` — full loadData pipeline integration regression test for PR 232: real SQLite datastore with custom-rule finding verifies MatchCount=1, correct RuleName from match record

### `cmd/titus/scan_test.go` (2 new tests)

- `TestLoadRules_CustomPathMergedWithBuiltins` — custom rules via --rules are appended to builtins (not replacing them); both custom ID and known builtin present in result
- `TestLoadRules_CustomRuleMissingBaseScore_Rejected` — rule file missing base_score causes load-time error, not silent zero-score findings

### `pkg/scoring/engine_test.go` (1 new test)

- `TestEngine_CustomRuleID_UsesBaseScore` — finding whose RuleID matches no registered scorer receives exactly rule.BaseScore as Final with zero applied modifiers

## Test plan

- [x] GOWORK=off CGO_ENABLED=0 go test ./pkg/explore/... ./cmd/titus/... ./pkg/scoring/... — 322 tests pass (0 failures)
- [x] GOWORK=off golangci-lint run ./pkg/explore/ ./cmd/titus/ ./pkg/scoring/ — 0 issues