### PR TITLE
feat(scoring): add Atlassian/Jira Go scorer

### DIFF
--- a/pkg/scoring/atlassian.go
+++ b/pkg/scoring/atlassian.go
@@ -22,8 +22,8 @@ var (
 		regexp.MustCompile(`\b([a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,})\b`),
 	}
 	atlassianDomainPatterns = []*regexp.Regexp{
-		regexp.MustCompile(`https?://([a-z][a-z0-9\-]{1,24}\.atlassian\.net)`),
-		regexp.MustCompile(`\b([a-z][a-z0-9\-]{1,24}\.atlassian\.net)\b`),
+		regexp.MustCompile(`(?i)https?://([a-z][a-z0-9\-]{1,24}\.atlassian\.net)`),
+		regexp.MustCompile(`(?i)\b([a-z][a-z0-9\-]{1,24}\.atlassian\.net)\b`),
 	}
 )
 
@@ -99,7 +99,7 @@ func (c *atlassianSiteAdminCondition) Evaluate(ctx context.Context, m *types.Mat
 	if err != nil {
 		return false, nil
 	}
-	defer func() { io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return false, nil
@@ -135,7 +135,7 @@ func (c *atlassianSiteAdminCondition) Evaluate(ctx context.Context, m *types.Mat
 	if err != nil {
 		return false, nil
 	}
-	defer func() { io.Copy(io.Discard, permResp.Body); permResp.Body.Close() }()
+	defer func() { _, _ = io.Copy(io.Discard, permResp.Body); permResp.Body.Close() }()
 
 	if permResp.StatusCode != http.StatusOK {
 		return false, nil
@@ -196,7 +196,7 @@ func (c *atlassianProjectCountCondition) Evaluate(ctx context.Context, m *types.
 	if err != nil {
 		return false, nil
 	}
-	defer func() { io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return false, nil
@@ -275,7 +275,7 @@ func (c *atlassianTokenExpiredCondition) Evaluate(ctx context.Context, m *types.
 	if err != nil {
 		return false, nil
 	}
-	defer func() { io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
 
 	return resp.StatusCode == http.StatusUnauthorized, nil
 }

--- a/pkg/scoring/atlassian.go
+++ b/pkg/scoring/atlassian.go
@@ -99,7 +99,7 @@ func (c *atlassianSiteAdminCondition) Evaluate(ctx context.Context, m *types.Mat
 	if err != nil {
 		return false, nil
 	}
-	defer func() { _, _ = io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return false, nil
@@ -135,7 +135,7 @@ func (c *atlassianSiteAdminCondition) Evaluate(ctx context.Context, m *types.Mat
 	if err != nil {
 		return false, nil
 	}
-	defer func() { _, _ = io.Copy(io.Discard, permResp.Body); permResp.Body.Close() }()
+	defer func() { _, _ = io.Copy(io.Discard, permResp.Body); _ = permResp.Body.Close() }()
 
 	if permResp.StatusCode != http.StatusOK {
 		return false, nil
@@ -196,7 +196,7 @@ func (c *atlassianProjectCountCondition) Evaluate(ctx context.Context, m *types.
 	if err != nil {
 		return false, nil
 	}
-	defer func() { _, _ = io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return false, nil
@@ -275,7 +275,7 @@ func (c *atlassianTokenExpiredCondition) Evaluate(ctx context.Context, m *types.
 	if err != nil {
 		return false, nil
 	}
-	defer func() { _, _ = io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
 
 	return resp.StatusCode == http.StatusUnauthorized, nil
 }

--- a/pkg/scoring/atlassian.go
+++ b/pkg/scoring/atlassian.go
@@ -1,0 +1,339 @@
+package scoring
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+)
+
+// Pre-compiled patterns for extracting Atlassian credentials from snippet context.
+var (
+	atlassianEmailPatterns = []*regexp.Regexp{
+		regexp.MustCompile(`(?i)email\s*=\s*['"]([a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,})['"]`),
+		regexp.MustCompile(`(?i)JIRA_USER\s*=\s*['"]([a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,})['"]`),
+		regexp.MustCompile(`(?i)user\s*=\s*['"]([a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,})['"]`),
+		regexp.MustCompile(`(?i)env\s*\(\s*['"][^'"]*['"]\s*,\s*['"]([a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,})['"]\s*\)`),
+		regexp.MustCompile(`\b([a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,})\b`),
+	}
+	atlassianDomainPatterns = []*regexp.Regexp{
+		regexp.MustCompile(`https?://([a-z][a-z0-9\-]{1,24}\.atlassian\.net)`),
+		regexp.MustCompile(`\b([a-z][a-z0-9\-]{1,24}\.atlassian\.net)\b`),
+	}
+)
+
+// extractAtlassianCredentials extracts token, email, and domain from a match.
+// Returns empty strings and false if any piece is missing.
+func extractAtlassianCredentials(m *types.Match) (token, email, domain string, ok bool) {
+	if m == nil {
+		return "", "", "", false
+	}
+	tok, hasToken := m.NamedGroups["token"]
+	if !hasToken || len(tok) == 0 {
+		return "", "", "", false
+	}
+	token = string(tok)
+
+	email = searchSnippetForScoring(m.Snippet, atlassianEmailPatterns)
+	if email == "" {
+		return "", "", "", false
+	}
+
+	domain = searchSnippetForScoring(m.Snippet, atlassianDomainPatterns)
+	if domain == "" {
+		return "", "", "", false
+	}
+
+	return token, email, domain, true
+}
+
+// searchSnippetForScoring searches all three snippet parts against patterns,
+// returning the first captured group match.
+func searchSnippetForScoring(snippet types.Snippet, patterns []*regexp.Regexp) string {
+	parts := [][]byte{snippet.Before, snippet.Matching, snippet.After}
+	for _, pattern := range patterns {
+		for _, part := range parts {
+			if matches := pattern.FindSubmatch(part); len(matches) >= 2 {
+				return string(matches[1])
+			}
+		}
+	}
+	return ""
+}
+
+// atlassianHTTPClient is an interface for making HTTP requests (allows testing).
+type atlassianHTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// atlassianSiteAdminCondition fires when the Atlassian token belongs to a
+// site admin on any accessible site. Uses GET /rest/api/3/myself on the
+// domain extracted from snippet context.
+type atlassianSiteAdminCondition struct {
+	client atlassianHTTPClient
+}
+
+func (c *atlassianSiteAdminCondition) markDynamic() {}
+
+func (c *atlassianSiteAdminCondition) Evaluate(ctx context.Context, m *types.Match) (bool, error) {
+	token, email, domain, ok := extractAtlassianCredentials(m)
+	if !ok {
+		return false, nil
+	}
+
+	// GET /rest/api/3/myself returns user info including accountType
+	url := fmt.Sprintf("https://%s/rest/api/3/myself", domain)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return false, nil
+	}
+	req.SetBasicAuth(email, token)
+
+	client := c.httpClient()
+	resp, err := client.Do(req)
+	if err != nil {
+		return false, nil
+	}
+	defer func() { io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return false, nil
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false, nil
+	}
+
+	// Check for admin indicators in the response
+	var userInfo struct {
+		AccountType    string `json:"accountType"`
+		ApplicationRoles struct {
+			Items []struct {
+				Key string `json:"key"`
+			} `json:"items"`
+		} `json:"applicationRoles"`
+	}
+	if err := json.Unmarshal(body, &userInfo); err != nil {
+		return false, nil
+	}
+
+	// Now check if user has admin permissions
+	permURL := fmt.Sprintf("https://%s/rest/api/3/mypermissions?permissions=ADMINISTER", domain)
+	permReq, err := http.NewRequestWithContext(ctx, "GET", permURL, nil)
+	if err != nil {
+		return false, nil
+	}
+	permReq.SetBasicAuth(email, token)
+
+	permResp, err := client.Do(permReq)
+	if err != nil {
+		return false, nil
+	}
+	defer func() { io.Copy(io.Discard, permResp.Body); permResp.Body.Close() }()
+
+	if permResp.StatusCode != http.StatusOK {
+		return false, nil
+	}
+
+	permBody, err := io.ReadAll(permResp.Body)
+	if err != nil {
+		return false, nil
+	}
+
+	// Check ADMINISTER permission
+	var permResult struct {
+		Permissions map[string]struct {
+			HavePermission bool `json:"havePermission"`
+		} `json:"permissions"`
+	}
+	if err := json.Unmarshal(permBody, &permResult); err != nil {
+		return false, nil
+	}
+
+	if perm, ok := permResult.Permissions["ADMINISTER"]; ok && perm.HavePermission {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (c *atlassianSiteAdminCondition) httpClient() atlassianHTTPClient {
+	if c.client != nil {
+		return c.client
+	}
+	return defaultHTTPClient
+}
+
+// atlassianProjectCountCondition fires when the token has access to >= threshold projects.
+type atlassianProjectCountCondition struct {
+	threshold int
+	client    atlassianHTTPClient
+}
+
+func (c *atlassianProjectCountCondition) markDynamic() {}
+
+func (c *atlassianProjectCountCondition) Evaluate(ctx context.Context, m *types.Match) (bool, error) {
+	token, email, domain, ok := extractAtlassianCredentials(m)
+	if !ok {
+		return false, nil
+	}
+
+	url := fmt.Sprintf("https://%s/rest/api/3/project?maxResults=50", domain)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return false, nil
+	}
+	req.SetBasicAuth(email, token)
+
+	client := c.httpClient()
+	resp, err := client.Do(req)
+	if err != nil {
+		return false, nil
+	}
+	defer func() { io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return false, nil
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false, nil
+	}
+
+	var projects []json.RawMessage
+	if err := json.Unmarshal(body, &projects); err != nil {
+		return false, nil
+	}
+
+	return len(projects) >= c.threshold, nil
+}
+
+func (c *atlassianProjectCountCondition) httpClient() atlassianHTTPClient {
+	if c.client != nil {
+		return c.client
+	}
+	return defaultHTTPClient
+}
+
+// atlassianBitbucketAccessCondition fires when the token grants access to Bitbucket
+// (source code access). Checks via the accessible-resources endpoint pattern
+// or by looking for Bitbucket indicators in the snippet context.
+type atlassianBitbucketAccessCondition struct{}
+
+func (c *atlassianBitbucketAccessCondition) Evaluate(_ context.Context, m *types.Match) (bool, error) {
+	if m == nil {
+		return false, nil
+	}
+	// Check snippet context for Bitbucket indicators
+	combined := string(m.Snippet.Before) + string(m.Snippet.Matching) + string(m.Snippet.After)
+	lower := strings.ToLower(combined)
+	return strings.Contains(lower, "bitbucket"), nil
+}
+
+// atlassianGuestAccountCondition fires when the snippet context suggests this
+// is a guest/external account (lower risk).
+type atlassianGuestAccountCondition struct{}
+
+func (c *atlassianGuestAccountCondition) Evaluate(_ context.Context, m *types.Match) (bool, error) {
+	if m == nil {
+		return false, nil
+	}
+	combined := string(m.Snippet.Before) + string(m.Snippet.Matching) + string(m.Snippet.After)
+	lower := strings.ToLower(combined)
+	return strings.Contains(lower, "guest"), nil
+}
+
+// atlassianTokenExpiredCondition fires when the token is expired (401 from the API).
+type atlassianTokenExpiredCondition struct {
+	client atlassianHTTPClient
+}
+
+func (c *atlassianTokenExpiredCondition) markDynamic() {}
+
+func (c *atlassianTokenExpiredCondition) Evaluate(ctx context.Context, m *types.Match) (bool, error) {
+	token, email, domain, ok := extractAtlassianCredentials(m)
+	if !ok {
+		return false, nil
+	}
+
+	url := fmt.Sprintf("https://%s/rest/api/3/myself", domain)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return false, nil
+	}
+	req.SetBasicAuth(email, token)
+
+	client := c.httpClient()
+	resp, err := client.Do(req)
+	if err != nil {
+		return false, nil
+	}
+	defer func() { io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
+
+	return resp.StatusCode == http.StatusUnauthorized, nil
+}
+
+func (c *atlassianTokenExpiredCondition) httpClient() atlassianHTTPClient {
+	if c.client != nil {
+		return c.client
+	}
+	return defaultHTTPClient
+}
+
+// AtlassianGoScorer returns the Atlassian scoring configuration for np.atlassian.1.
+// Implements LAB-3366 (Atlassian admin detection) and LAB-3399 (Jira project scope).
+func AtlassianGoScorer() *Scorer {
+	return &Scorer{
+		Name:    "atlassian-scope",
+		RuleIDs: []string{"np.atlassian.1"},
+		Modifiers: []Modifier{
+			// Priority 100: Token expired → set_score 5 (highest priority, overrides all)
+			{
+				Name:      "token-expired",
+				Priority:  100,
+				Kind:      ModifierKindSetScore,
+				Value:     5,
+				Condition: &atlassianTokenExpiredCondition{},
+			},
+			// Priority 95: Site admin → set_score 85
+			{
+				Name:      "site-admin",
+				Priority:  95,
+				Kind:      ModifierKindSetScore,
+				Value:     85,
+				Condition: &atlassianSiteAdminCondition{},
+			},
+			// Priority 80: Bitbucket access → delta +15
+			{
+				Name:      "bitbucket-access",
+				Priority:  80,
+				Kind:      ModifierKindDelta,
+				Value:     15,
+				Condition: &atlassianBitbucketAccessCondition{},
+			},
+			// Priority 70: Access to 50+ projects → delta +10 (broad org-wide access)
+			{
+				Name:      "broad-project-access",
+				Priority:  70,
+				Kind:      ModifierKindDelta,
+				Value:     10,
+				Condition: &atlassianProjectCountCondition{threshold: 50},
+			},
+			// Priority 60: Guest account → delta -20 (limited scope)
+			{
+				Name:      "guest-account",
+				Priority:  60,
+				Kind:      ModifierKindDelta,
+				Value:     -20,
+				Condition: &atlassianGuestAccountCondition{},
+			},
+		},
+	}
+}

--- a/pkg/scoring/atlassian_test.go
+++ b/pkg/scoring/atlassian_test.go
@@ -15,11 +15,11 @@ func atlassianMatch(email, domain string) *types.Match {
 	return &types.Match{
 		RuleID: "np.atlassian.1",
 		NamedGroups: map[string][]byte{
-			"token": []byte("ATATT3xFfGF0testEXAMPLEtokenFORunit_testing=00000000"),
+			"token": []byte("ATATT3xFfGF0testEXAMPLEtokenFORunit_testing=ZZZZZZZZ"),
 		},
 		Snippet: types.Snippet{
 			Before:   []byte("email = '" + email + "'\n"),
-			Matching: []byte("api_token = 'ATATT3xFfGF0testEXAMPLEtokenFORunit_testing=00000000'"),
+			Matching: []byte("api_token = 'ATATT3xFfGF0testEXAMPLEtokenFORunit_testing=ZZZZZZZZ'"),
 			After:    []byte("# https://" + domain + "/rest/api/3/myself\n"),
 		},
 	}
@@ -29,7 +29,7 @@ func TestExtractAtlassianCredentials_Success(t *testing.T) {
 	m := atlassianMatch("info@example.com", "mycompany.atlassian.net")
 	token, email, domain, ok := extractAtlassianCredentials(m)
 	assert.True(t, ok)
-	assert.Equal(t, "ATATT3xFfGF0testEXAMPLEtokenFORunit_testing=00000000", token)
+	assert.Equal(t, "ATATT3xFfGF0testEXAMPLEtokenFORunit_testing=ZZZZZZZZ", token)
 	assert.Equal(t, "info@example.com", email)
 	assert.Equal(t, "mycompany.atlassian.net", domain)
 }
@@ -51,7 +51,7 @@ func TestExtractAtlassianCredentials_MissingEmail(t *testing.T) {
 	m := &types.Match{
 		RuleID: "np.atlassian.1",
 		NamedGroups: map[string][]byte{
-			"token": []byte("ATATT3xFfGF0testEXAMPLEshort=00000000"),
+			"token": []byte("ATATT3xFfGF0testEXAMPLEshort=ZZZZZZZZ"),
 		},
 		Snippet: types.Snippet{
 			Before: []byte("no email here\n"),
@@ -66,7 +66,7 @@ func TestExtractAtlassianCredentials_MissingDomain(t *testing.T) {
 	m := &types.Match{
 		RuleID: "np.atlassian.1",
 		NamedGroups: map[string][]byte{
-			"token": []byte("ATATT3xFfGF0testEXAMPLEshort=00000000"),
+			"token": []byte("ATATT3xFfGF0testEXAMPLEshort=ZZZZZZZZ"),
 		},
 		Snippet: types.Snippet{
 			Before: []byte("email = 'info@example.com'\n"),
@@ -188,7 +188,7 @@ func TestAtlassianBitbucketAccessCondition_HasBitbucket(t *testing.T) {
 	m := &types.Match{
 		RuleID: "np.atlassian.1",
 		NamedGroups: map[string][]byte{
-			"token": []byte("ATATT3xFfGF0testEXAMPLEshort=00000000"),
+			"token": []byte("ATATT3xFfGF0testEXAMPLEshort=ZZZZZZZZ"),
 		},
 		Snippet: types.Snippet{
 			Before: []byte("# Bitbucket integration\nemail = 'info@example.com'\n"),
@@ -213,7 +213,7 @@ func TestAtlassianGuestAccountCondition_IsGuest(t *testing.T) {
 	m := &types.Match{
 		RuleID: "np.atlassian.1",
 		NamedGroups: map[string][]byte{
-			"token": []byte("ATATT3xFfGF0testEXAMPLEshort=00000000"),
+			"token": []byte("ATATT3xFfGF0testEXAMPLEshort=ZZZZZZZZ"),
 		},
 		Snippet: types.Snippet{
 			Before: []byte("# Guest user access\n"),

--- a/pkg/scoring/atlassian_test.go
+++ b/pkg/scoring/atlassian_test.go
@@ -82,13 +82,13 @@ func TestAtlassianSiteAdminCondition_IsAdmin(t *testing.T) {
 		switch r.URL.Path {
 		case "/rest/api/3/myself":
 			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(map[string]interface{}{
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
 				"accountType": "atlassian",
 				"accountId":   "123",
 			})
 		case "/rest/api/3/mypermissions":
 			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(map[string]interface{}{
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
 				"permissions": map[string]interface{}{
 					"ADMINISTER": map[string]interface{}{
 						"havePermission": true,
@@ -114,12 +114,12 @@ func TestAtlassianSiteAdminCondition_NotAdmin(t *testing.T) {
 		switch r.URL.Path {
 		case "/rest/api/3/myself":
 			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(map[string]interface{}{
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
 				"accountType": "atlassian",
 			})
 		case "/rest/api/3/mypermissions":
 			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(map[string]interface{}{
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
 				"permissions": map[string]interface{}{
 					"ADMINISTER": map[string]interface{}{
 						"havePermission": false,
@@ -148,7 +148,7 @@ func TestAtlassianProjectCountCondition_AboveThreshold(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(projects)
+		_ = json.NewEncoder(w).Encode(projects)
 	}))
 	defer server.Close()
 
@@ -168,7 +168,7 @@ func TestAtlassianProjectCountCondition_BelowThreshold(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(projects)
+		_ = json.NewEncoder(w).Encode(projects)
 	}))
 	defer server.Close()
 
@@ -252,7 +252,7 @@ func TestAtlassianTokenExpiredCondition_Expired(t *testing.T) {
 func TestAtlassianTokenExpiredCondition_NotExpired(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"accountId":"123"}`))
+		_, _ = w.Write([]byte(`{"accountId":"123"}`))
 	}))
 	defer server.Close()
 

--- a/pkg/scoring/atlassian_test.go
+++ b/pkg/scoring/atlassian_test.go
@@ -15,11 +15,11 @@ func atlassianMatch(email, domain string) *types.Match {
 	return &types.Match{
 		RuleID: "np.atlassian.1",
 		NamedGroups: map[string][]byte{
-			"token": []byte("ATATT3xFfGF0pogUFVOH0_AjBEA8LJcnOJx_Ki4yl_PY=110E6FC6"),
+			"token": []byte("ATATT3xFfGF0testEXAMPLEtokenFORunit_testing=00000000"),
 		},
 		Snippet: types.Snippet{
 			Before:   []byte("email = '" + email + "'\n"),
-			Matching: []byte("api_token = 'ATATT3xFfGF0pogUFVOH0_AjBEA8LJcnOJx_Ki4yl_PY=110E6FC6'"),
+			Matching: []byte("api_token = 'ATATT3xFfGF0testEXAMPLEtokenFORunit_testing=00000000'"),
 			After:    []byte("# https://" + domain + "/rest/api/3/myself\n"),
 		},
 	}
@@ -29,7 +29,7 @@ func TestExtractAtlassianCredentials_Success(t *testing.T) {
 	m := atlassianMatch("info@example.com", "mycompany.atlassian.net")
 	token, email, domain, ok := extractAtlassianCredentials(m)
 	assert.True(t, ok)
-	assert.Equal(t, "ATATT3xFfGF0pogUFVOH0_AjBEA8LJcnOJx_Ki4yl_PY=110E6FC6", token)
+	assert.Equal(t, "ATATT3xFfGF0testEXAMPLEtokenFORunit_testing=00000000", token)
 	assert.Equal(t, "info@example.com", email)
 	assert.Equal(t, "mycompany.atlassian.net", domain)
 }
@@ -51,7 +51,7 @@ func TestExtractAtlassianCredentials_MissingEmail(t *testing.T) {
 	m := &types.Match{
 		RuleID: "np.atlassian.1",
 		NamedGroups: map[string][]byte{
-			"token": []byte("ATATT3xFfGF0pogUFVOH0=110E6FC6"),
+			"token": []byte("ATATT3xFfGF0testEXAMPLEshort=00000000"),
 		},
 		Snippet: types.Snippet{
 			Before: []byte("no email here\n"),
@@ -66,7 +66,7 @@ func TestExtractAtlassianCredentials_MissingDomain(t *testing.T) {
 	m := &types.Match{
 		RuleID: "np.atlassian.1",
 		NamedGroups: map[string][]byte{
-			"token": []byte("ATATT3xFfGF0pogUFVOH0=110E6FC6"),
+			"token": []byte("ATATT3xFfGF0testEXAMPLEshort=00000000"),
 		},
 		Snippet: types.Snippet{
 			Before: []byte("email = 'info@example.com'\n"),
@@ -188,7 +188,7 @@ func TestAtlassianBitbucketAccessCondition_HasBitbucket(t *testing.T) {
 	m := &types.Match{
 		RuleID: "np.atlassian.1",
 		NamedGroups: map[string][]byte{
-			"token": []byte("ATATT3xFfGF0pogUFVOH0=110E6FC6"),
+			"token": []byte("ATATT3xFfGF0testEXAMPLEshort=00000000"),
 		},
 		Snippet: types.Snippet{
 			Before: []byte("# Bitbucket integration\nemail = 'info@example.com'\n"),
@@ -213,7 +213,7 @@ func TestAtlassianGuestAccountCondition_IsGuest(t *testing.T) {
 	m := &types.Match{
 		RuleID: "np.atlassian.1",
 		NamedGroups: map[string][]byte{
-			"token": []byte("ATATT3xFfGF0pogUFVOH0=110E6FC6"),
+			"token": []byte("ATATT3xFfGF0testEXAMPLEshort=00000000"),
 		},
 		Snippet: types.Snippet{
 			Before: []byte("# Guest user access\n"),

--- a/pkg/scoring/atlassian_test.go
+++ b/pkg/scoring/atlassian_test.go
@@ -1,0 +1,319 @@
+package scoring
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func atlassianMatch(email, domain string) *types.Match {
+	return &types.Match{
+		RuleID: "np.atlassian.1",
+		NamedGroups: map[string][]byte{
+			"token": []byte("ATATT3xFfGF0pogUFVOH0_AjBEA8LJcnOJx_Ki4yl_PY=110E6FC6"),
+		},
+		Snippet: types.Snippet{
+			Before:   []byte("email = '" + email + "'\n"),
+			Matching: []byte("api_token = 'ATATT3xFfGF0pogUFVOH0_AjBEA8LJcnOJx_Ki4yl_PY=110E6FC6'"),
+			After:    []byte("# https://" + domain + "/rest/api/3/myself\n"),
+		},
+	}
+}
+
+func TestExtractAtlassianCredentials_Success(t *testing.T) {
+	m := atlassianMatch("info@example.com", "mycompany.atlassian.net")
+	token, email, domain, ok := extractAtlassianCredentials(m)
+	assert.True(t, ok)
+	assert.Equal(t, "ATATT3xFfGF0pogUFVOH0_AjBEA8LJcnOJx_Ki4yl_PY=110E6FC6", token)
+	assert.Equal(t, "info@example.com", email)
+	assert.Equal(t, "mycompany.atlassian.net", domain)
+}
+
+func TestExtractAtlassianCredentials_MissingToken(t *testing.T) {
+	m := &types.Match{
+		RuleID:      "np.atlassian.1",
+		NamedGroups: map[string][]byte{},
+		Snippet: types.Snippet{
+			Before: []byte("email = 'info@example.com'\n"),
+			After:  []byte("https://mycompany.atlassian.net\n"),
+		},
+	}
+	_, _, _, ok := extractAtlassianCredentials(m)
+	assert.False(t, ok)
+}
+
+func TestExtractAtlassianCredentials_MissingEmail(t *testing.T) {
+	m := &types.Match{
+		RuleID: "np.atlassian.1",
+		NamedGroups: map[string][]byte{
+			"token": []byte("ATATT3xFfGF0pogUFVOH0=110E6FC6"),
+		},
+		Snippet: types.Snippet{
+			Before: []byte("no email here\n"),
+			After:  []byte("https://mycompany.atlassian.net\n"),
+		},
+	}
+	_, _, _, ok := extractAtlassianCredentials(m)
+	assert.False(t, ok)
+}
+
+func TestExtractAtlassianCredentials_MissingDomain(t *testing.T) {
+	m := &types.Match{
+		RuleID: "np.atlassian.1",
+		NamedGroups: map[string][]byte{
+			"token": []byte("ATATT3xFfGF0pogUFVOH0=110E6FC6"),
+		},
+		Snippet: types.Snippet{
+			Before: []byte("email = 'info@example.com'\n"),
+			After:  []byte("no domain here\n"),
+		},
+	}
+	_, _, _, ok := extractAtlassianCredentials(m)
+	assert.False(t, ok)
+}
+
+func TestAtlassianSiteAdminCondition_IsAdmin(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/rest/api/3/myself":
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"accountType": "atlassian",
+				"accountId":   "123",
+			})
+		case "/rest/api/3/mypermissions":
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"permissions": map[string]interface{}{
+					"ADMINISTER": map[string]interface{}{
+						"havePermission": true,
+					},
+				},
+			})
+		}
+	}))
+	defer server.Close()
+
+	c := &atlassianSiteAdminCondition{
+		client: &redirectingClient{target: server.URL},
+	}
+
+	m := atlassianMatch("info@example.com", "mycompany.atlassian.net")
+	fired, err := c.Evaluate(context.Background(), m)
+	assert.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestAtlassianSiteAdminCondition_NotAdmin(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/rest/api/3/myself":
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"accountType": "atlassian",
+			})
+		case "/rest/api/3/mypermissions":
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"permissions": map[string]interface{}{
+					"ADMINISTER": map[string]interface{}{
+						"havePermission": false,
+					},
+				},
+			})
+		}
+	}))
+	defer server.Close()
+
+	c := &atlassianSiteAdminCondition{
+		client: &redirectingClient{target: server.URL},
+	}
+
+	m := atlassianMatch("info@example.com", "mycompany.atlassian.net")
+	fired, err := c.Evaluate(context.Background(), m)
+	assert.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestAtlassianProjectCountCondition_AboveThreshold(t *testing.T) {
+	projects := make([]map[string]string, 55)
+	for i := range projects {
+		projects[i] = map[string]string{"key": "PROJ"}
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(projects)
+	}))
+	defer server.Close()
+
+	c := &atlassianProjectCountCondition{
+		threshold: 50,
+		client:    &redirectingClient{target: server.URL},
+	}
+
+	m := atlassianMatch("info@example.com", "mycompany.atlassian.net")
+	fired, err := c.Evaluate(context.Background(), m)
+	assert.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestAtlassianProjectCountCondition_BelowThreshold(t *testing.T) {
+	projects := []map[string]string{{"key": "PROJ1"}, {"key": "PROJ2"}}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(projects)
+	}))
+	defer server.Close()
+
+	c := &atlassianProjectCountCondition{
+		threshold: 50,
+		client:    &redirectingClient{target: server.URL},
+	}
+
+	m := atlassianMatch("info@example.com", "mycompany.atlassian.net")
+	fired, err := c.Evaluate(context.Background(), m)
+	assert.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestAtlassianBitbucketAccessCondition_HasBitbucket(t *testing.T) {
+	c := &atlassianBitbucketAccessCondition{}
+	m := &types.Match{
+		RuleID: "np.atlassian.1",
+		NamedGroups: map[string][]byte{
+			"token": []byte("ATATT3xFfGF0pogUFVOH0=110E6FC6"),
+		},
+		Snippet: types.Snippet{
+			Before: []byte("# Bitbucket integration\nemail = 'info@example.com'\n"),
+			After:  []byte("https://mycompany.atlassian.net\n"),
+		},
+	}
+	fired, err := c.Evaluate(context.Background(), m)
+	assert.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestAtlassianBitbucketAccessCondition_NoBitbucket(t *testing.T) {
+	c := &atlassianBitbucketAccessCondition{}
+	m := atlassianMatch("info@example.com", "mycompany.atlassian.net")
+	fired, err := c.Evaluate(context.Background(), m)
+	assert.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestAtlassianGuestAccountCondition_IsGuest(t *testing.T) {
+	c := &atlassianGuestAccountCondition{}
+	m := &types.Match{
+		RuleID: "np.atlassian.1",
+		NamedGroups: map[string][]byte{
+			"token": []byte("ATATT3xFfGF0pogUFVOH0=110E6FC6"),
+		},
+		Snippet: types.Snippet{
+			Before: []byte("# Guest user access\n"),
+			After:  []byte("https://mycompany.atlassian.net\n"),
+		},
+	}
+	fired, err := c.Evaluate(context.Background(), m)
+	assert.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestAtlassianGuestAccountCondition_NotGuest(t *testing.T) {
+	c := &atlassianGuestAccountCondition{}
+	m := atlassianMatch("info@example.com", "mycompany.atlassian.net")
+	fired, err := c.Evaluate(context.Background(), m)
+	assert.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestAtlassianTokenExpiredCondition_Expired(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	c := &atlassianTokenExpiredCondition{
+		client: &redirectingClient{target: server.URL},
+	}
+
+	m := atlassianMatch("info@example.com", "mycompany.atlassian.net")
+	fired, err := c.Evaluate(context.Background(), m)
+	assert.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestAtlassianTokenExpiredCondition_NotExpired(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"accountId":"123"}`))
+	}))
+	defer server.Close()
+
+	c := &atlassianTokenExpiredCondition{
+		client: &redirectingClient{target: server.URL},
+	}
+
+	m := atlassianMatch("info@example.com", "mycompany.atlassian.net")
+	fired, err := c.Evaluate(context.Background(), m)
+	assert.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestAtlassianGoScorer_Structure(t *testing.T) {
+	s := AtlassianGoScorer()
+	assert.Equal(t, "atlassian-scope", s.Name)
+	assert.Contains(t, s.RuleIDs, "np.atlassian.1")
+	assert.Equal(t, 5, len(s.Modifiers), "expected 5 modifiers")
+
+	// Verify modifier names and priorities
+	names := make([]string, len(s.Modifiers))
+	for i, mod := range s.Modifiers {
+		names[i] = mod.Name
+	}
+	assert.Contains(t, names, "token-expired")
+	assert.Contains(t, names, "site-admin")
+	assert.Contains(t, names, "bitbucket-access")
+	assert.Contains(t, names, "broad-project-access")
+	assert.Contains(t, names, "guest-account")
+}
+
+func TestAtlassianGoScorer_MissingCredentials(t *testing.T) {
+	// All conditions should gracefully return false when credentials are missing
+	s := AtlassianGoScorer()
+	m := &types.Match{
+		RuleID:      "np.atlassian.1",
+		NamedGroups: map[string][]byte{},
+	}
+
+	for _, mod := range s.Modifiers {
+		fired, err := mod.Condition.Evaluate(context.Background(), m)
+		assert.NoError(t, err, "modifier %s should not error", mod.Name)
+		assert.False(t, fired, "modifier %s should not fire without credentials", mod.Name)
+	}
+}
+
+// redirectingClient redirects all requests to a test server URL.
+type redirectingClient struct {
+	target string
+}
+
+func (c *redirectingClient) Do(req *http.Request) (*http.Response, error) {
+	// Rewrite the URL to point to the test server
+	testURL := c.target + req.URL.Path
+	if req.URL.RawQuery != "" {
+		testURL += "?" + req.URL.RawQuery
+	}
+	newReq, err := http.NewRequestWithContext(req.Context(), req.Method, testURL, req.Body)
+	if err != nil {
+		return nil, err
+	}
+	newReq.Header = req.Header
+	return http.DefaultClient.Do(newReq)
+}

--- a/pkg/scoring/go_scorers.go
+++ b/pkg/scoring/go_scorers.go
@@ -6,5 +6,6 @@ func BuiltinGoScorers() []*Scorer {
 	return []*Scorer{
 		AWSGoScorer(),
 		GitHubGoScorer(),
+		AtlassianGoScorer(),
 	}
 }


### PR DESCRIPTION
## Summary

- Add Go scorer for `np.atlassian.1` with 5 modifiers covering site admin detection, project access breadth, Bitbucket access, guest accounts, and expired tokens
- Extracts email and domain from snippet context (Basic auth required for Atlassian API)
- 16 tests covering all conditions, credential extraction, and graceful degradation

## Modifiers

| Name | Priority | Kind | Value | Condition |
|------|----------|------|-------|-----------|
| token-expired | 100 | set_score | 5 | 401 from `/rest/api/3/myself` |
| site-admin | 95 | set_score | 85 | ADMINISTER permission via `/rest/api/3/mypermissions` |
| bitbucket-access | 80 | delta | +15 | Bitbucket keyword in snippet context |
| broad-project-access | 70 | delta | +10 | 50+ projects via `/rest/api/3/project` |
| guest-account | 60 | delta | -20 | Guest keyword in snippet context |

## Linear

Resolves [LAB-3366](https://linear.app/praetorianlabs/issue/LAB-3366) and [LAB-3399](https://linear.app/praetorianlabs/issue/LAB-3399)
Part of [LAB-3356](https://linear.app/praetorianlabs/issue/LAB-3356) (Release v1.3.0 Roadmap)
Depends on [PR #245](https://github.com/praetorian-inc/titus/pull/245) (Atlassian validator)

## Test plan

- [x] All 16 unit tests pass (`go test ./pkg/scoring/ -run Atlassian`)
- [x] All existing scoring tests pass
- [x] `go build ./...` succeeds
- [ ] Manual test with `--score-scope` against real Atlassian token (optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)