### PR TITLE
feat(validator): add Atlassian Cloud API token validator

### DIFF
--- a/pkg/validator/atlassian.go
+++ b/pkg/validator/atlassian.go
@@ -91,7 +91,7 @@ func (v *AtlassianValidator) Validate(ctx context.Context, match *types.Match) (
 			fmt.Sprintf("request failed: %v", err),
 		), nil
 	}
-	defer func() { io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
 
 	// Evaluate response
 	switch resp.StatusCode {

--- a/pkg/validator/atlassian.go
+++ b/pkg/validator/atlassian.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"regexp"
+	"time"
 
 	"github.com/praetorian-inc/titus/pkg/types"
 )
@@ -36,7 +37,7 @@ type AtlassianValidator struct {
 
 // NewAtlassianValidator creates a new Atlassian credential validator.
 func NewAtlassianValidator() *AtlassianValidator {
-	return &AtlassianValidator{client: http.DefaultClient}
+	return &AtlassianValidator{client: &http.Client{Timeout: 30 * time.Second}}
 }
 
 // NewAtlassianValidatorWithClient creates a validator with a custom HTTP client (for testing).

--- a/pkg/validator/atlassian.go
+++ b/pkg/validator/atlassian.go
@@ -1,0 +1,145 @@
+// pkg/validator/atlassian.go
+package validator
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+)
+
+// Pre-compiled patterns for extracting email from snippet context.
+var atlassianEmailPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)email\s*=\s*['"]([a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,})['"]`),
+	regexp.MustCompile(`(?i)JIRA_USER\s*=\s*['"]([a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,})['"]`),
+	regexp.MustCompile(`(?i)user\s*=\s*['"]([a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,})['"]`),
+	regexp.MustCompile(`(?i)env\s*\(\s*['"][^'"]*['"]\s*,\s*['"]([a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,})['"]\s*\)`),
+	regexp.MustCompile(`\b([a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,})\b`),
+}
+
+// Pre-compiled patterns for extracting Atlassian domain from snippet context.
+var atlassianDomainPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`https?://([a-z][a-z0-9\-]{1,24}\.atlassian\.net)`),
+	regexp.MustCompile(`\b([a-z][a-z0-9\-]{1,24}\.atlassian\.net)\b`),
+}
+
+// AtlassianValidator validates Atlassian Cloud API tokens using the Jira REST API.
+// Atlassian API token authentication requires email and domain from context.
+// Basic Auth format: email:api_token
+// The regex captures the token; the validator searches snippet context for email and domain.
+type AtlassianValidator struct {
+	client *http.Client
+}
+
+// NewAtlassianValidator creates a new Atlassian credential validator.
+func NewAtlassianValidator() *AtlassianValidator {
+	return &AtlassianValidator{client: http.DefaultClient}
+}
+
+// NewAtlassianValidatorWithClient creates a validator with a custom HTTP client (for testing).
+func NewAtlassianValidatorWithClient(client *http.Client) *AtlassianValidator {
+	return &AtlassianValidator{client: client}
+}
+
+// Name returns the validator name.
+func (v *AtlassianValidator) Name() string {
+	return "atlassian"
+}
+
+// CanValidate returns true for Atlassian-related rule IDs.
+func (v *AtlassianValidator) CanValidate(ruleID string) bool {
+	return ruleID == "np.atlassian.1"
+}
+
+// Validate checks Atlassian credentials against the Jira REST API.
+func (v *AtlassianValidator) Validate(ctx context.Context, match *types.Match) (*types.ValidationResult, error) {
+	// Extract credentials
+	domain, email, token, err := v.extractCredentials(match)
+	if err != nil {
+		// Partial credentials - return undetermined
+		return types.NewValidationResult(
+			types.StatusUndetermined,
+			0,
+			fmt.Sprintf("cannot validate: %v", err),
+		), nil
+	}
+
+	// Build request to Atlassian API (myself is lightweight and confirms identity)
+	url := fmt.Sprintf("https://%s/rest/api/3/myself", domain)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return types.NewValidationResult(
+			types.StatusUndetermined,
+			0,
+			fmt.Sprintf("failed to create request: %v", err),
+		), nil
+	}
+
+	// Set Basic Auth: email:api_token
+	req.SetBasicAuth(email, token)
+
+	// Execute request
+	resp, err := v.client.Do(req)
+	if err != nil {
+		return types.NewValidationResult(
+			types.StatusUndetermined,
+			0,
+			fmt.Sprintf("request failed: %v", err),
+		), nil
+	}
+	defer func() { io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
+
+	// Evaluate response
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return types.NewValidationResult(
+			types.StatusValid,
+			1.0,
+			fmt.Sprintf("valid Atlassian credentials for domain %s", domain),
+		), nil
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return types.NewValidationResult(
+			types.StatusInvalid,
+			1.0,
+			fmt.Sprintf("credentials rejected: HTTP %d", resp.StatusCode),
+		), nil
+	default:
+		return types.NewValidationResult(
+			types.StatusUndetermined,
+			0.5,
+			fmt.Sprintf("unexpected status code: HTTP %d", resp.StatusCode),
+		), nil
+	}
+}
+
+// extractCredentials extracts Atlassian credentials from match.
+// Expects token from NamedGroups, searches snippet for domain and email.
+func (v *AtlassianValidator) extractCredentials(match *types.Match) (domain, email, token string, err error) {
+	// Extract token from named groups
+	if match.NamedGroups == nil {
+		return "", "", "", fmt.Errorf("no named capture groups in match")
+	}
+
+	tokenBytes, hasToken := match.NamedGroups["token"]
+	if !hasToken || len(tokenBytes) == 0 {
+		return "", "", "", fmt.Errorf("token not found in named groups")
+	}
+	token = string(tokenBytes)
+
+	// Search domain in snippet context
+	domain = searchSnippet(match.Snippet, atlassianDomainPatterns)
+	if domain == "" {
+		return "", "", "", fmt.Errorf("partial credentials: found token but atlassian domain not in context")
+	}
+
+	// Search email in snippet context
+	email = searchSnippet(match.Snippet, atlassianEmailPatterns)
+	if email == "" {
+		return "", "", "", fmt.Errorf("partial credentials: found token and domain but email not in context")
+	}
+
+	return domain, email, token, nil
+}

--- a/pkg/validator/atlassian.go
+++ b/pkg/validator/atlassian.go
@@ -91,7 +91,7 @@ func (v *AtlassianValidator) Validate(ctx context.Context, match *types.Match) (
 			fmt.Sprintf("request failed: %v", err),
 		), nil
 	}
-	defer func() { _, _ = io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
 
 	// Evaluate response
 	switch resp.StatusCode {

--- a/pkg/validator/atlassian_test.go
+++ b/pkg/validator/atlassian_test.go
@@ -1,0 +1,366 @@
+// pkg/validator/atlassian_test.go
+package validator
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAtlassianValidator_Name(t *testing.T) {
+	v := NewAtlassianValidator()
+	assert.Equal(t, "atlassian", v.Name())
+}
+
+func TestAtlassianValidator_CanValidate(t *testing.T) {
+	v := NewAtlassianValidator()
+
+	// Atlassian rule
+	assert.True(t, v.CanValidate("np.atlassian.1"))
+
+	// Non-Atlassian rules
+	assert.False(t, v.CanValidate("np.github.1"))
+	assert.False(t, v.CanValidate("np.aws.1"))
+	assert.False(t, v.CanValidate("np.zendesk.1"))
+}
+
+func TestAtlassianValidator_ExtractCredentials_TokenFromNamedGroups(t *testing.T) {
+	v := NewAtlassianValidator()
+
+	match := &types.Match{
+		RuleID: "np.atlassian.1",
+		NamedGroups: map[string][]byte{
+			"token": []byte("ATATT3xFfGF0pogUFVOH0_AjBEA8LJcnOJx_Ki4yl_PY=110E6FC6"),
+		},
+		Snippet: types.Snippet{
+			Before:   []byte("email = 'info@example.com'\n"),
+			Matching: []byte("api_token = 'ATATT3xFfGF0pogUFVOH0_AjBEA8LJcnOJx_Ki4yl_PY=110E6FC6'"),
+			After:    []byte("# https://mycompany.atlassian.net/rest/api/3/myself\n"),
+		},
+	}
+
+	domain, email, token, err := v.extractCredentials(match)
+	assert.NoError(t, err)
+	assert.Equal(t, "ATATT3xFfGF0pogUFVOH0_AjBEA8LJcnOJx_Ki4yl_PY=110E6FC6", token)
+	assert.Equal(t, "info@example.com", email)
+	assert.Equal(t, "mycompany.atlassian.net", domain)
+}
+
+func TestAtlassianValidator_ExtractCredentials_EmailFromJIRA_USER(t *testing.T) {
+	v := NewAtlassianValidator()
+
+	match := &types.Match{
+		RuleID: "np.atlassian.1",
+		NamedGroups: map[string][]byte{
+			"token": []byte("ATATT3xFfGF0xYT7HPCi5lokFfZWNkl0R1xi9BpiieoCRoG3=D46B4967"),
+		},
+		Snippet: types.Snippet{
+			Before:   []byte("JIRA_USER=\"example@example.com\"\n"),
+			Matching: []byte("JIRA_API_TOKEN=\"ATATT3xFfGF0xYT7HPCi5lokFfZWNkl0R1xi9BpiieoCRoG3=D46B4967\""),
+			After:    []byte("JIRA_HOST=https://myorg.atlassian.net\n"),
+		},
+	}
+
+	domain, email, token, err := v.extractCredentials(match)
+	assert.NoError(t, err)
+	assert.Equal(t, "ATATT3xFfGF0xYT7HPCi5lokFfZWNkl0R1xi9BpiieoCRoG3=D46B4967", token)
+	assert.Equal(t, "example@example.com", email)
+	assert.Equal(t, "myorg.atlassian.net", domain)
+}
+
+func TestAtlassianValidator_ExtractCredentials_EmailFromEnvFunction(t *testing.T) {
+	v := NewAtlassianValidator()
+
+	// Example from the rule file: env('JIRA_USER', 'admin@example.com')
+	match := &types.Match{
+		RuleID: "np.atlassian.1",
+		NamedGroups: map[string][]byte{
+			"token": []byte("ATATT3xFfGF0Hv2D5CyGjDnjGL5j9medBUqp=569C722C"),
+		},
+		Snippet: types.Snippet{
+			Before:   []byte("'user' => env('JIRA_USER', 'admin@example.com'),\n"),
+			Matching: []byte("'token' => env('JIRA_API_TOKEN', 'ATATT3xFfGF0Hv2D5CyGjDnjGL5j9medBUqp=569C722C'),"),
+			After:    []byte("'host' => env('JIRA_HOST', 'https://example.atlassian.net'),\n"),
+		},
+	}
+
+	domain, email, token, err := v.extractCredentials(match)
+	assert.NoError(t, err)
+	assert.Equal(t, "ATATT3xFfGF0Hv2D5CyGjDnjGL5j9medBUqp=569C722C", token)
+	assert.Equal(t, "admin@example.com", email)
+	assert.Equal(t, "example.atlassian.net", domain)
+}
+
+func TestAtlassianValidator_ExtractCredentials_DomainFromHTTPSURL(t *testing.T) {
+	v := NewAtlassianValidator()
+
+	match := &types.Match{
+		RuleID: "np.atlassian.1",
+		NamedGroups: map[string][]byte{
+			"token": []byte("ATATT3xFfGF0pogUFVOH0_AjBEA8LJcnOJx_Ki4yl=110E6FC6"),
+		},
+		Snippet: types.Snippet{
+			Before:   []byte("url = 'https://myteam.atlassian.net'\nuser = 'ops@myteam.com'\n"),
+			Matching: []byte("token = 'ATATT3xFfGF0pogUFVOH0_AjBEA8LJcnOJx_Ki4yl=110E6FC6'"),
+			After:    []byte(""),
+		},
+	}
+
+	domain, email, token, err := v.extractCredentials(match)
+	assert.NoError(t, err)
+	assert.Equal(t, "myteam.atlassian.net", domain)
+	assert.Equal(t, "ops@myteam.com", email)
+	assert.Equal(t, "ATATT3xFfGF0pogUFVOH0_AjBEA8LJcnOJx_Ki4yl=110E6FC6", token)
+}
+
+func TestAtlassianValidator_ExtractCredentials_MissingToken(t *testing.T) {
+	v := NewAtlassianValidator()
+
+	match := &types.Match{
+		RuleID:      "np.atlassian.1",
+		NamedGroups: map[string][]byte{},
+		Snippet: types.Snippet{
+			Before: []byte("email = 'info@example.com'\n"),
+		},
+	}
+
+	_, _, _, err := v.extractCredentials(match)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "token")
+}
+
+func TestAtlassianValidator_ExtractCredentials_NoNamedGroups(t *testing.T) {
+	v := NewAtlassianValidator()
+
+	match := &types.Match{
+		RuleID:      "np.atlassian.1",
+		NamedGroups: nil,
+	}
+
+	_, _, _, err := v.extractCredentials(match)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no named capture groups")
+}
+
+func TestAtlassianValidator_ExtractCredentials_MissingEmail(t *testing.T) {
+	v := NewAtlassianValidator()
+
+	match := &types.Match{
+		RuleID: "np.atlassian.1",
+		NamedGroups: map[string][]byte{
+			"token": []byte("ATATT3xFfGF0pogUFVOH0_AjBEA8=110E6FC6"),
+		},
+		Snippet: types.Snippet{
+			Before:   []byte("# no email here\n"),
+			Matching: []byte("api_token = 'ATATT3xFfGF0pogUFVOH0_AjBEA8=110E6FC6'"),
+			After:    []byte("JIRA_HOST=https://mycompany.atlassian.net\n"),
+		},
+	}
+
+	_, _, _, err := v.extractCredentials(match)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "email")
+}
+
+func TestAtlassianValidator_ExtractCredentials_MissingDomain(t *testing.T) {
+	v := NewAtlassianValidator()
+
+	match := &types.Match{
+		RuleID: "np.atlassian.1",
+		NamedGroups: map[string][]byte{
+			"token": []byte("ATATT3xFfGF0pogUFVOH0_AjBEA8=110E6FC6"),
+		},
+		Snippet: types.Snippet{
+			Before:   []byte("email = 'info@example.com'\n"),
+			Matching: []byte("api_token = 'ATATT3xFfGF0pogUFVOH0_AjBEA8=110E6FC6'"),
+			After:    []byte("# no atlassian domain here\n"),
+		},
+	}
+
+	_, _, _, err := v.extractCredentials(match)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "domain")
+}
+
+func TestAtlassianValidator_Validate_Valid(t *testing.T) {
+	// Mock server that returns 200 OK
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify Basic auth header is present
+		auth := r.Header.Get("Authorization")
+		assert.Contains(t, auth, "Basic ")
+		// Verify path
+		assert.Equal(t, "/rest/api/3/myself", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	v := NewAtlassianValidatorWithClient(&http.Client{
+		Transport: &testTransport{url: server.URL},
+	})
+
+	match := &types.Match{
+		RuleID: "np.atlassian.1",
+		NamedGroups: map[string][]byte{
+			"token": []byte("ATATT3xFfGF0pogUFVOH0_AjBEA8LJcnOJx_Ki4yl_PY=110E6FC6"),
+		},
+		Snippet: types.Snippet{
+			Before:   []byte("email = 'info@example.com'\n"),
+			Matching: []byte("api_token = 'ATATT3xFfGF0pogUFVOH0_AjBEA8LJcnOJx_Ki4yl_PY=110E6FC6'"),
+			After:    []byte("# https://mycompany.atlassian.net/rest/api/3/myself\n"),
+		},
+	}
+
+	result, err := v.Validate(context.Background(), match)
+	assert.NoError(t, err)
+	assert.Equal(t, types.StatusValid, result.Status)
+	assert.Equal(t, 1.0, result.Confidence)
+	assert.Contains(t, result.Message, "mycompany.atlassian.net")
+}
+
+func TestAtlassianValidator_Validate_Invalid_Unauthorized(t *testing.T) {
+	// Mock server that returns 401
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	v := NewAtlassianValidatorWithClient(&http.Client{
+		Transport: &testTransport{url: server.URL},
+	})
+
+	match := &types.Match{
+		RuleID: "np.atlassian.1",
+		NamedGroups: map[string][]byte{
+			"token": []byte("ATATT3xFfGF0invalidtoken=110E6FC6"),
+		},
+		Snippet: types.Snippet{
+			Before:   []byte("email = 'info@example.com'\n"),
+			Matching: []byte("api_token = 'ATATT3xFfGF0invalidtoken=110E6FC6'"),
+			After:    []byte("JIRA_HOST=https://mycompany.atlassian.net\n"),
+		},
+	}
+
+	result, err := v.Validate(context.Background(), match)
+	assert.NoError(t, err)
+	assert.Equal(t, types.StatusInvalid, result.Status)
+	assert.Equal(t, 1.0, result.Confidence)
+	assert.Contains(t, result.Message, "401")
+}
+
+func TestAtlassianValidator_Validate_Invalid_Forbidden(t *testing.T) {
+	// Mock server that returns 403
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	v := NewAtlassianValidatorWithClient(&http.Client{
+		Transport: &testTransport{url: server.URL},
+	})
+
+	match := &types.Match{
+		RuleID: "np.atlassian.1",
+		NamedGroups: map[string][]byte{
+			"token": []byte("ATATT3xFfGF0pogUFVOH0_AjBEA8=110E6FC6"),
+		},
+		Snippet: types.Snippet{
+			Before:   []byte("email = 'info@example.com'\n"),
+			Matching: []byte("api_token = 'ATATT3xFfGF0pogUFVOH0_AjBEA8=110E6FC6'"),
+			After:    []byte("JIRA_HOST=https://mycompany.atlassian.net\n"),
+		},
+	}
+
+	result, err := v.Validate(context.Background(), match)
+	assert.NoError(t, err)
+	assert.Equal(t, types.StatusInvalid, result.Status)
+	assert.Equal(t, 1.0, result.Confidence)
+	assert.Contains(t, result.Message, "403")
+}
+
+func TestAtlassianValidator_Validate_Undetermined_ServerError(t *testing.T) {
+	// Mock server that returns 500
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	v := NewAtlassianValidatorWithClient(&http.Client{
+		Transport: &testTransport{url: server.URL},
+	})
+
+	match := &types.Match{
+		RuleID: "np.atlassian.1",
+		NamedGroups: map[string][]byte{
+			"token": []byte("ATATT3xFfGF0pogUFVOH0_AjBEA8=110E6FC6"),
+		},
+		Snippet: types.Snippet{
+			Before:   []byte("email = 'info@example.com'\n"),
+			Matching: []byte("api_token = 'ATATT3xFfGF0pogUFVOH0_AjBEA8=110E6FC6'"),
+			After:    []byte("JIRA_HOST=https://mycompany.atlassian.net\n"),
+		},
+	}
+
+	result, err := v.Validate(context.Background(), match)
+	assert.NoError(t, err)
+	assert.Equal(t, types.StatusUndetermined, result.Status)
+	assert.Equal(t, 0.5, result.Confidence)
+	assert.Contains(t, result.Message, "500")
+}
+
+func TestAtlassianValidator_Validate_PartialCredentials(t *testing.T) {
+	v := NewAtlassianValidator()
+
+	// Missing domain in context
+	match := &types.Match{
+		RuleID: "np.atlassian.1",
+		NamedGroups: map[string][]byte{
+			"token": []byte("ATATT3xFfGF0pogUFVOH0_AjBEA8=110E6FC6"),
+		},
+		Snippet: types.Snippet{
+			Before:   []byte("email = 'info@example.com'\n"),
+			Matching: []byte("api_token = 'ATATT3xFfGF0pogUFVOH0_AjBEA8=110E6FC6'"),
+			After:    []byte("# no atlassian domain in context\n"),
+		},
+	}
+
+	result, err := v.Validate(context.Background(), match)
+	assert.NoError(t, err)
+	assert.Equal(t, types.StatusUndetermined, result.Status)
+	assert.Contains(t, result.Message, "cannot validate")
+}
+
+func TestAtlassianValidator_Validate_BasicAuthFormat(t *testing.T) {
+	// Verify that Basic auth uses email:token format
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		username, password, ok := r.BasicAuth()
+		assert.True(t, ok, "Basic auth should be present")
+		assert.Equal(t, "info@example.com", username)
+		assert.Equal(t, "ATATT3xFfGF0pogUFVOH0_AjBEA8LJcnOJx=110E6FC6", password)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	v := NewAtlassianValidatorWithClient(&http.Client{
+		Transport: &testTransport{url: server.URL},
+	})
+
+	match := &types.Match{
+		RuleID: "np.atlassian.1",
+		NamedGroups: map[string][]byte{
+			"token": []byte("ATATT3xFfGF0pogUFVOH0_AjBEA8LJcnOJx=110E6FC6"),
+		},
+		Snippet: types.Snippet{
+			Before:   []byte("email = 'info@example.com'\n"),
+			Matching: []byte("api_token = 'ATATT3xFfGF0pogUFVOH0_AjBEA8LJcnOJx=110E6FC6'"),
+			After:    []byte("# https://mycompany.atlassian.net/rest/api/3/myself\n"),
+		},
+	}
+
+	result, err := v.Validate(context.Background(), match)
+	assert.NoError(t, err)
+	assert.Equal(t, types.StatusValid, result.Status)
+}

--- a/pkg/validator/atlassian_test.go
+++ b/pkg/validator/atlassian_test.go
@@ -34,18 +34,18 @@ func TestAtlassianValidator_ExtractCredentials_TokenFromNamedGroups(t *testing.T
 	match := &types.Match{
 		RuleID: "np.atlassian.1",
 		NamedGroups: map[string][]byte{
-			"token": []byte("ATATT3xFfGF0testEXAMPLEtokenFORunit_testing=00000000"),
+			"token": []byte("ATATT3xFfGF0testEXAMPLEtokenFORunit_testing=ZZZZZZZZ"),
 		},
 		Snippet: types.Snippet{
 			Before:   []byte("email = 'info@example.com'\n"),
-			Matching: []byte("api_token = 'ATATT3xFfGF0testEXAMPLEtokenFORunit_testing=00000000'"),
+			Matching: []byte("api_token = 'ATATT3xFfGF0testEXAMPLEtokenFORunit_testing=ZZZZZZZZ'"),
 			After:    []byte("# https://mycompany.atlassian.net/rest/api/3/myself\n"),
 		},
 	}
 
 	domain, email, token, err := v.extractCredentials(match)
 	assert.NoError(t, err)
-	assert.Equal(t, "ATATT3xFfGF0testEXAMPLEtokenFORunit_testing=00000000", token)
+	assert.Equal(t, "ATATT3xFfGF0testEXAMPLEtokenFORunit_testing=ZZZZZZZZ", token)
 	assert.Equal(t, "info@example.com", email)
 	assert.Equal(t, "mycompany.atlassian.net", domain)
 }
@@ -56,18 +56,18 @@ func TestAtlassianValidator_ExtractCredentials_EmailFromJIRA_USER(t *testing.T) 
 	match := &types.Match{
 		RuleID: "np.atlassian.1",
 		NamedGroups: map[string][]byte{
-			"token": []byte("ATATT3xFfGF0testEXAMPLEjiraUserToken_ForTests=00000000"),
+			"token": []byte("ATATT3xFfGF0testEXAMPLEjiraUserToken_ForTests=ZZZZZZZZ"),
 		},
 		Snippet: types.Snippet{
 			Before:   []byte("JIRA_USER=\"example@example.com\"\n"),
-			Matching: []byte("JIRA_API_TOKEN=\"ATATT3xFfGF0testEXAMPLEjiraUserToken_ForTests=00000000\""),
+			Matching: []byte("JIRA_API_TOKEN=\"ATATT3xFfGF0testEXAMPLEjiraUserToken_ForTests=ZZZZZZZZ\""),
 			After:    []byte("JIRA_HOST=https://myorg.atlassian.net\n"),
 		},
 	}
 
 	domain, email, token, err := v.extractCredentials(match)
 	assert.NoError(t, err)
-	assert.Equal(t, "ATATT3xFfGF0testEXAMPLEjiraUserToken_ForTests=00000000", token)
+	assert.Equal(t, "ATATT3xFfGF0testEXAMPLEjiraUserToken_ForTests=ZZZZZZZZ", token)
 	assert.Equal(t, "example@example.com", email)
 	assert.Equal(t, "myorg.atlassian.net", domain)
 }
@@ -79,18 +79,18 @@ func TestAtlassianValidator_ExtractCredentials_EmailFromEnvFunction(t *testing.T
 	match := &types.Match{
 		RuleID: "np.atlassian.1",
 		NamedGroups: map[string][]byte{
-			"token": []byte("ATATT3xFfGF0testEXAMPLEenvFuncToken_Test=00000000"),
+			"token": []byte("ATATT3xFfGF0testEXAMPLEenvFuncToken_Test=ZZZZZZZZ"),
 		},
 		Snippet: types.Snippet{
 			Before:   []byte("'user' => env('JIRA_USER', 'admin@example.com'),\n"),
-			Matching: []byte("'token' => env('JIRA_API_TOKEN', 'ATATT3xFfGF0testEXAMPLEenvFuncToken_Test=00000000'),"),
+			Matching: []byte("'token' => env('JIRA_API_TOKEN', 'ATATT3xFfGF0testEXAMPLEenvFuncToken_Test=ZZZZZZZZ'),"),
 			After:    []byte("'host' => env('JIRA_HOST', 'https://example.atlassian.net'),\n"),
 		},
 	}
 
 	domain, email, token, err := v.extractCredentials(match)
 	assert.NoError(t, err)
-	assert.Equal(t, "ATATT3xFfGF0testEXAMPLEenvFuncToken_Test=00000000", token)
+	assert.Equal(t, "ATATT3xFfGF0testEXAMPLEenvFuncToken_Test=ZZZZZZZZ", token)
 	assert.Equal(t, "admin@example.com", email)
 	assert.Equal(t, "example.atlassian.net", domain)
 }
@@ -101,11 +101,11 @@ func TestAtlassianValidator_ExtractCredentials_DomainFromHTTPSURL(t *testing.T) 
 	match := &types.Match{
 		RuleID: "np.atlassian.1",
 		NamedGroups: map[string][]byte{
-			"token": []byte("ATATT3xFfGF0testEXAMPLEhttpsDomain_Testing=00000000"),
+			"token": []byte("ATATT3xFfGF0testEXAMPLEhttpsDomain_Testing=ZZZZZZZZ"),
 		},
 		Snippet: types.Snippet{
 			Before:   []byte("url = 'https://myteam.atlassian.net'\nuser = 'ops@myteam.com'\n"),
-			Matching: []byte("token = 'ATATT3xFfGF0testEXAMPLEhttpsDomain_Testing=00000000'"),
+			Matching: []byte("token = 'ATATT3xFfGF0testEXAMPLEhttpsDomain_Testing=ZZZZZZZZ'"),
 			After:    []byte(""),
 		},
 	}
@@ -114,7 +114,7 @@ func TestAtlassianValidator_ExtractCredentials_DomainFromHTTPSURL(t *testing.T) 
 	assert.NoError(t, err)
 	assert.Equal(t, "myteam.atlassian.net", domain)
 	assert.Equal(t, "ops@myteam.com", email)
-	assert.Equal(t, "ATATT3xFfGF0testEXAMPLEhttpsDomain_Testing=00000000", token)
+	assert.Equal(t, "ATATT3xFfGF0testEXAMPLEhttpsDomain_Testing=ZZZZZZZZ", token)
 }
 
 func TestAtlassianValidator_ExtractCredentials_MissingToken(t *testing.T) {
@@ -152,11 +152,11 @@ func TestAtlassianValidator_ExtractCredentials_MissingEmail(t *testing.T) {
 	match := &types.Match{
 		RuleID: "np.atlassian.1",
 		NamedGroups: map[string][]byte{
-			"token": []byte("ATATT3xFfGF0testEXAMPLEshort=00000000"),
+			"token": []byte("ATATT3xFfGF0testEXAMPLEshort=ZZZZZZZZ"),
 		},
 		Snippet: types.Snippet{
 			Before:   []byte("# no email here\n"),
-			Matching: []byte("api_token = 'ATATT3xFfGF0testEXAMPLEshort=00000000'"),
+			Matching: []byte("api_token = 'ATATT3xFfGF0testEXAMPLEshort=ZZZZZZZZ'"),
 			After:    []byte("JIRA_HOST=https://mycompany.atlassian.net\n"),
 		},
 	}
@@ -172,11 +172,11 @@ func TestAtlassianValidator_ExtractCredentials_MissingDomain(t *testing.T) {
 	match := &types.Match{
 		RuleID: "np.atlassian.1",
 		NamedGroups: map[string][]byte{
-			"token": []byte("ATATT3xFfGF0testEXAMPLEshort=00000000"),
+			"token": []byte("ATATT3xFfGF0testEXAMPLEshort=ZZZZZZZZ"),
 		},
 		Snippet: types.Snippet{
 			Before:   []byte("email = 'info@example.com'\n"),
-			Matching: []byte("api_token = 'ATATT3xFfGF0testEXAMPLEshort=00000000'"),
+			Matching: []byte("api_token = 'ATATT3xFfGF0testEXAMPLEshort=ZZZZZZZZ'"),
 			After:    []byte("# no atlassian domain here\n"),
 		},
 	}
@@ -205,11 +205,11 @@ func TestAtlassianValidator_Validate_Valid(t *testing.T) {
 	match := &types.Match{
 		RuleID: "np.atlassian.1",
 		NamedGroups: map[string][]byte{
-			"token": []byte("ATATT3xFfGF0testEXAMPLEtokenFORunit_testing=00000000"),
+			"token": []byte("ATATT3xFfGF0testEXAMPLEtokenFORunit_testing=ZZZZZZZZ"),
 		},
 		Snippet: types.Snippet{
 			Before:   []byte("email = 'info@example.com'\n"),
-			Matching: []byte("api_token = 'ATATT3xFfGF0testEXAMPLEtokenFORunit_testing=00000000'"),
+			Matching: []byte("api_token = 'ATATT3xFfGF0testEXAMPLEtokenFORunit_testing=ZZZZZZZZ'"),
 			After:    []byte("# https://mycompany.atlassian.net/rest/api/3/myself\n"),
 		},
 	}
@@ -235,11 +235,11 @@ func TestAtlassianValidator_Validate_Invalid_Unauthorized(t *testing.T) {
 	match := &types.Match{
 		RuleID: "np.atlassian.1",
 		NamedGroups: map[string][]byte{
-			"token": []byte("ATATT3xFfGF0testINVALIDexample=00000000"),
+			"token": []byte("ATATT3xFfGF0testINVALIDexample=ZZZZZZZZ"),
 		},
 		Snippet: types.Snippet{
 			Before:   []byte("email = 'info@example.com'\n"),
-			Matching: []byte("api_token = 'ATATT3xFfGF0testINVALIDexample=00000000'"),
+			Matching: []byte("api_token = 'ATATT3xFfGF0testINVALIDexample=ZZZZZZZZ'"),
 			After:    []byte("JIRA_HOST=https://mycompany.atlassian.net\n"),
 		},
 	}
@@ -265,11 +265,11 @@ func TestAtlassianValidator_Validate_Invalid_Forbidden(t *testing.T) {
 	match := &types.Match{
 		RuleID: "np.atlassian.1",
 		NamedGroups: map[string][]byte{
-			"token": []byte("ATATT3xFfGF0testEXAMPLEshort=00000000"),
+			"token": []byte("ATATT3xFfGF0testEXAMPLEshort=ZZZZZZZZ"),
 		},
 		Snippet: types.Snippet{
 			Before:   []byte("email = 'info@example.com'\n"),
-			Matching: []byte("api_token = 'ATATT3xFfGF0testEXAMPLEshort=00000000'"),
+			Matching: []byte("api_token = 'ATATT3xFfGF0testEXAMPLEshort=ZZZZZZZZ'"),
 			After:    []byte("JIRA_HOST=https://mycompany.atlassian.net\n"),
 		},
 	}
@@ -295,11 +295,11 @@ func TestAtlassianValidator_Validate_Undetermined_ServerError(t *testing.T) {
 	match := &types.Match{
 		RuleID: "np.atlassian.1",
 		NamedGroups: map[string][]byte{
-			"token": []byte("ATATT3xFfGF0testEXAMPLEshort=00000000"),
+			"token": []byte("ATATT3xFfGF0testEXAMPLEshort=ZZZZZZZZ"),
 		},
 		Snippet: types.Snippet{
 			Before:   []byte("email = 'info@example.com'\n"),
-			Matching: []byte("api_token = 'ATATT3xFfGF0testEXAMPLEshort=00000000'"),
+			Matching: []byte("api_token = 'ATATT3xFfGF0testEXAMPLEshort=ZZZZZZZZ'"),
 			After:    []byte("JIRA_HOST=https://mycompany.atlassian.net\n"),
 		},
 	}
@@ -318,11 +318,11 @@ func TestAtlassianValidator_Validate_PartialCredentials(t *testing.T) {
 	match := &types.Match{
 		RuleID: "np.atlassian.1",
 		NamedGroups: map[string][]byte{
-			"token": []byte("ATATT3xFfGF0testEXAMPLEshort=00000000"),
+			"token": []byte("ATATT3xFfGF0testEXAMPLEshort=ZZZZZZZZ"),
 		},
 		Snippet: types.Snippet{
 			Before:   []byte("email = 'info@example.com'\n"),
-			Matching: []byte("api_token = 'ATATT3xFfGF0testEXAMPLEshort=00000000'"),
+			Matching: []byte("api_token = 'ATATT3xFfGF0testEXAMPLEshort=ZZZZZZZZ'"),
 			After:    []byte("# no atlassian domain in context\n"),
 		},
 	}
@@ -339,7 +339,7 @@ func TestAtlassianValidator_Validate_BasicAuthFormat(t *testing.T) {
 		username, password, ok := r.BasicAuth()
 		assert.True(t, ok, "Basic auth should be present")
 		assert.Equal(t, "info@example.com", username)
-		assert.Equal(t, "ATATT3xFfGF0testEXAMPLEbasicAuthCheck=00000000", password)
+		assert.Equal(t, "ATATT3xFfGF0testEXAMPLEbasicAuthCheck=ZZZZZZZZ", password)
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
@@ -351,11 +351,11 @@ func TestAtlassianValidator_Validate_BasicAuthFormat(t *testing.T) {
 	match := &types.Match{
 		RuleID: "np.atlassian.1",
 		NamedGroups: map[string][]byte{
-			"token": []byte("ATATT3xFfGF0testEXAMPLEbasicAuthCheck=00000000"),
+			"token": []byte("ATATT3xFfGF0testEXAMPLEbasicAuthCheck=ZZZZZZZZ"),
 		},
 		Snippet: types.Snippet{
 			Before:   []byte("email = 'info@example.com'\n"),
-			Matching: []byte("api_token = 'ATATT3xFfGF0testEXAMPLEbasicAuthCheck=00000000'"),
+			Matching: []byte("api_token = 'ATATT3xFfGF0testEXAMPLEbasicAuthCheck=ZZZZZZZZ'"),
 			After:    []byte("# https://mycompany.atlassian.net/rest/api/3/myself\n"),
 		},
 	}

--- a/pkg/validator/atlassian_test.go
+++ b/pkg/validator/atlassian_test.go
@@ -34,18 +34,18 @@ func TestAtlassianValidator_ExtractCredentials_TokenFromNamedGroups(t *testing.T
 	match := &types.Match{
 		RuleID: "np.atlassian.1",
 		NamedGroups: map[string][]byte{
-			"token": []byte("ATATT3xFfGF0pogUFVOH0_AjBEA8LJcnOJx_Ki4yl_PY=110E6FC6"),
+			"token": []byte("ATATT3xFfGF0testEXAMPLEtokenFORunit_testing=00000000"),
 		},
 		Snippet: types.Snippet{
 			Before:   []byte("email = 'info@example.com'\n"),
-			Matching: []byte("api_token = 'ATATT3xFfGF0pogUFVOH0_AjBEA8LJcnOJx_Ki4yl_PY=110E6FC6'"),
+			Matching: []byte("api_token = 'ATATT3xFfGF0testEXAMPLEtokenFORunit_testing=00000000'"),
 			After:    []byte("# https://mycompany.atlassian.net/rest/api/3/myself\n"),
 		},
 	}
 
 	domain, email, token, err := v.extractCredentials(match)
 	assert.NoError(t, err)
-	assert.Equal(t, "ATATT3xFfGF0pogUFVOH0_AjBEA8LJcnOJx_Ki4yl_PY=110E6FC6", token)
+	assert.Equal(t, "ATATT3xFfGF0testEXAMPLEtokenFORunit_testing=00000000", token)
 	assert.Equal(t, "info@example.com", email)
 	assert.Equal(t, "mycompany.atlassian.net", domain)
 }
@@ -56,18 +56,18 @@ func TestAtlassianValidator_ExtractCredentials_EmailFromJIRA_USER(t *testing.T) 
 	match := &types.Match{
 		RuleID: "np.atlassian.1",
 		NamedGroups: map[string][]byte{
-			"token": []byte("ATATT3xFfGF0xYT7HPCi5lokFfZWNkl0R1xi9BpiieoCRoG3=D46B4967"),
+			"token": []byte("ATATT3xFfGF0testEXAMPLEjiraUserToken_ForTests=00000000"),
 		},
 		Snippet: types.Snippet{
 			Before:   []byte("JIRA_USER=\"example@example.com\"\n"),
-			Matching: []byte("JIRA_API_TOKEN=\"ATATT3xFfGF0xYT7HPCi5lokFfZWNkl0R1xi9BpiieoCRoG3=D46B4967\""),
+			Matching: []byte("JIRA_API_TOKEN=\"ATATT3xFfGF0testEXAMPLEjiraUserToken_ForTests=00000000\""),
 			After:    []byte("JIRA_HOST=https://myorg.atlassian.net\n"),
 		},
 	}
 
 	domain, email, token, err := v.extractCredentials(match)
 	assert.NoError(t, err)
-	assert.Equal(t, "ATATT3xFfGF0xYT7HPCi5lokFfZWNkl0R1xi9BpiieoCRoG3=D46B4967", token)
+	assert.Equal(t, "ATATT3xFfGF0testEXAMPLEjiraUserToken_ForTests=00000000", token)
 	assert.Equal(t, "example@example.com", email)
 	assert.Equal(t, "myorg.atlassian.net", domain)
 }
@@ -79,18 +79,18 @@ func TestAtlassianValidator_ExtractCredentials_EmailFromEnvFunction(t *testing.T
 	match := &types.Match{
 		RuleID: "np.atlassian.1",
 		NamedGroups: map[string][]byte{
-			"token": []byte("ATATT3xFfGF0Hv2D5CyGjDnjGL5j9medBUqp=569C722C"),
+			"token": []byte("ATATT3xFfGF0testEXAMPLEenvFuncToken_Test=00000000"),
 		},
 		Snippet: types.Snippet{
 			Before:   []byte("'user' => env('JIRA_USER', 'admin@example.com'),\n"),
-			Matching: []byte("'token' => env('JIRA_API_TOKEN', 'ATATT3xFfGF0Hv2D5CyGjDnjGL5j9medBUqp=569C722C'),"),
+			Matching: []byte("'token' => env('JIRA_API_TOKEN', 'ATATT3xFfGF0testEXAMPLEenvFuncToken_Test=00000000'),"),
 			After:    []byte("'host' => env('JIRA_HOST', 'https://example.atlassian.net'),\n"),
 		},
 	}
 
 	domain, email, token, err := v.extractCredentials(match)
 	assert.NoError(t, err)
-	assert.Equal(t, "ATATT3xFfGF0Hv2D5CyGjDnjGL5j9medBUqp=569C722C", token)
+	assert.Equal(t, "ATATT3xFfGF0testEXAMPLEenvFuncToken_Test=00000000", token)
 	assert.Equal(t, "admin@example.com", email)
 	assert.Equal(t, "example.atlassian.net", domain)
 }
@@ -101,11 +101,11 @@ func TestAtlassianValidator_ExtractCredentials_DomainFromHTTPSURL(t *testing.T) 
 	match := &types.Match{
 		RuleID: "np.atlassian.1",
 		NamedGroups: map[string][]byte{
-			"token": []byte("ATATT3xFfGF0pogUFVOH0_AjBEA8LJcnOJx_Ki4yl=110E6FC6"),
+			"token": []byte("ATATT3xFfGF0testEXAMPLEhttpsDomain_Testing=00000000"),
 		},
 		Snippet: types.Snippet{
 			Before:   []byte("url = 'https://myteam.atlassian.net'\nuser = 'ops@myteam.com'\n"),
-			Matching: []byte("token = 'ATATT3xFfGF0pogUFVOH0_AjBEA8LJcnOJx_Ki4yl=110E6FC6'"),
+			Matching: []byte("token = 'ATATT3xFfGF0testEXAMPLEhttpsDomain_Testing=00000000'"),
 			After:    []byte(""),
 		},
 	}
@@ -114,7 +114,7 @@ func TestAtlassianValidator_ExtractCredentials_DomainFromHTTPSURL(t *testing.T) 
 	assert.NoError(t, err)
 	assert.Equal(t, "myteam.atlassian.net", domain)
 	assert.Equal(t, "ops@myteam.com", email)
-	assert.Equal(t, "ATATT3xFfGF0pogUFVOH0_AjBEA8LJcnOJx_Ki4yl=110E6FC6", token)
+	assert.Equal(t, "ATATT3xFfGF0testEXAMPLEhttpsDomain_Testing=00000000", token)
 }
 
 func TestAtlassianValidator_ExtractCredentials_MissingToken(t *testing.T) {
@@ -152,11 +152,11 @@ func TestAtlassianValidator_ExtractCredentials_MissingEmail(t *testing.T) {
 	match := &types.Match{
 		RuleID: "np.atlassian.1",
 		NamedGroups: map[string][]byte{
-			"token": []byte("ATATT3xFfGF0pogUFVOH0_AjBEA8=110E6FC6"),
+			"token": []byte("ATATT3xFfGF0testEXAMPLEshort=00000000"),
 		},
 		Snippet: types.Snippet{
 			Before:   []byte("# no email here\n"),
-			Matching: []byte("api_token = 'ATATT3xFfGF0pogUFVOH0_AjBEA8=110E6FC6'"),
+			Matching: []byte("api_token = 'ATATT3xFfGF0testEXAMPLEshort=00000000'"),
 			After:    []byte("JIRA_HOST=https://mycompany.atlassian.net\n"),
 		},
 	}
@@ -172,11 +172,11 @@ func TestAtlassianValidator_ExtractCredentials_MissingDomain(t *testing.T) {
 	match := &types.Match{
 		RuleID: "np.atlassian.1",
 		NamedGroups: map[string][]byte{
-			"token": []byte("ATATT3xFfGF0pogUFVOH0_AjBEA8=110E6FC6"),
+			"token": []byte("ATATT3xFfGF0testEXAMPLEshort=00000000"),
 		},
 		Snippet: types.Snippet{
 			Before:   []byte("email = 'info@example.com'\n"),
-			Matching: []byte("api_token = 'ATATT3xFfGF0pogUFVOH0_AjBEA8=110E6FC6'"),
+			Matching: []byte("api_token = 'ATATT3xFfGF0testEXAMPLEshort=00000000'"),
 			After:    []byte("# no atlassian domain here\n"),
 		},
 	}
@@ -205,11 +205,11 @@ func TestAtlassianValidator_Validate_Valid(t *testing.T) {
 	match := &types.Match{
 		RuleID: "np.atlassian.1",
 		NamedGroups: map[string][]byte{
-			"token": []byte("ATATT3xFfGF0pogUFVOH0_AjBEA8LJcnOJx_Ki4yl_PY=110E6FC6"),
+			"token": []byte("ATATT3xFfGF0testEXAMPLEtokenFORunit_testing=00000000"),
 		},
 		Snippet: types.Snippet{
 			Before:   []byte("email = 'info@example.com'\n"),
-			Matching: []byte("api_token = 'ATATT3xFfGF0pogUFVOH0_AjBEA8LJcnOJx_Ki4yl_PY=110E6FC6'"),
+			Matching: []byte("api_token = 'ATATT3xFfGF0testEXAMPLEtokenFORunit_testing=00000000'"),
 			After:    []byte("# https://mycompany.atlassian.net/rest/api/3/myself\n"),
 		},
 	}
@@ -235,11 +235,11 @@ func TestAtlassianValidator_Validate_Invalid_Unauthorized(t *testing.T) {
 	match := &types.Match{
 		RuleID: "np.atlassian.1",
 		NamedGroups: map[string][]byte{
-			"token": []byte("ATATT3xFfGF0invalidtoken=110E6FC6"),
+			"token": []byte("ATATT3xFfGF0testINVALIDexample=00000000"),
 		},
 		Snippet: types.Snippet{
 			Before:   []byte("email = 'info@example.com'\n"),
-			Matching: []byte("api_token = 'ATATT3xFfGF0invalidtoken=110E6FC6'"),
+			Matching: []byte("api_token = 'ATATT3xFfGF0testINVALIDexample=00000000'"),
 			After:    []byte("JIRA_HOST=https://mycompany.atlassian.net\n"),
 		},
 	}
@@ -265,11 +265,11 @@ func TestAtlassianValidator_Validate_Invalid_Forbidden(t *testing.T) {
 	match := &types.Match{
 		RuleID: "np.atlassian.1",
 		NamedGroups: map[string][]byte{
-			"token": []byte("ATATT3xFfGF0pogUFVOH0_AjBEA8=110E6FC6"),
+			"token": []byte("ATATT3xFfGF0testEXAMPLEshort=00000000"),
 		},
 		Snippet: types.Snippet{
 			Before:   []byte("email = 'info@example.com'\n"),
-			Matching: []byte("api_token = 'ATATT3xFfGF0pogUFVOH0_AjBEA8=110E6FC6'"),
+			Matching: []byte("api_token = 'ATATT3xFfGF0testEXAMPLEshort=00000000'"),
 			After:    []byte("JIRA_HOST=https://mycompany.atlassian.net\n"),
 		},
 	}
@@ -295,11 +295,11 @@ func TestAtlassianValidator_Validate_Undetermined_ServerError(t *testing.T) {
 	match := &types.Match{
 		RuleID: "np.atlassian.1",
 		NamedGroups: map[string][]byte{
-			"token": []byte("ATATT3xFfGF0pogUFVOH0_AjBEA8=110E6FC6"),
+			"token": []byte("ATATT3xFfGF0testEXAMPLEshort=00000000"),
 		},
 		Snippet: types.Snippet{
 			Before:   []byte("email = 'info@example.com'\n"),
-			Matching: []byte("api_token = 'ATATT3xFfGF0pogUFVOH0_AjBEA8=110E6FC6'"),
+			Matching: []byte("api_token = 'ATATT3xFfGF0testEXAMPLEshort=00000000'"),
 			After:    []byte("JIRA_HOST=https://mycompany.atlassian.net\n"),
 		},
 	}
@@ -318,11 +318,11 @@ func TestAtlassianValidator_Validate_PartialCredentials(t *testing.T) {
 	match := &types.Match{
 		RuleID: "np.atlassian.1",
 		NamedGroups: map[string][]byte{
-			"token": []byte("ATATT3xFfGF0pogUFVOH0_AjBEA8=110E6FC6"),
+			"token": []byte("ATATT3xFfGF0testEXAMPLEshort=00000000"),
 		},
 		Snippet: types.Snippet{
 			Before:   []byte("email = 'info@example.com'\n"),
-			Matching: []byte("api_token = 'ATATT3xFfGF0pogUFVOH0_AjBEA8=110E6FC6'"),
+			Matching: []byte("api_token = 'ATATT3xFfGF0testEXAMPLEshort=00000000'"),
 			After:    []byte("# no atlassian domain in context\n"),
 		},
 	}
@@ -339,7 +339,7 @@ func TestAtlassianValidator_Validate_BasicAuthFormat(t *testing.T) {
 		username, password, ok := r.BasicAuth()
 		assert.True(t, ok, "Basic auth should be present")
 		assert.Equal(t, "info@example.com", username)
-		assert.Equal(t, "ATATT3xFfGF0pogUFVOH0_AjBEA8LJcnOJx=110E6FC6", password)
+		assert.Equal(t, "ATATT3xFfGF0testEXAMPLEbasicAuthCheck=00000000", password)
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
@@ -351,11 +351,11 @@ func TestAtlassianValidator_Validate_BasicAuthFormat(t *testing.T) {
 	match := &types.Match{
 		RuleID: "np.atlassian.1",
 		NamedGroups: map[string][]byte{
-			"token": []byte("ATATT3xFfGF0pogUFVOH0_AjBEA8LJcnOJx=110E6FC6"),
+			"token": []byte("ATATT3xFfGF0testEXAMPLEbasicAuthCheck=00000000"),
 		},
 		Snippet: types.Snippet{
 			Before:   []byte("email = 'info@example.com'\n"),
-			Matching: []byte("api_token = 'ATATT3xFfGF0pogUFVOH0_AjBEA8LJcnOJx=110E6FC6'"),
+			Matching: []byte("api_token = 'ATATT3xFfGF0testEXAMPLEbasicAuthCheck=00000000'"),
 			After:    []byte("# https://mycompany.atlassian.net/rest/api/3/myself\n"),
 		},
 	}

--- a/pkg/validator/engine.go
+++ b/pkg/validator/engine.go
@@ -32,6 +32,7 @@ func NewDefaultEngine(workers int) *Engine {
 	validators = append(validators, NewMattermostValidator())
 	validators = append(validators, NewTrueNASValidator())
 	validators = append(validators, NewGitHubAppTokenValidator())
+	validators = append(validators, NewAtlassianValidator())
 
 	// Embedded YAML validators
 	embedded, err := LoadEmbeddedValidators()


### PR DESCRIPTION
## Summary

- Add Go validator for `np.atlassian.1` (Atlassian Cloud API tokens) that validates tokens via Basic auth against `GET /rest/api/3/myself`
- Extracts email and domain from snippet context using regex patterns (similar to AWS validator approach)
- Returns Valid (200), Invalid (401/403), or Undetermined when context is insufficient
- 14 tests covering credential extraction, HTTP responses, and auth format

## Linear

Resolves [LAB-3999](https://linear.app/praetorianlabs/issue/LAB-3999)
Part of [LAB-3356](https://linear.app/praetorianlabs/issue/LAB-3356) (Release v1.3.0 Roadmap)

## Test plan

- [x] All 14 unit tests pass (`go test ./pkg/validator/ -run Atlassian`)
- [x] `go build ./...` succeeds
- [ ] Manual test with real Atlassian API token (optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)