### PR TITLE
ci(go-sec): re-pin go-sec.yml to v2.6.2 + grant pull-requests:read

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,9 +24,10 @@ permissions:
 
 jobs:
   security:
-    uses: praetorian-inc/public-workflows/.github/workflows/go-sec.yml@7c1302bdef0a72e7f5743738baa45272c8e1f8d7  # v2.1.0
+    uses: praetorian-inc/public-workflows/.github/workflows/go-sec.yml@c1a6ca690193bc4bbc5ee55d903f8ea17a37cd35  # v2.6.2
     permissions:
       contents: read
+      pull-requests: read     # go-sec.yml preflight reads PR files + repo tree
       security-events: write
       actions: read           # required by codeql-action/upload-sarif for run metadata
     secrets: inherit


### PR DESCRIPTION
Re-pin `go-sec.yml` → **v2.6.2** (`c1a6ca690193`). v2.6.2 visibility-gates SARIF upload (no GHAS-403 on internal repos) and skips cleanly when a repo has no Go sources.

**Adds `pull-requests: read`** — v2.6.2's preflight reads PR files / the repo tree; without this grant the run would `startup_failure` (reusable requests a scope the caller didn't grant).

Verified: actionlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)