### PR TITLE
test: verify Claude reviewer opus-4-8 fix (DO NOT MERGE)

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   claude-code-action:
-    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@23254e12b026871dd9bbf2bad4ef6fee29910fb1  # v2.6.0
+    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@2d4ebcb9a35f353647701eb4caa8ecbd46c32052  # v2.6.4
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/claude-md-drift.yml
+++ b/.github/workflows/claude-md-drift.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   drift-check:
-    uses: praetorian-inc/public-workflows/.github/workflows/claude-md-drift.yml@25c08fbd15a931e275f207ecee1758c931f89ea5  # v2.3.1
+    uses: praetorian-inc/public-workflows/.github/workflows/claude-md-drift.yml@2d4ebcb9a35f353647701eb4caa8ecbd46c32052  # v2.6.4
     permissions:
       contents: read
       pull-requests: write

--- a/titus.go
+++ b/titus.go
@@ -586,3 +586,5 @@ func LoadBuiltinRules() ([]*Rule, error) {
 	loader := rule.NewLoader()
 	return loader.LoadBuiltinRules()
 }
+
+// verify-claude-fix: trivial no-op comment to exercise the claude reviewer pipeline (PR not for merge)


### PR DESCRIPTION
Verification PR for public-workflows #93 / v2.6.4 (claude-code-action v1.0.101→v1.0.135). Bumps titus's claude pins to v2.6.4 and includes a trivial code change so the Claude reviewer job executes (not skipped). **Not for merge** — will be closed once the Claude review posts. Expected: `claude-code-action` job runs to success and posts a "## Claude Review" comment (no thinking.type.enabled 400).