### PR TITLE
fix(secrets-scan): fail-closed on public repo (fail-on-findings: true)

### DIFF
--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -24,5 +24,7 @@ jobs:
       security-events: write
       actions: read
       pull-requests: read
+    with:
+      fail-on-findings: true
     secrets: inherit
 


### PR DESCRIPTION
## Why

This is a **public** repository. A secret committed here is world-readable and
search-indexed the instant it lands — by the time it surfaces in the Security
tab, rotation is the only remedy left.

Today this caller runs the Titus secret scanner in **observe-only** mode
(`fail-on-findings` defaults to `false` in the reusable), so a detected secret
does **not** fail CI on `push:main` or PR. For public repos the correct posture
is **fail-closed** — consistent with GitHub making push-protection default-on
for public repos.

## Change

Add `with: { fail-on-findings: true }` to the calling job. A Titus hit now
**breaks the build**. `upload-sarif` stays `true` (GHAS is free on public repos),
so we keep Security-tab tracking **and** gain blocking.

No change to the pinned reusable SHA or permissions. (Pin-comment hygiene — the
`# v2.2.1` label over an untagged SHA — is tracked as a separate follow-up.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
