### PR TITLE
feat(scoring): add Google API key scorer with Gemini AI detection

### DIFF
--- a/pkg/scoring/scorers/google.yaml
+++ b/pkg/scoring/scorers/google.yaml
@@ -1,0 +1,50 @@
+# Google API key scorer — dynamic HTTP modifiers for Gemini AI access (LAB-4000).
+#
+# Rule IDs covered:
+#   np.google.5 — Google API Key (AIza prefix): base_score 55
+#   np.google.7 — Google API Key (Base64 encoded): base_score 55
+#   np.google.8 — Google Maps API Key (AIza with maps context): base_score 50
+#
+# All three patterns capture a named group "key", making them suitable for
+# query parameter auth injection in HTTP modifiers.
+#
+# API documentation:
+#   Generative AI / Gemini models endpoint:
+#     https://ai.google.dev/api/models#method:-models.list
+#   Response schema (models array with name, displayName, supportedGenerationMethods):
+#     https://ai.google.dev/api/models#Model
+scorers:
+  - name: google-gemini-scope
+    rule_ids:
+      - np.google.5
+      - np.google.7
+      - np.google.8
+
+    modifiers:
+      # --- Dynamic: check if key has Gemini/Generative AI API access ---
+      - name: gemini-api-access
+        priority: 90
+        http:
+          method: GET
+          url: "https://generativelanguage.googleapis.com/v1/models?key={{key}}"
+          auth:
+            type: none
+            secret_group: key
+        fires_when:
+          status_code: 200
+        delta: 15   # AI model access — elevated risk
+
+      # --- Dynamic: check if key grants access to advanced models ---
+      # gemini-2.0-flash or gemini-1.5-pro in the models list indicates
+      # access to production-grade models with higher capability.
+      - name: gemini-advanced-models
+        priority: 80
+        http:
+          method: GET
+          url: "https://generativelanguage.googleapis.com/v1/models?key={{key}}"
+          auth:
+            type: none
+            secret_group: key
+        fires_when:
+          response_body_contains: "gemini-1.5-pro"
+        delta: 10   # access to advanced models — broader capability

--- a/pkg/validator/validators/google-gemini.yaml
+++ b/pkg/validator/validators/google-gemini.yaml
@@ -1,0 +1,17 @@
+# Google API key validation via Gemini/Generative AI API
+# Validates base64-encoded Google API keys (np.google.7) which lack a
+# validator in google.yaml. Uses the lightweight models list endpoint.
+# Returns 200 for valid keys with Generative AI API enabled,
+# 400 for malformed keys, 403 for valid keys without API access.
+validators:
+  - name: google-api-key-gemini
+    rule_ids:
+      - np.google.7
+    http:
+      method: GET
+      url: "https://generativelanguage.googleapis.com/v1/models?key={{key}}"
+      auth:
+        type: none
+        secret_group: "key"
+      success_codes: [200]
+      failure_codes: [400, 403]

--- a/pkg/validator/validators/google-gemini.yaml
+++ b/pkg/validator/validators/google-gemini.yaml
@@ -2,7 +2,10 @@
 # Validates base64-encoded Google API keys (np.google.7) which lack a
 # validator in google.yaml. Uses the lightweight models list endpoint.
 # Returns 200 for valid keys with Generative AI API enabled,
-# 400 for malformed keys, 403 for valid keys without API access.
+# 400 for malformed/invalid keys.
+# Note: 403 means the key IS valid but lacks Generative AI API access —
+# it may still work for YouTube, Maps, etc. We treat 403 as undetermined
+# (not invalid) so other validators or manual review can assess the key.
 validators:
   - name: google-api-key-gemini
     rule_ids:
@@ -14,4 +17,4 @@ validators:
         type: none
         secret_group: "key"
       success_codes: [200]
-      failure_codes: [400, 403]
+      failure_codes: [400]


### PR DESCRIPTION
## Summary

- Add YAML scorer for Google API keys (`np.google.5`, `np.google.7`, `np.google.8`) with dynamic HTTP modifiers that detect Gemini/Generative AI API access
- Add Gemini validator for `np.google.7` (base64-encoded API keys) which previously had no validator

## Scoring Modifiers

| Name | Priority | Kind | Value | Condition |
|------|----------|------|-------|-----------|
| gemini-api-access | 90 | delta | +15 | 200 from `generativelanguage.googleapis.com/v1/models` |
| gemini-advanced-models | 80 | delta | +10 | Response contains `gemini-1.5-pro` |

With both modifiers firing, a `np.google.5` key (base_score 55) scores 80 (high severity).

## Linear

Resolves [LAB-4000](https://linear.app/praetorianlabs/issue/LAB-4000)
Part of [LAB-3356](https://linear.app/praetorianlabs/issue/LAB-3356) (Release v1.3.0 Roadmap)

## Test plan

- [x] All existing scoring tests pass (`go test ./pkg/scoring/`)
- [x] All existing validator tests pass (`go test ./pkg/validator/`)
- [x] `go build ./...` succeeds
- [ ] Manual test with `--score-scope` against real Google API key (optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)