### PR TITLE
ci(graphify): add code knowledge graph workflow

### DIFF
--- a/.github/workflows/graphify-graph.yml
+++ b/.github/workflows/graphify-graph.yml
@@ -33,6 +33,6 @@ permissions:
 
 jobs:
   graph:
-    uses: praetorian-inc/public-workflows/.github/workflows/graphify-graph.yml@c81c12f1aae98b023e1aea25077c58a628857b6c  # v2.9.0
+    uses: praetorian-inc/public-workflows/.github/workflows/graphify-graph.yml@0c602372f3d0d038912dd08e159ecc83954a4995  # v2.9.3
     permissions:
       contents: read

--- a/.github/workflows/graphify-graph.yml
+++ b/.github/workflows/graphify-graph.yml
@@ -1,0 +1,38 @@
+name: graphify-graph
+# Builds this repo's code knowledge graph via the shared public-workflows reusable
+# and publishes graph.json as an artifact, so engineers and agents query the latest
+# graph without each rebuilding it locally. graphify has no server — the graph is a
+# file (graphify-out/graph.json) that `graphify query` reads.
+#
+# Pull the latest graph:
+#   gh run download -R praetorian-inc/titus -n titus-graph -D graphify-out
+#
+# Code-only & keyless: respects the committed .graphifyignore (no LLM API key needed).
+# Bump the reusable pin in lockstep with the GRAPHIFY_VERSION pin in the
+# praetorian-claude monorepo Makefile.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '.graphifyignore'
+      - '.github/workflows/graphify-graph.yml'
+  pull_request:
+    paths:
+      - '.graphifyignore'
+      - '.github/workflows/graphify-graph.yml'
+  schedule:
+    - cron: '0 7 * * 1'   # Mondays 07:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  graph:
+    uses: praetorian-inc/public-workflows/.github/workflows/graphify-graph.yml@c81c12f1aae98b023e1aea25077c58a628857b6c  # v2.9.0
+    permissions:
+      contents: read

--- a/.graphifyignore
+++ b/.graphifyignore
@@ -1,0 +1,39 @@
+# graphify: keyless code-only baseline.
+# Docs/papers/images require an LLM backend for semantic extraction; excluding
+# them keeps the graph buildable with no API key and matches what the keyless
+# per-commit hook (`graphify update`, AST-only) maintains. To include docs later,
+# remove the relevant lines and rebuild with a backend (e.g. GEMINI_API_KEY).
+
+# Transient / generated noise (.json is treated as code by graphify)
+.claude/
+*-lock.json
+package-lock.json
+*.lock
+
+# Images
+*.png
+*.jpg
+*.jpeg
+*.gif
+*.svg
+*.webp
+*.ico
+*.bmp
+*.tiff
+
+# Docs / papers (graphify DOC_EXTENSIONS + PAPER_EXTENSIONS)
+*.md
+*.mdx
+*.qmd
+*.txt
+*.rst
+*.html
+*.yaml
+*.yml
+*.pdf
+# extra office/text formats (not graphify-native, excluded for cleanliness)
+*.doc
+*.docx
+*.ppt
+*.pptx
+*.csv


### PR DESCRIPTION
## What

Adds a `graphify-graph` CI workflow that builds this repo's **code knowledge graph** and publishes `graph.json` as a downloadable artifact (`titus-graph`).

- **Thin caller** of the shared `praetorian-inc/public-workflows/.github/workflows/graphify-graph.yml@v2.9.0` reusable (SHA-pinned). No bespoke build logic here.
- **`.graphifyignore`** added so the **keyless, code-only** extraction never routes a doc/image/pdf to graphify's semantic (LLM) extractor — which would abort the build with "no LLM API key found". No secrets required; uses only the auto-granted `GITHUB_TOKEN`.

## Why

[graphify](https://github.com/safishamsi/graphify) turns the repo's tree-sitter AST into a queryable nodes/edges graph. For codebase-understanding questions (how does X work, what calls Y, trace a data flow) it returns a scoped subgraph far smaller than raw grep — useful to engineers and to AI assistants.

The graph has **no server**: it's just a file. CI builds it once; everyone pulls the same artifact instead of rebuilding locally. The `praetorian-claude` monorepo's SessionStart hook **auto-discovers** any repo that commits `graphify-graph.yml` and downloads the artifact into `titus/graphify-out/graph.json` automatically — no monorepo change needed.

## Triggers

- `push` to `main` touching `**/*.go`, `go.mod`, `go.sum`, `.graphifyignore`, or the workflow itself
- `pull_request` touching `.graphifyignore` / the workflow (validates changes)
- weekly schedule (Mon 07:00 UTC) + `workflow_dispatch`

## Rollout

Follows the already-merged guard-core pattern (praetorian-inc/guard#5950). Pilot batch: titus, julius, pius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)