### PR TITLE
feat(scoring): add Supabase management token scorer

### DIFF
--- a/pkg/scoring/go_scorers.go
+++ b/pkg/scoring/go_scorers.go
@@ -6,5 +6,6 @@ func BuiltinGoScorers() []*Scorer {
 	return []*Scorer{
 		AWSGoScorer(),
 		GitHubGoScorer(),
+		SupabaseGoScorer(),
 	}
 }

--- a/pkg/scoring/supabase.go
+++ b/pkg/scoring/supabase.go
@@ -1,0 +1,188 @@
+package scoring
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+)
+
+// supabaseHTTPClient is an interface for making HTTP requests (allows testing).
+type supabaseHTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// extractSupabaseToken extracts the management token from positional group 1.
+// kingfisher.supabase.1 uses (sbp_...) without a named group.
+func extractSupabaseToken(m *types.Match) (string, bool) {
+	if m == nil {
+		return "", false
+	}
+	// Try positional group first (the rule uses unnamed capture)
+	if len(m.Groups) > 0 && len(m.Groups[0]) > 0 {
+		return string(m.Groups[0]), true
+	}
+	// Fall back to named groups in case the rule is updated
+	for _, name := range []string{"token", "1"} {
+		if v, ok := m.NamedGroups[name]; ok && len(v) > 0 {
+			return string(v), true
+		}
+	}
+	return "", false
+}
+
+// supabaseTokenExpiredCondition fires when the token returns 401.
+type supabaseTokenExpiredCondition struct {
+	client supabaseHTTPClient
+}
+
+func (c *supabaseTokenExpiredCondition) markDynamic() {}
+
+func (c *supabaseTokenExpiredCondition) Evaluate(ctx context.Context, m *types.Match) (bool, error) {
+	token, ok := extractSupabaseToken(m)
+	if !ok {
+		return false, nil
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", "https://api.supabase.com/v1/organizations", nil)
+	if err != nil {
+		return false, nil
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := c.httpClient().Do(req)
+	if err != nil {
+		return false, nil
+	}
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
+
+	return resp.StatusCode == http.StatusUnauthorized, nil
+}
+
+func (c *supabaseTokenExpiredCondition) httpClient() supabaseHTTPClient {
+	if c.client != nil {
+		return c.client
+	}
+	return defaultHTTPClient
+}
+
+// supabaseActiveTokenCondition fires when the token is confirmed active (200).
+type supabaseActiveTokenCondition struct {
+	client supabaseHTTPClient
+}
+
+func (c *supabaseActiveTokenCondition) markDynamic() {}
+
+func (c *supabaseActiveTokenCondition) Evaluate(ctx context.Context, m *types.Match) (bool, error) {
+	token, ok := extractSupabaseToken(m)
+	if !ok {
+		return false, nil
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", "https://api.supabase.com/v1/organizations", nil)
+	if err != nil {
+		return false, nil
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := c.httpClient().Do(req)
+	if err != nil {
+		return false, nil
+	}
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
+
+	return resp.StatusCode == http.StatusOK, nil
+}
+
+func (c *supabaseActiveTokenCondition) httpClient() supabaseHTTPClient {
+	if c.client != nil {
+		return c.client
+	}
+	return defaultHTTPClient
+}
+
+// supabaseMultiProjectCondition fires when the token has access to >= threshold projects.
+type supabaseMultiProjectCondition struct {
+	threshold int
+	client    supabaseHTTPClient
+}
+
+func (c *supabaseMultiProjectCondition) markDynamic() {}
+
+func (c *supabaseMultiProjectCondition) Evaluate(ctx context.Context, m *types.Match) (bool, error) {
+	token, ok := extractSupabaseToken(m)
+	if !ok {
+		return false, nil
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", "https://api.supabase.com/v1/projects", nil)
+	if err != nil {
+		return false, nil
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := c.httpClient().Do(req)
+	if err != nil {
+		return false, nil
+	}
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return false, nil
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false, nil
+	}
+
+	var projects []json.RawMessage
+	if err := json.Unmarshal(body, &projects); err != nil {
+		return false, nil
+	}
+
+	return len(projects) >= c.threshold, nil
+}
+
+func (c *supabaseMultiProjectCondition) httpClient() supabaseHTTPClient {
+	if c.client != nil {
+		return c.client
+	}
+	return defaultHTTPClient
+}
+
+// SupabaseGoScorer returns the Supabase scoring configuration for kingfisher.supabase.1.
+func SupabaseGoScorer() *Scorer {
+	return &Scorer{
+		Name:    "supabase-management-scope",
+		RuleIDs: []string{"kingfisher.supabase.1"},
+		Modifiers: []Modifier{
+			// Priority 100: Token expired → set_score 5
+			{
+				Name:      "token-expired",
+				Priority:  100,
+				Kind:      ModifierKindSetScore,
+				Value:     5,
+				Condition: &supabaseTokenExpiredCondition{},
+			},
+			// Priority 90: Token confirmed active → delta +5
+			{
+				Name:      "active-token",
+				Priority:  90,
+				Kind:      ModifierKindDelta,
+				Value:     5,
+				Condition: &supabaseActiveTokenCondition{},
+			},
+			// Priority 70: 5+ projects → delta +5 (broad infrastructure access)
+			{
+				Name:      "multi-project",
+				Priority:  70,
+				Kind:      ModifierKindDelta,
+				Value:     5,
+				Condition: &supabaseMultiProjectCondition{threshold: 5},
+			},
+		},
+	}
+}

--- a/pkg/scoring/supabase.go
+++ b/pkg/scoring/supabase.go
@@ -56,7 +56,7 @@ func (c *supabaseTokenExpiredCondition) Evaluate(ctx context.Context, m *types.M
 	if err != nil {
 		return false, nil
 	}
-	defer func() { _, _ = io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
 
 	return resp.StatusCode == http.StatusUnauthorized, nil
 }
@@ -91,7 +91,7 @@ func (c *supabaseActiveTokenCondition) Evaluate(ctx context.Context, m *types.Ma
 	if err != nil {
 		return false, nil
 	}
-	defer func() { _, _ = io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
 
 	return resp.StatusCode == http.StatusOK, nil
 }
@@ -127,7 +127,7 @@ func (c *supabaseMultiProjectCondition) Evaluate(ctx context.Context, m *types.M
 	if err != nil {
 		return false, nil
 	}
-	defer func() { _, _ = io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return false, nil

--- a/pkg/scoring/supabase_test.go
+++ b/pkg/scoring/supabase_test.go
@@ -1,0 +1,210 @@
+package scoring
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func supabaseMatch() *types.Match {
+	return &types.Match{
+		RuleID: "kingfisher.supabase.1",
+		Groups: [][]byte{
+			[]byte("sbp_testexampletoken1234567890abcdefghij"),
+		},
+		NamedGroups: map[string][]byte{},
+	}
+}
+
+func TestExtractSupabaseToken_FromPositionalGroup(t *testing.T) {
+	m := supabaseMatch()
+	token, ok := extractSupabaseToken(m)
+	assert.True(t, ok)
+	assert.Equal(t, "sbp_testexampletoken1234567890abcdefghij", token)
+}
+
+func TestExtractSupabaseToken_FromNamedGroup(t *testing.T) {
+	m := &types.Match{
+		RuleID: "kingfisher.supabase.1",
+		Groups: [][]byte{},
+		NamedGroups: map[string][]byte{
+			"token": []byte("sbp_testexampletoken1234567890abcdefghij"),
+		},
+	}
+	token, ok := extractSupabaseToken(m)
+	assert.True(t, ok)
+	assert.Equal(t, "sbp_testexampletoken1234567890abcdefghij", token)
+}
+
+func TestExtractSupabaseToken_Missing(t *testing.T) {
+	m := &types.Match{
+		RuleID:      "kingfisher.supabase.1",
+		Groups:      [][]byte{},
+		NamedGroups: map[string][]byte{},
+	}
+	_, ok := extractSupabaseToken(m)
+	assert.False(t, ok)
+}
+
+func TestExtractSupabaseToken_Nil(t *testing.T) {
+	_, ok := extractSupabaseToken(nil)
+	assert.False(t, ok)
+}
+
+func TestSupabaseTokenExpiredCondition_Expired(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	c := &supabaseTokenExpiredCondition{
+		client: &supabaseRedirectingClient{target: server.URL},
+	}
+
+	fired, err := c.Evaluate(context.Background(), supabaseMatch())
+	assert.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestSupabaseTokenExpiredCondition_NotExpired(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[{"id":"org1"}]`))
+	}))
+	defer server.Close()
+
+	c := &supabaseTokenExpiredCondition{
+		client: &supabaseRedirectingClient{target: server.URL},
+	}
+
+	fired, err := c.Evaluate(context.Background(), supabaseMatch())
+	assert.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestSupabaseActiveTokenCondition_Active(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.Header.Get("Authorization"), "Bearer sbp_")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[{"id":"org1"}]`))
+	}))
+	defer server.Close()
+
+	c := &supabaseActiveTokenCondition{
+		client: &supabaseRedirectingClient{target: server.URL},
+	}
+
+	fired, err := c.Evaluate(context.Background(), supabaseMatch())
+	assert.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestSupabaseActiveTokenCondition_Inactive(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	c := &supabaseActiveTokenCondition{
+		client: &supabaseRedirectingClient{target: server.URL},
+	}
+
+	fired, err := c.Evaluate(context.Background(), supabaseMatch())
+	assert.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestSupabaseMultiProjectCondition_AboveThreshold(t *testing.T) {
+	projects := make([]map[string]string, 7)
+	for i := range projects {
+		projects[i] = map[string]string{"id": "proj"}
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1/projects", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(projects)
+	}))
+	defer server.Close()
+
+	c := &supabaseMultiProjectCondition{
+		threshold: 5,
+		client:    &supabaseRedirectingClient{target: server.URL},
+	}
+
+	fired, err := c.Evaluate(context.Background(), supabaseMatch())
+	assert.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestSupabaseMultiProjectCondition_BelowThreshold(t *testing.T) {
+	projects := []map[string]string{{"id": "proj1"}, {"id": "proj2"}}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(projects)
+	}))
+	defer server.Close()
+
+	c := &supabaseMultiProjectCondition{
+		threshold: 5,
+		client:    &supabaseRedirectingClient{target: server.URL},
+	}
+
+	fired, err := c.Evaluate(context.Background(), supabaseMatch())
+	assert.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestSupabaseGoScorer_Structure(t *testing.T) {
+	s := SupabaseGoScorer()
+	assert.Equal(t, "supabase-management-scope", s.Name)
+	assert.Contains(t, s.RuleIDs, "kingfisher.supabase.1")
+	assert.Equal(t, 3, len(s.Modifiers))
+
+	names := make([]string, len(s.Modifiers))
+	for i, mod := range s.Modifiers {
+		names[i] = mod.Name
+	}
+	assert.Contains(t, names, "token-expired")
+	assert.Contains(t, names, "active-token")
+	assert.Contains(t, names, "multi-project")
+}
+
+// supabaseRedirectingClient redirects all requests to a test server URL.
+type supabaseRedirectingClient struct {
+	target string
+}
+
+func (c *supabaseRedirectingClient) Do(req *http.Request) (*http.Response, error) {
+	testURL := c.target + req.URL.Path
+	if req.URL.RawQuery != "" {
+		testURL += "?" + req.URL.RawQuery
+	}
+	newReq, err := http.NewRequestWithContext(req.Context(), req.Method, testURL, req.Body)
+	if err != nil {
+		return nil, err
+	}
+	newReq.Header = req.Header
+	return http.DefaultClient.Do(newReq)
+}
+
+func TestSupabaseGoScorer_MissingToken(t *testing.T) {
+	s := SupabaseGoScorer()
+	m := &types.Match{
+		RuleID:      "kingfisher.supabase.1",
+		Groups:      [][]byte{},
+		NamedGroups: map[string][]byte{},
+	}
+
+	for _, mod := range s.Modifiers {
+		fired, err := mod.Condition.Evaluate(context.Background(), m)
+		assert.NoError(t, err, "modifier %s should not error", mod.Name)
+		assert.False(t, fired, "modifier %s should not fire without token", mod.Name)
+	}
+}


### PR DESCRIPTION
## Summary

- Add Go scorer for `kingfisher.supabase.1` (Supabase management tokens, base_score 90) with 3 modifiers
- Go scorer required because the rule uses positional capture groups `(sbp_...)` which the YAML scoring framework doesn't support
- 12 tests covering token extraction, all conditions, and graceful degradation

## Scoring Modifiers

| Name | Priority | Kind | Value | Condition |
|------|----------|------|-------|-----------|
| token-expired | 100 | set_score | 5 | 401 from `/v1/organizations` |
| active-token | 90 | delta | +5 | 200 from `/v1/organizations` |
| multi-project | 70 | delta | +5 | 5+ projects via `/v1/projects` |

Base score 90 (critical) → active + multi-project = 100 (critical), expired = 5 (info).

## Linear

Resolves [LAB-4001](https://linear.app/praetorianlabs/issue/LAB-4001)
Part of [LAB-3356](https://linear.app/praetorianlabs/issue/LAB-3356) (Release v1.3.0 Roadmap)

## Test plan

- [x] All 12 unit tests pass (`go test ./pkg/scoring/ -run Supabase`)
- [x] All existing scoring tests pass
- [x] `go build ./...` succeeds
- [ ] Manual test with `--score-scope` against real Supabase token (optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)