### PR TITLE
added dnf support to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,8 @@ ifeq ($(VECTORSCAN_AVAILABLE),0)
 		elif command -v dnf &>/dev/null; then \
 			sudo dnf install -y vectorscan-devel; \
 		else \
-			echo "No supported package manager found (expected apt-get or dnf)";\
+			echo "No supported package manager found (expected apt-get or dnf)"; \
+	    	exit 1;\
 		fi && \
 		echo "[vectorscan] Installed successfully via OS package manager" || \
 		(echo "" && \

--- a/Makefile
+++ b/Makefile
@@ -77,8 +77,12 @@ ifeq ($(VECTORSCAN_AVAILABLE),0)
 		echo "" && \
 		exit 1); \
 	else \
-		sudo apt-get install -y libhyperscan-dev && \
-		echo "[vectorscan] Installed successfully via apt-get" || \
+		if command -v apt-get &>/dev/null; then \
+			sudo apt-get install -y libhyperscan-dev; \
+		elif command -v dnf &>/dev/null; then \
+			sudo dnf install -y vectorscan-devel; \
+		fi && \
+		echo "[vectorscan] Installed successfully via OS package manager" || \
 		(echo "" && \
 		echo "Vectorscan is required for the default build (10-100x faster scanning)." && \
 		echo "Install it manually:" && \

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ ifeq ($(VECTORSCAN_AVAILABLE),0)
 		echo "" && \
 		echo "  macOS (Homebrew):  brew install vectorscan" && \
 		echo "  Ubuntu/Debian:     sudo apt-get install libhyperscan-dev" && \
-		echo "  Fedora/RHEL:       sudo dnf install hyperscan-devel" && \
+		echo "  Fedora/RHEL:       sudo dnf install vectorscan-devel" && \
 		echo "" && \
 		echo "Or build without vectorscan (slower, but no dependencies):" && \
 		echo "  make build-pure" && \
@@ -81,6 +81,8 @@ ifeq ($(VECTORSCAN_AVAILABLE),0)
 			sudo apt-get install -y libhyperscan-dev; \
 		elif command -v dnf &>/dev/null; then \
 			sudo dnf install -y vectorscan-devel; \
+		else \
+			echo "No supported package manager found (expected apt-get or dnf)";\
 		fi && \
 		echo "[vectorscan] Installed successfully via OS package manager" || \
 		(echo "" && \
@@ -89,7 +91,7 @@ ifeq ($(VECTORSCAN_AVAILABLE),0)
 		echo "" && \
 		echo "  macOS (Homebrew):  brew install vectorscan" && \
 		echo "  Ubuntu/Debian:     sudo apt-get install libhyperscan-dev" && \
-		echo "  Fedora/RHEL:       sudo dnf install hyperscan-devel" && \
+		echo "  Fedora/RHEL:       sudo dnf install vectorscan-devel" && \
 		echo "" && \
 		echo "Or build without vectorscan (slower, but no dependencies):" && \
 		echo "  make build-pure" && \


### PR DESCRIPTION
While installing titus on Fedora 44, I realized that the Makefile did not yet support the installation of the hyperscan/vectorscan dependency via dnf. I hope the formatting and the style is as expected.