### PR TITLE
ci: retry Docker Hub pull in static-binary test to fix flakiness

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -88,20 +88,31 @@ jobs:
         fi
 
     - name: Test in Alpine container
+      env:
+        ALPINE: alpine:3.19@sha256:6baf43584bcb78f2e5847d1de515f23499913ac9f12bdf834811a3145eb11ca1
       run: |
-        # Pull Alpine image
-        docker pull alpine:3.19@sha256:6baf43584bcb78f2e5847d1de515f23499913ac9f12bdf834811a3145eb11ca1
+        # Pull Alpine once, with retry+backoff. Anonymous Docker Hub pulls flake
+        # ("context deadline exceeded") and rate-limit on shared runner IPs.
+        for attempt in 1 2 3 4 5; do
+          docker pull "$ALPINE" && break
+          echo "docker pull failed (attempt $attempt/5), retrying in $((attempt * 10))s..."
+          sleep $((attempt * 10))
+        done
+        # Fail fast if every retry failed (image not in local cache).
+        docker image inspect "$ALPINE" > /dev/null
+
+        # Subsequent runs hit the local image cache — no further Docker Hub calls.
 
         # Test --help works
         docker run --rm \
           -v "$(pwd)/titus-static:/titus:ro" \
-          alpine:3.19@sha256:6baf43584bcb78f2e5847d1de515f23499913ac9f12bdf834811a3145eb11ca1 /titus --help
+          "$ALPINE" /titus --help
 
         # Test actual scan (use :memory: since SQLite requires CGO)
         docker run --rm \
           -v "$(pwd)/titus-static:/titus:ro" \
           -v "$(pwd)/testdata:/testdata:ro" \
-          alpine:3.19@sha256:6baf43584bcb78f2e5847d1de515f23499913ac9f12bdf834811a3145eb11ca1 /titus scan /testdata/secrets --format=json --output :memory:
+          "$ALPINE" /titus scan /testdata/secrets --format=json --output :memory:
 
     - name: Upload static binary on success
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2


### PR DESCRIPTION
## Problem

The **Static Binary Container Test (No CGO)** job in `integration.yml` intermittently fails at its first step:

```
Error response from daemon: Get "https://registry-1.docker.io/v2/": context deadline exceeded
##[error]Process completed with exit code 1.
```

Example: https://github.com/praetorian-inc/titus/actions/runs/27113603827/job/80016052829

This is a **transient Docker Hub failure**, not a code problem — anonymous pulls flake and rate-limit on GitHub's shared runner IP ranges. The job hit Docker Hub three times (one `docker pull` + two `docker run` that re-resolve the pinned digest), so any of the three could trip the timeout.

## Fix

- Wrap `docker pull` in a **retry + linear backoff** loop (5 attempts: 10s/20s/30s/40s).
- Pull the pinned Alpine digest **once up front**; the two `docker run` calls now hit the local image cache instead of re-resolving against Docker Hub, so the job touches the network exactly once.
- `docker image inspect` after the loop **fails fast** if every retry was exhausted.
- Pinned digest moved to an `ALPINE` env var (single source of truth, no behavior change).

No secrets required. If rate-limiting persists despite retries, a follow-up can add `docker/login-action` with org Docker Hub creds to raise the pull-limit ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)