### PR TITLE
fix(ci): grant pull-requests: read to secrets-scan (fixes startup_failure)

### DIFF
--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -23,5 +23,6 @@ jobs:
       contents: read
       security-events: write
       actions: read
+      pull-requests: read
     secrets: inherit
 


### PR DESCRIPTION
The `Secrets Scan` workflow has been `startup_failure`-ing on every push/PR — the Titus secret scanner was silently disabled.

**Root cause:** the shared reusable `public-workflows/.github/workflows/titus-scan.yml`'s `preflight` job declares `pull-requests: read`, but this caller (copied from the reusable's own example) only grants `contents`/`security-events`/`actions`. A reusable workflow's job cannot request a permission scope the caller didn't grant, so the run fails at startup validation before any job runs.

**Fix:** add `pull-requests: read` to the calling job's `permissions`. Verified end-to-end on pius#77 — Secrets Scan went from `startup_failure` to `success` (preflight + Titus scan both ran).

🤖 Generated with [Claude Code](https://claude.com/claude-code)