### PR TITLE
feat(scoring): Stripe API key scoring by key type and account status

### DIFF
--- a/cmd/titus/scan_scoring_integration_test.go
+++ b/cmd/titus/scan_scoring_integration_test.go
@@ -227,6 +227,42 @@ func TestRunScan_UnscoredRule_StillEmitsFindingWithBaseOnly(t *testing.T) {
 	assert.Contains(t, string(raw), `"Applied":[]`, "Applied must marshal as [] not null")
 }
 
+// TestRunScan_StripeLiveKey_BaseScore verifies that an np.stripe.1 finding
+// with a sk_live_ prefix gets base_score 90 with no modifiers applied (no
+// --score-scope, so dynamic modifiers are skipped).
+func TestRunScan_StripeLiveKey_BaseScore(t *testing.T) {
+	engine, err := buildScoringEngine()
+	require.NoError(t, err)
+
+	rule := &types.Rule{ID: "np.stripe.1", BaseScore: 90}
+	match := &types.Match{
+		NamedGroups: map[string][]byte{"key": []byte("sk_live_dhhfUUyfrAace5dBAZ10JrAD")},
+	}
+	score := engine.Score(context.Background(), &types.Finding{RuleID: rule.ID}, []*types.Match{match}, rule)
+	assert.Equal(t, 90, score.Final)
+	assert.Len(t, score.Applied, 0)
+}
+
+// TestRunScan_StripeRestrictedKey_DeltaMinus25 verifies that an np.stripe.1
+// finding with an rk_live_ prefix receives the restricted-key-prefix static
+// modifier (delta -25).
+func TestRunScan_StripeRestrictedKey_DeltaMinus25(t *testing.T) {
+	engine, err := buildScoringEngine()
+	require.NoError(t, err)
+
+	rule := &types.Rule{ID: "np.stripe.1", BaseScore: 90}
+	match := &types.Match{
+		NamedGroups: map[string][]byte{"key": []byte("rk_live_dhhfuuyfrAace5dbaz10jrad")},
+	}
+	score := engine.Score(context.Background(), &types.Finding{RuleID: rule.ID}, []*types.Match{match}, rule)
+	assert.Equal(t, 65, score.Final) // 90 - 25
+	require.Len(t, score.Applied, 1)
+	assert.Equal(t, "restricted-key-prefix", score.Applied[0].Name)
+	assert.Equal(t, "stripe-key-scope", score.Applied[0].Scorer)
+	assert.Equal(t, "delta", score.Applied[0].Kind)
+	assert.Equal(t, -25, score.Applied[0].Value)
+}
+
 // TestRunScan_MultiMatchDedup_ScoredOncePerFinding verifies the architectural
 // invariant that Engine.Score is called exactly once per unique finding even
 // when a rule matches multiple times in the same file.

--- a/cmd/titus/scan_scoring_scope_test.go
+++ b/cmd/titus/scan_scoring_scope_test.go
@@ -97,7 +97,7 @@ scorers:
           method: GET
           url: ` + mockURL + `/v1/account
           auth:
-            type: basic
+            type: bearer
             secret_group: "key"
         fires_when:
           json_path_equals:
@@ -110,7 +110,7 @@ scorers:
           method: GET
           url: ` + mockURL + `/v1/account
           auth:
-            type: basic
+            type: bearer
             secret_group: "key"
         fires_when:
           json_path_equals:
@@ -125,6 +125,10 @@ scorers:
 // sets the final score to 95 for an sk_live_ key.
 func TestStripeScorer_ChargesEnabledLive_SetScore95(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if auth := r.Header.Get("Authorization"); auth != "Bearer sk_live_dhhfUUyfrAace5dBAZ10JrAD" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"charges_enabled": true, "country": "US"}`))
@@ -167,6 +171,10 @@ func TestStripeScorer_ChargesEnabledLive_SetScore95(t *testing.T) {
 // the final score to 30 for an sk_live_ key.
 func TestStripeScorer_ChargesDisabled_SetScore30(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if auth := r.Header.Get("Authorization"); auth != "Bearer sk_live_dhhfUUyfrAace5dBAZ10JrAD" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"charges_enabled": false, "country": "US"}`))
@@ -213,6 +221,10 @@ func TestStripeScorer_ChargesDisabled_SetScore30(t *testing.T) {
 // The restricted key penalty applies on top of the set_score. Final = 70.
 func TestStripeScorer_RestrictedKey_ChargesEnabled_Score70(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if auth := r.Header.Get("Authorization"); auth != "Bearer rk_live_dhhfuuyfrAace5dbaz10jrad" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"charges_enabled": true}`))
@@ -264,6 +276,10 @@ func TestStripeScorer_RestrictedKey_ChargesEnabled_Score70(t *testing.T) {
 // Final = 5.
 func TestStripeScorer_RestrictedKey_ChargesDisabled_Score5(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if auth := r.Header.Get("Authorization"); auth != "Bearer rk_live_dhhfuuyfrAace5dbaz10jrad" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"charges_enabled": false}`))

--- a/cmd/titus/scan_scoring_scope_test.go
+++ b/cmd/titus/scan_scoring_scope_test.go
@@ -74,6 +74,275 @@ scorers:
 	assert.Equal(t, "set_score", score.Applied[0].Kind)
 }
 
+// stripeTestScorerYAML builds an inline scorer YAML for np.stripe.1 with all
+// three modifiers (static restricted-key-prefix + two dynamic charges_enabled
+// modifiers). The HTTP modifier URLs point at the provided mock server URL so
+// tests make real HTTP calls against an in-process httptest.Server.
+func stripeTestScorerYAML(mockURL string) []byte {
+	return []byte(`
+scorers:
+  - name: stripe-key-scope
+    rule_ids:
+      - np.stripe.1
+    modifiers:
+      - name: restricted-key-prefix
+        priority: 70
+        match_group:
+          name: key
+          matches: '^rk_live_'
+        delta: -25
+      - name: charges-enabled-live
+        priority: 90
+        http:
+          method: GET
+          url: ` + mockURL + `/v1/account
+          auth:
+            type: basic
+            secret_group: "key"
+        fires_when:
+          json_path_equals:
+            path: ".charges_enabled"
+            value: true
+        set_score: 95
+      - name: charges-disabled
+        priority: 80
+        http:
+          method: GET
+          url: ` + mockURL + `/v1/account
+          auth:
+            type: basic
+            secret_group: "key"
+        fires_when:
+          json_path_equals:
+            path: ".charges_enabled"
+            value: false
+        set_score: 30
+`)
+}
+
+// TestStripeScorer_ChargesEnabledLive_SetScore95 verifies that when the Stripe
+// API reports charges_enabled=true, the charges-enabled-live modifier fires and
+// sets the final score to 95 for an sk_live_ key.
+func TestStripeScorer_ChargesEnabledLive_SetScore95(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"charges_enabled": true, "country": "US"}`))
+	}))
+	defer srv.Close()
+
+	const ruleID = "np.stripe.1"
+	loader := scoring.NewLoader()
+	scorers, err := loader.LoadScorers(stripeTestScorerYAML(srv.URL))
+	require.NoError(t, err)
+
+	engine := scoring.NewEngine(scorers, scoring.EngineConfig{
+		ScopeEnabled: true,
+		Timeout:      5 * time.Second,
+	})
+
+	rule := &types.Rule{ID: ruleID, BaseScore: 90}
+	finding := &types.Finding{ID: "stripe-finding-1", RuleID: ruleID}
+	match := &types.Match{
+		RuleID:      ruleID,
+		NamedGroups: map[string][]byte{"key": []byte("sk_live_dhhfUUyfrAace5dBAZ10JrAD")},
+	}
+
+	score := engine.Score(context.Background(), finding, []*types.Match{match}, rule)
+	require.NotNil(t, score)
+
+	assert.Equal(t, 95, score.Final, "charges_enabled=true should set_score to 95")
+
+	// charges-enabled-live must appear in Applied; charges-disabled must not.
+	var appliedNames []string
+	for _, a := range score.Applied {
+		appliedNames = append(appliedNames, a.Name)
+	}
+	assert.Contains(t, appliedNames, "charges-enabled-live")
+	assert.NotContains(t, appliedNames, "charges-disabled")
+}
+
+// TestStripeScorer_ChargesDisabled_SetScore30 verifies that when the Stripe API
+// reports charges_enabled=false, the charges-disabled modifier fires and sets
+// the final score to 30 for an sk_live_ key.
+func TestStripeScorer_ChargesDisabled_SetScore30(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"charges_enabled": false, "country": "US"}`))
+	}))
+	defer srv.Close()
+
+	const ruleID = "np.stripe.1"
+	loader := scoring.NewLoader()
+	scorers, err := loader.LoadScorers(stripeTestScorerYAML(srv.URL))
+	require.NoError(t, err)
+
+	engine := scoring.NewEngine(scorers, scoring.EngineConfig{
+		ScopeEnabled: true,
+		Timeout:      5 * time.Second,
+	})
+
+	rule := &types.Rule{ID: ruleID, BaseScore: 90}
+	finding := &types.Finding{ID: "stripe-finding-2", RuleID: ruleID}
+	match := &types.Match{
+		RuleID:      ruleID,
+		NamedGroups: map[string][]byte{"key": []byte("sk_live_dhhfUUyfrAace5dBAZ10JrAD")},
+	}
+
+	score := engine.Score(context.Background(), finding, []*types.Match{match}, rule)
+	require.NotNil(t, score)
+
+	assert.Equal(t, 30, score.Final, "charges_enabled=false should set_score to 30")
+
+	var appliedNames []string
+	for _, a := range score.Applied {
+		appliedNames = append(appliedNames, a.Name)
+	}
+	assert.Contains(t, appliedNames, "charges-disabled")
+}
+
+// TestStripeScorer_RestrictedKey_ChargesEnabled_Score70 verifies scoring for an
+// rk_live_ key when charges_enabled=true.
+//
+// Modifier execution order (priority DESC):
+//   1. priority  90: charges-enabled-live   set_score 95 → 95
+//   2. priority  80: charges-disabled       does NOT fire (charges_enabled is true)
+//   3. priority  70: restricted-key-prefix  delta -25 → 95 - 25 = 70
+//
+// The restricted key penalty applies on top of the set_score. Final = 70.
+func TestStripeScorer_RestrictedKey_ChargesEnabled_Score70(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"charges_enabled": true}`))
+	}))
+	defer srv.Close()
+
+	const ruleID = "np.stripe.1"
+	loader := scoring.NewLoader()
+	scorers, err := loader.LoadScorers(stripeTestScorerYAML(srv.URL))
+	require.NoError(t, err)
+
+	engine := scoring.NewEngine(scorers, scoring.EngineConfig{
+		ScopeEnabled: true,
+		Timeout:      5 * time.Second,
+	})
+
+	rule := &types.Rule{ID: ruleID, BaseScore: 90}
+	finding := &types.Finding{ID: "stripe-finding-3", RuleID: ruleID}
+	match := &types.Match{
+		RuleID:      ruleID,
+		NamedGroups: map[string][]byte{"key": []byte("rk_live_dhhfuuyfrAace5dbaz10jrad")},
+	}
+
+	score := engine.Score(context.Background(), finding, []*types.Match{match}, rule)
+	require.NotNil(t, score)
+
+	assert.Equal(t, 70, score.Final, "rk_live_ + charges_enabled=true: set_score 95 then delta -25 = 70")
+
+	require.Len(t, score.Applied, 2)
+	assert.Equal(t, "charges-enabled-live", score.Applied[0].Name)
+	assert.Equal(t, "restricted-key-prefix", score.Applied[1].Name)
+	assert.NotContains(t, func() []string {
+		var names []string
+		for _, a := range score.Applied {
+			names = append(names, a.Name)
+		}
+		return names
+	}(), "charges-disabled")
+}
+
+// TestStripeScorer_RestrictedKey_ChargesDisabled_Score5 verifies scoring for an
+// rk_live_ key when charges_enabled=false.
+//
+// Modifier execution order (priority DESC):
+//   1. priority  90: charges-enabled-live   does NOT fire
+//   2. priority  80: charges-disabled       set_score 30 → 30
+//   3. priority  70: restricted-key-prefix  delta -25 → 30 - 25 = 5
+//
+// Final = 5.
+func TestStripeScorer_RestrictedKey_ChargesDisabled_Score5(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"charges_enabled": false}`))
+	}))
+	defer srv.Close()
+
+	const ruleID = "np.stripe.1"
+	loader := scoring.NewLoader()
+	scorers, err := loader.LoadScorers(stripeTestScorerYAML(srv.URL))
+	require.NoError(t, err)
+
+	engine := scoring.NewEngine(scorers, scoring.EngineConfig{
+		ScopeEnabled: true,
+		Timeout:      5 * time.Second,
+	})
+
+	rule := &types.Rule{ID: ruleID, BaseScore: 90}
+	finding := &types.Finding{ID: "stripe-finding-4", RuleID: ruleID}
+	match := &types.Match{
+		RuleID:      ruleID,
+		NamedGroups: map[string][]byte{"key": []byte("rk_live_dhhfuuyfrAace5dbaz10jrad")},
+	}
+
+	score := engine.Score(context.Background(), finding, []*types.Match{match}, rule)
+	require.NotNil(t, score)
+
+	assert.Equal(t, 5, score.Final, "rk_live_ + charges_enabled=false: set_score 30 then delta -25 = 5")
+
+	require.Len(t, score.Applied, 2)
+	assert.Equal(t, "charges-disabled", score.Applied[0].Name)
+	assert.Equal(t, "restricted-key-prefix", score.Applied[1].Name)
+	assert.NotContains(t, func() []string {
+		var names []string
+		for _, a := range score.Applied {
+			names = append(names, a.Name)
+		}
+		return names
+	}(), "charges-enabled-live")
+}
+
+// TestStripeScorer_ScopeDisabled_DynamicSkipped verifies that with
+// ScopeEnabled=false, HTTP modifiers are not executed. Only the static
+// restricted-key-prefix modifier can fire (and only for rk_live_ keys).
+// An sk_live_ key with scope disabled must return the base score unchanged.
+func TestStripeScorer_ScopeDisabled_DynamicSkipped(t *testing.T) {
+	// The mock server must not be called when scope is disabled.
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"charges_enabled": true}`))
+	}))
+	defer srv.Close()
+
+	const ruleID = "np.stripe.1"
+	loader := scoring.NewLoader()
+	scorers, err := loader.LoadScorers(stripeTestScorerYAML(srv.URL))
+	require.NoError(t, err)
+
+	engine := scoring.NewEngine(scorers, scoring.EngineConfig{
+		ScopeEnabled: false,
+	})
+
+	rule := &types.Rule{ID: ruleID, BaseScore: 90}
+	finding := &types.Finding{ID: "stripe-finding-5", RuleID: ruleID}
+	match := &types.Match{
+		RuleID:      ruleID,
+		NamedGroups: map[string][]byte{"key": []byte("sk_live_dhhfUUyfrAace5dBAZ10JrAD")},
+	}
+
+	score := engine.Score(context.Background(), finding, []*types.Match{match}, rule)
+	require.NotNil(t, score)
+
+	assert.Equal(t, 90, score.Final, "scope disabled: sk_live_ should return base score unchanged")
+	assert.Equal(t, 0, int(calls.Load()), "scope disabled: no HTTP calls should be made")
+	assert.Empty(t, score.Applied, "scope disabled: no modifiers should fire for sk_live_")
+}
+
 // TestScopeDisabled_DynamicModifiersSkipped verifies that when ScopeEnabled=false,
 // HTTP modifiers do not fire even if the condition would have matched.
 func TestScopeDisabled_DynamicModifiersSkipped(t *testing.T) {

--- a/pkg/rule/rules/stripe.yml
+++ b/pkg/rule/rules/stripe.yml
@@ -2,7 +2,7 @@ rules:
 
 - name: Stripe Publishable API Key
   id: np.stripe.3
-  base_score: 5
+  base_score: 10
 
   # Publishable keys (pk_live_*, pk_test_*) are intentionally designed to be embedded
   # in client-side code (browsers, mobile apps). They identify a merchant account for
@@ -69,7 +69,7 @@ rules:
 
 - name: Stripe API Test Key
   id: np.stripe.2
-  base_score: 50
+  base_score: 5
 
   pattern: '(?i)\b(?P<key>(?:sk|rk)_test_[a-z0-9]{24})\b'
 

--- a/pkg/scoring/scorers/stripe.yaml
+++ b/pkg/scoring/scorers/stripe.yaml
@@ -1,0 +1,61 @@
+# Stripe API key scorer — static + dynamic modifiers (M3 scope).
+#
+# Rule IDs covered:
+#   np.stripe.1 — live key (sk_live_, rk_live_): base_score 90
+#
+# The "key" named capture group from the detection rule is used for both
+# static prefix checks and basic auth injection in HTTP modifiers.
+#
+# API documentation:
+#   GET /v1/account (charges_enabled, country, business_profile):
+#     https://docs.stripe.com/api/accounts/retrieve
+#   GET /v1/balance (available, pending):
+#     https://docs.stripe.com/api/balance/balance_retrieve
+#
+# Stripe uses Basic Auth: the API key is the password, username is empty.
+# The existing YAML validator (pkg/validator/validators/stripe.yaml) handles
+# binary pass/fail via /v1/balance. This scorer adds risk differentiation.
+scorers:
+  - name: stripe-key-scope
+    rule_ids:
+      - np.stripe.1
+    modifiers:
+      # --- Static: restricted key prefix detection ---
+      - name: restricted-key-prefix
+        priority: 70
+        match_group:
+          name: key
+          matches: '^rk_live_'
+        delta: -25
+
+      # --- Dynamic (M3, only when --score-scope) ---
+
+      # charges_enabled: true — account can process real payments
+      - name: charges-enabled-live
+        priority: 90
+        http:
+          method: GET
+          url: https://api.stripe.com/v1/account
+          auth:
+            type: basic
+            secret_group: "key"
+        fires_when:
+          json_path_equals:
+            path: ".charges_enabled"
+            value: true
+        set_score: 95
+
+      # charges_enabled: false — account not yet live
+      - name: charges-disabled
+        priority: 80
+        http:
+          method: GET
+          url: https://api.stripe.com/v1/account
+          auth:
+            type: basic
+            secret_group: "key"
+        fires_when:
+          json_path_equals:
+            path: ".charges_enabled"
+            value: false
+        set_score: 30

--- a/pkg/scoring/scorers/stripe.yaml
+++ b/pkg/scoring/scorers/stripe.yaml
@@ -4,17 +4,18 @@
 #   np.stripe.1 — live key (sk_live_, rk_live_): base_score 90
 #
 # The "key" named capture group from the detection rule is used for both
-# static prefix checks and basic auth injection in HTTP modifiers.
+# static prefix checks and bearer auth injection in HTTP modifiers.
 #
 # API documentation:
 #   GET /v1/account (charges_enabled, country, business_profile):
 #     https://docs.stripe.com/api/accounts/retrieve
-#   GET /v1/balance (available, pending):
-#     https://docs.stripe.com/api/balance/balance_retrieve
 #
-# Stripe uses Basic Auth: the API key is the password, username is empty.
-# The existing YAML validator (pkg/validator/validators/stripe.yaml) handles
-# binary pass/fail via /v1/balance. This scorer adds risk differentiation.
+# Stripe accepts both Basic Auth and Bearer token authentication.
+# Bearer is used here to avoid username/password mapping ambiguity.
+#
+# Note: restricted keys (rk_live_) require explicit Account read permission
+# to access /v1/account. Keys without that permission receive 403; the
+# dynamic modifier is skipped and the static delta -25 still applies.
 scorers:
   - name: stripe-key-scope
     rule_ids:
@@ -37,7 +38,7 @@ scorers:
           method: GET
           url: https://api.stripe.com/v1/account
           auth:
-            type: basic
+            type: bearer
             secret_group: "key"
         fires_when:
           json_path_equals:
@@ -52,7 +53,7 @@ scorers:
           method: GET
           url: https://api.stripe.com/v1/account
           auth:
-            type: basic
+            type: bearer
             secret_group: "key"
         fires_when:
           json_path_equals:


### PR DESCRIPTION
## Summary

- Add YAML scorer (`stripe-key-scope`) for `np.stripe.1` live keys with static prefix detection (`rk_live_` delta -25) and dynamic `charges_enabled` checks via `/v1/account` (set_score 95 when live, set_score 30 when not)
- Lower `np.stripe.2` (test keys) base_score from 50 to 5 — test mode keys access only synthetic data
- Raise `np.stripe.3` (publishable keys) base_score from 5 to 10 — intentionally public but identifies a real merchant account

### Scoring matrix

| Key type | `--score-scope` off | charges_enabled=true | charges_enabled=false |
|---|---|---|---|
| `sk_live_` | 90 (base) | 95 (critical) | 30 (low) |
| `rk_live_` | 65 (base - 25) | 70 (high) | 5 (info) |
| `sk_test_` / `rk_test_` | 5 (base) | — | — |
| `pk_live_` / `pk_test_` | 10 (base) | — | — |

Closes LAB-3381

## Test plan

- [x] Static scorer tests: `TestRunScan_StripeLiveKey_BaseScore`, `TestRunScan_StripeRestrictedKey_DeltaMinus25`
- [x] Dynamic scorer tests with mock HTTP: `TestStripeScorer_ChargesEnabledLive_SetScore95`, `TestStripeScorer_ChargesDisabled_SetScore30`, `TestStripeScorer_RestrictedKey_ChargesEnabled_Score70`, `TestStripeScorer_RestrictedKey_ChargesDisabled_Score5`, `TestStripeScorer_ScopeDisabled_DynamicSkipped`
- [x] Scorer alignment test: `TestBuiltinScorers_AllRuleIDsReferenceExtantRules`
- [x] Existing validator unaffected: `TestLoadEmbeddedValidators`
- [x] Full suite: `./pkg/scoring/`, `./pkg/rule/`, `./pkg/validator/`, `./cmd/titus/` all pass