### PR TITLE
fix(ci): re-pin titus-scan to real tag v2.6.0 + adopt verify-pins gate

### DIFF
--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   scan:
-    uses: praetorian-inc/public-workflows/.github/workflows/titus-scan.yml@e2da966933b2c8f02a32540e7bd5812f93a056fb  # v2.2.1
+    uses: praetorian-inc/public-workflows/.github/workflows/titus-scan.yml@23254e12b026871dd9bbf2bad4ef6fee29910fb1  # v2.6.0
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/verify-pins.yml
+++ b/.github/workflows/verify-pins.yml
@@ -1,0 +1,16 @@
+name: Verify Pins
+# Fails CI if any first-party praetorian-inc/public-workflows `uses:` pin carries a
+# dishonest version comment (missing tag, nonexistent tag, or SHA != that tag).
+on:
+  pull_request:
+    paths: ['.github/workflows/**']
+  push:
+    branches: [main]
+    paths: ['.github/workflows/**']
+permissions:
+  contents: read
+jobs:
+  verify:
+    uses: praetorian-inc/public-workflows/.github/workflows/verify-pins.yml@23254e12b026871dd9bbf2bad4ef6fee29910fb1  # v2.6.0
+    permissions:
+      contents: read


### PR DESCRIPTION
## Why

Two pin-integrity fixes, in one PR per repo:

1. **Re-pin titus-scan to a real tag.** This repo pinned the Titus secret-scanner
   reusable with the comment `# v2.2.1` — but **that tag never existed** (public-workflows
   tags jump v2.2.0 → v2.3.0). A lying version comment defeats audits and Dependabot.
   Re-pinned to **`v2.6.0`** (`23254e12b026`), the current tag carrying the hardened,
   fail-closed, visibility-aware titus-scan reusable. Byte-identical scanner behavior —
   this is a label-honesty fix.

2. **Adopt the `verify-pins` gate.** Adds `.github/workflows/verify-pins.yml` calling the
   new reusable (also `v2.6.0`). On any future `.github/workflows/**` change it verifies
   every first-party public-workflows pin's `# vX.Y.Z` comment matches a real tag at that
   SHA — so a dishonest pin can never merge again.

All other first-party pins in this repo (go-ci, codex-code, claude-code, gemini-code,
claude-md-drift, external-contrib, go-sec) were audited and are already honest, so the new
gate passes on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
