### PR TITLE
fix(ci): drop secrets: inherit from titus secrets-scan caller (least-privilege)

### DIFF
--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -26,5 +26,4 @@ jobs:
       pull-requests: read
     with:
       fail-on-findings: true
-    secrets: inherit
 


### PR DESCRIPTION
## Why

The `titus-scan.yml` reusable declares **no `secrets:` block** — it only uses
`GITHUB_TOKEN`, which GitHub Actions auto-grants to called reusable workflows
*without* `secrets: inherit`. So `secrets: inherit` here forwarded this repo's
entire secret store to the reusable for nothing — an unnecessary blast-radius
expansion that violates least-privilege (GitHub Well-Architected: "Avoid
`secrets: inherit` … pass only required secrets").

This drops `secrets: inherit` from the calling job. Scanner behavior is
unchanged (jupiter #293 already runs green without it). Permissions and
`fail-on-findings` are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
