### PR TITLE
test(validator): harness hardening follow-ups (PR #264 review)

### DIFF
--- a/pkg/validator/embed.go
+++ b/pkg/validator/embed.go
@@ -7,18 +7,25 @@ import (
 	"path/filepath"
 )
 
-// NOTE: The following legacy-format files are embedded and loadable but produce
-// validators with empty RuleIDs that never match at runtime. They use an older
-// schema (e.g. rule_id/valid_status keys instead of rule_ids/success_codes) and
-// are flagged for future migration:
+// NOTE: The following files are embedded but produce no active validators at
+// runtime. They are skipped by the schema contract test (yaml_contract_test.go).
+// Two distinct classes:
 //
-//   - blynk.yaml
-//   - clay.yaml
-//   - clojars.yaml
-//   - codeclimate.yaml
-//   - curl.yaml
+// Empty-RuleID legacy (load but validators have empty rule_ids, never match):
 //
-// The schema contract test (yaml_contract_test.go) skips these intentionally.
+//   - blynk.yaml       — rule_id/valid_status schema (old format)
+//   - clay.yaml        — request/response/classification schema (old format)
+//   - clojars.yaml     — no rule_ids field (old format)
+//   - codeclimate.yaml — root-level entry, no validators: wrapper (old format)
+//   - curl.yaml        — placeholder/template with empty URLs
+//
+// Zero-validator / non-HTTP (register nothing at runtime):
+//
+//   - adobe.yaml       — all validators commented out; needs client_id+secret pair not yet supported
+//   - bitbucket.yaml   — all validators commented out; needs username+app_password not yet supported
+//   - cratesio.yaml    — old kingfisher http.request schema, not current validators: format
+//   - credentials.yaml — entropy/length validator schema, not HTTP-based
+//   - firebase.yaml    — all validators commented out; FCM legacy API deprecated June 2024
 //
 //go:embed validators/*.yaml
 var validatorsFS embed.FS

--- a/pkg/validator/internal/vcrtest/vcrtest.go
+++ b/pkg/validator/internal/vcrtest/vcrtest.go
@@ -40,11 +40,49 @@ func getCore() (*scanner.Core, error) {
 	return sharedCore, coreInitErr
 }
 
+// options holds per-cassette configuration for Client.
+type options struct {
+	// keepResponseBody controls whether the response body is persisted in the
+	// cassette. Defaults to false (bodies are elided) to minimise cassette
+	// attack surface. Only validators that inspect the response body need to opt
+	// in via WithResponseBody.
+	//
+	// Default-elide rationale: most validators decide on HTTP status code alone,
+	// so storing response bodies adds noise and a potential secret-leak surface
+	// with no benefit. A body-matcher that forgets WithResponseBody will fail
+	// loudly on replay (body is empty) rather than silently (secret in body).
+	keepResponseBody bool
+}
+
+// Option is a functional option for Client.
+type Option func(*options)
+
+// WithResponseBody opts the cassette into persisting response bodies.
+// Use this only for validators whose Match logic inspects the response body
+// (i.e. those with SuccessBodyContains or FailureBodyContains set in their
+// YAML definition). The body is still scanned and redacted before being
+// written to the cassette.
+//
+// Without this option, response bodies are blanked in record mode and
+// Content-Length is dropped, so nothing leaks into testdata/.
+func WithResponseBody() Option {
+	return func(o *options) {
+		o.keepResponseBody = true
+	}
+}
+
 // Client returns an *http.Client bound to the named cassette.
 // cassettePath is relative to the test file, e.g. "testdata/huggingface/valid".
 // The recorder is stopped via t.Cleanup.
-func Client(t *testing.T, cassettePath string) *http.Client {
+//
+// By default, response bodies are elided from cassettes (see WithResponseBody).
+func Client(t *testing.T, cassettePath string, opts ...Option) *http.Client {
 	t.Helper()
+
+	o := &options{}
+	for _, opt := range opts {
+		opt(o)
+	}
 
 	isRecording := os.Getenv("RECORD") == "1"
 	mode := recorder.ModeReplayOnly
@@ -56,7 +94,7 @@ func Client(t *testing.T, cassettePath string) *http.Client {
 		cassettePath,
 		recorder.WithMode(mode),
 		recorder.WithSkipRequestLatency(true),
-		recorder.WithHook(redactHook(isRecording), recorder.AfterCaptureHook),
+		recorder.WithHook(redactHook(isRecording, o.keepResponseBody), recorder.AfterCaptureHook),
 		recorder.WithMatcher(secretInsensitiveMatcher),
 	)
 	if err != nil {
@@ -89,11 +127,16 @@ func Client(t *testing.T, cassettePath string) *http.Client {
 // misconfiguration where the secret was never sent and the cassette would be
 // trivially "clean" but also useless.
 //
+// keepResponseBody controls whether the response body is persisted (Fix 2):
+// if false the body is blanked and Content-Length dropped before the cassette
+// is written. Most validators check status code alone; body-matchers opt in
+// via WithResponseBody so that a forgotten opt-in fails loudly on replay.
+//
 // If SECRET_PLAINTEXT is set the hook also performs a backup literal scrub of
 // the raw value and its URL-encoded form AFTER the dogfood assertion has already
 // passed. It does not satisfy or bypass the assertion; it is an extra safety net
 // for service-specific token formats the scanner's ruleset may not cover.
-func redactHook(isRecording bool) recorder.HookFunc {
+func redactHook(isRecording bool, keepResponseBody bool) recorder.HookFunc {
 	return func(i *cassette.Interaction) error {
 		if !isRecording {
 			// Replay mode: no-op.
@@ -121,12 +164,13 @@ func redactHook(isRecording bool) recorder.HookFunc {
 				requestFields = append(requestFields, field{"request.header." + h, v})
 			}
 		}
-		// NOTE: response headers are intentionally not scanned for new secrets.
+		// NOTE: response headers are intentionally not scanned for new secrets yet.
 		// A credential that appears only in a response header (e.g. X-Subject-Token,
 		// Set-Cookie) would not be detected by the dogfood assertion and would not
-		// be redacted below. This is a known gap tracked for a future follow-up.
-		responseFields := []field{
-			{"response.body", i.Response.Body},
+		// be redacted below. This will be addressed in a follow-up (Fix 4).
+		responseFields := []field{}
+		if keepResponseBody {
+			responseFields = append(responseFields, field{"response.body", i.Response.Body})
 		}
 
 		// scanAndCollect scans a field and returns all matched secret strings.
@@ -189,11 +233,19 @@ func redactHook(isRecording bool) recorder.HookFunc {
 			allSecrets = append(allSecrets, pt)
 		}
 
-		// Perform all redactions across every text field.
+		// Elide response body if not needed (secure-by-default).
+		if !keepResponseBody {
+			i.Response.Body = ""
+			i.Response.Headers.Del("Content-Length")
+		}
+
+		// Perform all redactions across every text field that is kept.
 		for _, secret := range allSecrets {
 			i.Request.URL = redactIn(i.Request.URL, secret)
 			i.Request.Body = redactIn(i.Request.Body, secret)
-			i.Response.Body = redactIn(i.Response.Body, secret)
+			if keepResponseBody {
+				i.Response.Body = redactIn(i.Response.Body, secret)
+			}
 			for h, vals := range i.Request.Headers {
 				for idx, v := range vals {
 					i.Request.Headers[h][idx] = redactIn(v, secret)

--- a/pkg/validator/internal/vcrtest/vcrtest.go
+++ b/pkg/validator/internal/vcrtest/vcrtest.go
@@ -52,6 +52,10 @@ type options struct {
 	// with no benefit. A body-matcher that forgets WithResponseBody will fail
 	// loudly on replay (body is empty) rather than silently (secret in body).
 	keepResponseBody bool
+
+	// matcher overrides the default secretInsensitiveMatcher for the cassette.
+	// Useful for the rare validator that routes by query string rather than path.
+	matcher cassette.MatcherFunc
 }
 
 // Option is a functional option for Client.
@@ -71,17 +75,34 @@ func WithResponseBody() Option {
 	}
 }
 
+// WithMatcher replaces the default secretInsensitiveMatcher for this cassette.
+// Use when the validator routes to different backend endpoints based on query
+// parameters (e.g. a single path but different resource IDs in the query).
+// The provided matcher receives the live request and the recorded cassette
+// request and should return true when they are logically equivalent.
+func WithMatcher(fn cassette.MatcherFunc) Option {
+	return func(o *options) {
+		o.matcher = fn
+	}
+}
+
 // Client returns an *http.Client bound to the named cassette.
 // cassettePath is relative to the test file, e.g. "testdata/huggingface/valid".
 // The recorder is stopped via t.Cleanup.
 //
 // By default, response bodies are elided from cassettes (see WithResponseBody).
+// By default, request matching uses secretInsensitiveMatcher (see WithMatcher).
 func Client(t *testing.T, cassettePath string, opts ...Option) *http.Client {
 	t.Helper()
 
 	o := &options{}
 	for _, opt := range opts {
 		opt(o)
+	}
+
+	matcherFn := cassette.MatcherFunc(secretInsensitiveMatcher)
+	if o.matcher != nil {
+		matcherFn = o.matcher
 	}
 
 	isRecording := os.Getenv("RECORD") == "1"
@@ -95,7 +116,7 @@ func Client(t *testing.T, cassettePath string, opts ...Option) *http.Client {
 		recorder.WithMode(mode),
 		recorder.WithSkipRequestLatency(true),
 		recorder.WithHook(redactHook(isRecording, o.keepResponseBody), recorder.AfterCaptureHook),
-		recorder.WithMatcher(secretInsensitiveMatcher),
+		recorder.WithMatcher(matcherFn),
 	)
 	if err != nil {
 		t.Fatalf("vcrtest: new recorder: %v", err)
@@ -263,25 +284,28 @@ func redactHook(isRecording bool, keepResponseBody bool) recorder.HookFunc {
 }
 
 // secretInsensitiveMatcher matches a live request against a recorded one by
-// comparing HTTP method and URL path only.
+// comparing HTTP method, host, URL path, and raw query string.
 //
-// This is intentionally loose: validators that pass the secret as a query
-// parameter or in the body will use Placeholder as the token value during
-// replay, so the live URL and cassette URL differ in the query string.
-// Matching on method+path ensures those requests still replay correctly.
+// Matching on query is safe with secret redaction: in record mode the hook
+// replaces every detected secret token with Placeholder in the cassette URL,
+// and the test passes Placeholder as the token value during replay, so live and
+// cassette query strings agree. A stray UN-redacted secret in the query causes
+// a replay MISS, surfacing the problem instead of silently hiding it.
 //
-// NOTE: validators that use query parameters for *routing* (i.e. different
-// paths are chosen based on the secret value) cannot be matched by this
-// default matcher and need a per-cassette custom matcher.
+// Previous behaviour matched path only, which (a) could mask a leaked secret
+// in the query string and (b) broke validators that hit the same path multiple
+// times with different queries.
+//
+// Use WithMatcher to override this behaviour for the rare case where routing is
+// determined by query parameters that should not be compared literally.
 func secretInsensitiveMatcher(r *http.Request, i cassette.Request) bool {
-	return r.Method == i.Method && r.URL.Path == reqURLPath(i.URL)
-}
-
-// reqURLPath parses rawURL and returns just the path component.
-func reqURLPath(rawURL string) string {
-	u, err := url.Parse(rawURL)
+	iu, err := url.Parse(i.URL)
 	if err != nil {
-		return rawURL
+		// Fallback: compare raw URL strings on parse failure.
+		return r.Method == i.Method && r.URL.String() == i.URL
 	}
-	return u.Path
+	return r.Method == i.Method &&
+		r.URL.Host == iu.Host &&
+		r.URL.Path == iu.Path &&
+		r.URL.RawQuery == iu.RawQuery
 }

--- a/pkg/validator/internal/vcrtest/vcrtest.go
+++ b/pkg/validator/internal/vcrtest/vcrtest.go
@@ -137,21 +137,17 @@ func Client(t *testing.T, cassettePath string, opts ...Option) *http.Client {
 // is no live secret to redact, and mutating cassette interactions during replay
 // would corrupt the round-trip.
 //
-// In record mode the hook uses the Titus scanner (dogfood) to detect secrets
-// in every text field of the interaction and replaces each detected token with
-// Placeholder. URL-encoded variants of each token are also replaced so that
-// query-string secrets do not survive encoding.
-//
-// Dogfood assertion: if the scanner finds zero matches across all request auth
-// material (URL + request headers + request body), the hook returns an error
-// so the recorder refuses to write the cassette. This guards against silent
-// misconfiguration where the secret was never sent and the cassette would be
-// trivially "clean" but also useless.
-//
-// keepResponseBody controls whether the response body is persisted (Fix 2):
-// if false the body is blanked and Content-Length dropped before the cassette
-// is written. Most validators check status code alone; body-matchers opt in
-// via WithResponseBody so that a forgotten opt-in fails loudly on replay.
+// In record mode the hook:
+//  1. Scans request auth material (URL + request headers + request body) for
+//     secrets using the Titus scanner. Dogfood assertion: zero matches is fatal,
+//     guarding against silent misconfiguration.
+//  2. Scans response header VALUES for new secrets (a credential minted only into
+//     a response header, e.g. Set-Cookie or X-Subject-Token, would otherwise
+//     survive into the cassette). Response headers are always scanned.
+//  3. If keepResponseBody is true, scans the response body for additional secrets;
+//     if false, blanks the body and drops Content-Length (secure-by-default).
+//  4. Redacts all detected secrets (and their URL-encoded variants) across all
+//     text fields that are persisted.
 //
 // If SECRET_PLAINTEXT is set the hook also performs a backup literal scrub of
 // the raw value and its URL-encoded form AFTER the dogfood assertion has already
@@ -184,14 +180,6 @@ func redactHook(isRecording bool, keepResponseBody bool) recorder.HookFunc {
 			for _, v := range vals {
 				requestFields = append(requestFields, field{"request.header." + h, v})
 			}
-		}
-		// NOTE: response headers are intentionally not scanned for new secrets yet.
-		// A credential that appears only in a response header (e.g. X-Subject-Token,
-		// Set-Cookie) would not be detected by the dogfood assertion and would not
-		// be redacted below. This will be addressed in a follow-up (Fix 4).
-		responseFields := []field{}
-		if keepResponseBody {
-			responseFields = append(responseFields, field{"response.body", i.Response.Body})
 		}
 
 		// scanAndCollect scans a field and returns all matched secret strings.
@@ -237,12 +225,26 @@ func redactHook(isRecording bool, keepResponseBody bool) recorder.HookFunc {
 				"(RECORD=1 SECRET_PLAINTEXT=<key> make record-fixtures SVC=<service>)")
 		}
 
-		// Collect secrets from response fields as well (they may differ from
-		// those in the request, e.g. a refresh token returned in the body).
+		// Collect secrets from response headers. A credential minted only into a
+		// response header (e.g. Set-Cookie, X-Subject-Token) would not be caught by
+		// the dogfood assertion (which is REQUEST-only by design) and would survive
+		// into the cassette if not explicitly scanned here.
+		// Note: response headers are always scanned regardless of keepResponseBody;
+		// even when the body is elided, response headers are persisted in the cassette.
 		allSecrets := make([]string, len(requestSecrets))
 		copy(allSecrets, requestSecrets)
-		for _, f := range responseFields {
-			secrets, scanErr := scanAndCollect(f)
+		for h, vals := range i.Response.Headers {
+			for _, v := range vals {
+				secrets, scanErr := scanAndCollect(field{"response.header." + h, v})
+				if scanErr != nil {
+					return scanErr
+				}
+				allSecrets = append(allSecrets, secrets...)
+			}
+		}
+		// Collect secrets from the response body only when it is kept.
+		if keepResponseBody {
+			secrets, scanErr := scanAndCollect(field{"response.body", i.Response.Body})
 			if scanErr != nil {
 				return scanErr
 			}

--- a/pkg/validator/internal/vcrtest/vcrtest_test.go
+++ b/pkg/validator/internal/vcrtest/vcrtest_test.go
@@ -366,3 +366,38 @@ func TestWithMatcher_Override(t *testing.T) {
 
 	require.NotNil(t, o.matcher, "WithMatcher must set options.matcher")
 }
+
+// ---- Fix 4: Response header secret detection ----
+
+// TestRedactHook_RecordMode_ResponseHeaderSecret verifies that a secret that
+// appears ONLY in a response header value (e.g. Set-Cookie, X-Subject-Token)
+// is detected and redacted. Previously this was a gap: response header values
+// were not scanned for new secrets.
+func TestRedactHook_RecordMode_ResponseHeaderSecret(t *testing.T) {
+	hook := redactHook(true, false)
+
+	i := &cassette.Interaction{
+		Request: cassette.Request{
+			Method:  "GET",
+			URL:     "https://example.com/api/validate",
+			Headers: make(http.Header),
+		},
+		Response: cassette.Response{
+			Code:    200,
+			Body:    "",
+			Headers: make(http.Header),
+		},
+	}
+	// Secret only in a request header (satisfies dogfood assertion).
+	i.Request.Headers.Set("Authorization", "Bearer "+testSecret)
+	// Additional secret minted into a response header only.
+	i.Response.Headers.Set("X-Subject-Token", testSecret)
+
+	err := hook(i)
+
+	require.NoError(t, err)
+	assert.NotContains(t, i.Response.Headers.Get("X-Subject-Token"), testSecret,
+		"response header must not contain the plaintext secret after redaction")
+	assert.Contains(t, i.Response.Headers.Get("X-Subject-Token"), Placeholder,
+		"response header must contain Placeholder after redaction")
+}

--- a/pkg/validator/internal/vcrtest/vcrtest_test.go
+++ b/pkg/validator/internal/vcrtest/vcrtest_test.go
@@ -50,7 +50,7 @@ func makeInteraction(secretInURL, secretInReqBody, secretInRespBody, secretInHea
 // it must not modify any fields and must return nil even when fields contain
 // detector-visible secrets.
 func TestRedactHook_ReplayMode(t *testing.T) {
-	hook := redactHook(false)
+	hook := redactHook(false, false)
 
 	i := makeInteraction(testSecret, testSecret, testSecret, testSecret)
 	origURL := i.Request.URL
@@ -71,7 +71,7 @@ func TestRedactHook_ReplayMode(t *testing.T) {
 // custom auth header (Authorization: Bearer <token>) is detected and replaced
 // with Placeholder in the cassette.
 func TestRedactHook_RecordMode_HeaderSecret(t *testing.T) {
-	hook := redactHook(true)
+	hook := redactHook(true, false)
 
 	i := makeInteraction("", "", "", testSecret)
 	// URL and bodies are benign so the secret is only in the header.
@@ -89,7 +89,7 @@ func TestRedactHook_RecordMode_HeaderSecret(t *testing.T) {
 // TestRedactHook_RecordMode_URLQuerySecret verifies that a secret carried as a
 // URL query parameter is redacted, including its percent-encoded form.
 func TestRedactHook_RecordMode_URLQuerySecret(t *testing.T) {
-	hook := redactHook(true)
+	hook := redactHook(true, false)
 
 	// Embed the secret in the URL query string (plain form).
 	i := &cassette.Interaction{
@@ -116,7 +116,7 @@ func TestRedactHook_RecordMode_URLQuerySecret(t *testing.T) {
 // TestRedactHook_RecordMode_RequestBodySecret verifies that a secret embedded
 // in the request body is replaced with Placeholder.
 func TestRedactHook_RecordMode_RequestBodySecret(t *testing.T) {
-	hook := redactHook(true)
+	hook := redactHook(true, false)
 
 	i := makeInteraction("", testSecret, "", "")
 
@@ -130,9 +130,10 @@ func TestRedactHook_RecordMode_RequestBodySecret(t *testing.T) {
 }
 
 // TestRedactHook_RecordMode_ResponseBodySecret verifies that a secret that
-// appears only in the response body is also redacted.
+// appears in the response body is redacted when WithResponseBody is used.
+// Without that option the body is elided entirely (see TestRedactHook_RecordMode_ResponseBodyElided).
 func TestRedactHook_RecordMode_ResponseBodySecret(t *testing.T) {
-	hook := redactHook(true)
+	hook := redactHook(true, true /* keepResponseBody */)
 
 	// Put the secret in the request header (so dogfood assertion passes) and
 	// also in the response body (so we can verify response-body redaction).
@@ -152,7 +153,7 @@ func TestRedactHook_RecordMode_ResponseBodySecret(t *testing.T) {
 // error. This ensures misconfigured recording (e.g. tests that never send a
 // real credential) fail loudly rather than producing a trivially-clean cassette.
 func TestRedactHook_RecordMode_DogfoodAssertion(t *testing.T) {
-	hook := redactHook(true)
+	hook := redactHook(true, false)
 
 	// No secret in URL, headers, or request body — scanner will find nothing.
 	i := &cassette.Interaction{
@@ -183,7 +184,7 @@ func TestRedactHook_RecordMode_DogfoodAssertion(t *testing.T) {
 func TestRedactHook_RecordMode_SecretPlaintextBackup(t *testing.T) {
 	t.Setenv("SECRET_PLAINTEXT", testSecret)
 
-	hook := redactHook(true)
+	hook := redactHook(true, false)
 
 	i := makeInteraction("", "", "", testSecret)
 
@@ -198,7 +199,7 @@ func TestRedactHook_RecordMode_SecretPlaintextBackup(t *testing.T) {
 // secret in a URL query parameter is also replaced. The scanner detects the
 // raw form; the hook then replaces both the raw and URL-encoded variants.
 func TestRedactHook_RecordMode_EncodedURLSecret(t *testing.T) {
-	hook := redactHook(true)
+	hook := redactHook(true, false)
 
 	// Percent-encode the secret as it would appear in a real URL.
 	// The hook must redact both the raw scanner match and the encoded form.
@@ -242,7 +243,7 @@ func TestRedactHook_RecordMode_NoSecretPlaintext(t *testing.T) {
 	// Explicitly unset SECRET_PLAINTEXT to confirm it is optional.
 	t.Setenv("SECRET_PLAINTEXT", "")
 
-	hook := redactHook(true)
+	hook := redactHook(true, false)
 
 	i := makeInteraction("", "", "", testSecret)
 
@@ -250,4 +251,44 @@ func TestRedactHook_RecordMode_NoSecretPlaintext(t *testing.T) {
 
 	require.NoError(t, err, "recording must succeed with scanner detection even without SECRET_PLAINTEXT")
 	assert.NotContains(t, i.Request.Headers.Get("Authorization"), testSecret)
+}
+
+// TestRedactHook_RecordMode_ResponseBodyElided verifies that by default
+// (keepResponseBody=false) the response body is blanked and Content-Length
+// is removed even when a secret was present. This is the secure-by-default
+// behaviour: nothing from the response body leaks into testdata/.
+func TestRedactHook_RecordMode_ResponseBodyElided(t *testing.T) {
+	hook := redactHook(true, false /* keepResponseBody=false */)
+
+	// Secret in auth header (satisfies dogfood) and in response body.
+	i := makeInteraction("", "", testSecret, testSecret)
+	i.Response.Headers.Set("Content-Length", "50")
+
+	err := hook(i)
+
+	require.NoError(t, err)
+	assert.Empty(t, i.Response.Body,
+		"response body must be blanked when keepResponseBody is false")
+	assert.Empty(t, i.Response.Headers.Get("Content-Length"),
+		"Content-Length must be dropped when response body is elided")
+}
+
+// TestRedactHook_RecordMode_ResponseBodyKept verifies that when
+// keepResponseBody=true (WithResponseBody option) the body is retained and
+// any secret within it is redacted.
+func TestRedactHook_RecordMode_ResponseBodyKept(t *testing.T) {
+	hook := redactHook(true, true /* keepResponseBody=true */)
+
+	// Secret in auth header (satisfies dogfood) and in response body.
+	i := makeInteraction("", "", testSecret, testSecret)
+
+	err := hook(i)
+
+	require.NoError(t, err)
+	assert.NotEmpty(t, i.Response.Body,
+		"response body must be retained when keepResponseBody is true")
+	assert.NotContains(t, i.Response.Body, testSecret,
+		"secret must be redacted from response body")
+	assert.Contains(t, i.Response.Body, Placeholder,
+		"Placeholder must appear in response body after redaction")
 }

--- a/pkg/validator/internal/vcrtest/vcrtest_test.go
+++ b/pkg/validator/internal/vcrtest/vcrtest_test.go
@@ -292,3 +292,77 @@ func TestRedactHook_RecordMode_ResponseBodyKept(t *testing.T) {
 	assert.Contains(t, i.Response.Body, Placeholder,
 		"Placeholder must appear in response body after redaction")
 }
+
+// ---- Fix 3: Matcher tests ----
+
+// TestSecretInsensitiveMatcher_SameMethodHostPathQuery verifies that the
+// matcher returns true when method, host, path, and raw query all match.
+func TestSecretInsensitiveMatcher_SameMethodHostPathQuery(t *testing.T) {
+	req, err := http.NewRequest("GET", "https://api.example.com/v1/users?token="+Placeholder, nil)
+	require.NoError(t, err)
+
+	cassReq := cassette.Request{
+		Method: "GET",
+		URL:    "https://api.example.com/v1/users?token=" + Placeholder,
+	}
+
+	assert.True(t, secretInsensitiveMatcher(req, cassReq),
+		"matcher must return true when method, host, path, and query all agree")
+}
+
+// TestSecretInsensitiveMatcher_DifferentQuery verifies that the matcher returns
+// false when the query string differs. This prevents two requests to the same
+// path but different query parameters from being treated as equivalent.
+func TestSecretInsensitiveMatcher_DifferentQuery(t *testing.T) {
+	req, err := http.NewRequest("GET", "https://api.example.com/v1/users?token=TokenA", nil)
+	require.NoError(t, err)
+
+	cassReq := cassette.Request{
+		Method: "GET",
+		URL:    "https://api.example.com/v1/users?token=TokenB",
+	}
+
+	assert.False(t, secretInsensitiveMatcher(req, cassReq),
+		"matcher must return false when query strings differ")
+}
+
+// TestSecretInsensitiveMatcher_DifferentHost verifies that the matcher returns
+// false when the host differs, even if path and query are the same.
+func TestSecretInsensitiveMatcher_DifferentHost(t *testing.T) {
+	req, err := http.NewRequest("GET", "https://api.example.com/v1/users", nil)
+	require.NoError(t, err)
+
+	cassReq := cassette.Request{
+		Method: "GET",
+		URL:    "https://other.example.com/v1/users",
+	}
+
+	assert.False(t, secretInsensitiveMatcher(req, cassReq),
+		"matcher must return false when hosts differ")
+}
+
+// TestSecretInsensitiveMatcher_DifferentMethod verifies that the matcher returns
+// false when the HTTP method differs.
+func TestSecretInsensitiveMatcher_DifferentMethod(t *testing.T) {
+	req, err := http.NewRequest("POST", "https://api.example.com/v1/users?token="+Placeholder, nil)
+	require.NoError(t, err)
+
+	cassReq := cassette.Request{
+		Method: "GET",
+		URL:    "https://api.example.com/v1/users?token=" + Placeholder,
+	}
+
+	assert.False(t, secretInsensitiveMatcher(req, cassReq),
+		"matcher must return false when methods differ")
+}
+
+// TestWithMatcher_Override verifies that WithMatcher replaces the default
+// secretInsensitiveMatcher for the cassette. We test by ensuring a custom
+// matcher is wired into the options struct via the functional option.
+func TestWithMatcher_Override(t *testing.T) {
+	o := &options{}
+	customMatcher := func(r *http.Request, i cassette.Request) bool { return true }
+	WithMatcher(customMatcher)(o)
+
+	require.NotNil(t, o.matcher, "WithMatcher must set options.matcher")
+}

--- a/pkg/validator/yaml_contract_test.go
+++ b/pkg/validator/yaml_contract_test.go
@@ -35,15 +35,21 @@ func TestAllEmbeddedYAMLValidators_SchemaValid(t *testing.T) {
 		"api_key": true,
 	}
 
-	// legacyFiles use an incompatible schema format (old kingfisher/blynk formats).
+	// legacyFiles use an incompatible schema format (old kingfisher/blynk formats)
+	// or are intentional placeholder / disabled files with zero active validators.
 	// They produce empty or broken ValidatorsConfig entries and are excluded
 	// until migrated to the current schema.
 	legacyFiles := map[string]bool{
+		"adobe.yaml":       true, // placeholder: needs client_id+secret pair, not supported yet
+		"bitbucket.yaml":   true, // placeholder: needs username+app_password, not supported yet
 		"blynk.yaml":       true, // rule_id/valid_status schema
 		"clay.yaml":        true, // request/response/classification schema
 		"clojars.yaml":     true, // no rule_ids field
 		"codeclimate.yaml": true, // root-level entry, no validators: wrapper
+		"cratesio.yaml":    true, // old kingfisher http.request schema
+		"credentials.yaml": true, // entropy-based validator schema, not HTTP
 		"curl.yaml":        true, // placeholder/template, empty URLs
+		"firebase.yaml":    true, // disabled: FCM legacy API deprecated/shut down
 	}
 
 	for _, e := range entries {
@@ -65,12 +71,29 @@ func TestAllEmbeddedYAMLValidators_SchemaValid(t *testing.T) {
 			t.Fatalf("%s: parse: %v", e.Name(), err)
 		}
 
+		// A non-legacy file that parses to zero validators is almost certainly
+		// a wrong-root YAML or an empty definition that silently passed before.
+		if len(cfg.Validators) < 1 {
+			t.Errorf("%s: defines no validators (len=0); add to legacyFiles if intentional", e.Name())
+			continue // skip per-validator assertions when there are none
+		}
+
 		for _, d := range cfg.Validators {
 			if len(d.RuleIDs) == 0 {
 				t.Errorf("%s/%s: empty rule_ids", e.Name(), d.Name)
 			}
 			if !knownAuth[d.HTTP.Auth.Type] {
 				t.Errorf("%s/%s: bad auth type %q (want one of: bearer, basic, header, query, api_key, none, or empty)", e.Name(), d.Name, d.HTTP.Auth.Type)
+			}
+			// Auth type "header" requires header_name to identify the target header.
+			// Without it, applyAuth returns an error at runtime (http.go:153).
+			if d.HTTP.Auth.Type == "header" && d.HTTP.Auth.HeaderName == "" {
+				t.Errorf("%s/%s: auth type=header requires header_name", e.Name(), d.Name)
+			}
+			// Auth type "query" requires query_param to name the URL parameter.
+			// Without it, applyAuth returns an error at runtime (http.go:159).
+			if d.HTTP.Auth.Type == "query" && d.HTTP.Auth.QueryParam == "" {
+				t.Errorf("%s/%s: auth type=query requires query_param", e.Name(), d.Name)
 			}
 			if len(d.HTTP.SuccessCodes) == 0 {
 				t.Errorf("%s/%s: no success_codes", e.Name(), d.Name)


### PR DESCRIPTION
## Validator test-harness hardening (follow-ups from PR #264)

Batches the non-deferred follow-up items from the #264 reviews. **Scope is strictly the harness + its tests — no validator definitions are modified** (verified: only `vcrtest.go`, `vcrtest_test.go`, `yaml_contract_test.go`, and a comment-only update to `embed.go`).

### Fixes
1. **Contract-test assertions** (`yaml_contract_test.go`) — assert ≥1 validator per non-legacy file; enforce `header_name` when `auth.type: header` and `query_param` when `auth.type: query` (Codex + Gemini). No active validators were malformed; five inert files (commented-out placeholders / non-HTTP / old-schema: `adobe`, `bitbucket`, `cratesio`, `credentials`, `firebase`) were added to the skip set — they register **zero** validators at runtime, so nothing functional changed.
2. **Response-body elision** (`vcrtest.go`) — default no longer persists response bodies; `WithResponseBody()` opts in for body-matching validators (which then get scanned+redacted). Secure-by-default: most validators decide on status code → empty body → nothing to leak.
3. **Matcher tightening** (`vcrtest.go`) — `secretInsensitiveMatcher` now matches method + host + path + raw query (was path-only). Fixes Gemini's leak-masking concern and supports validators that hit the same path with different queries. `WithMatcher()` override added for routing-by-query edge cases.
4. **Response-header secret scanning** (`vcrtest.go`) — response header values are now scanned for *new* secrets in record mode and redacted (closes the `X-Subject-Token`/`Set-Cookie` gap). Dogfood assertion stays request-only.

### Policy reaffirmed
Pre-existing validator definitions are **left alone** — the contract test *skips* non-conforming files (read-only `continue`), it never edits them. Validator changes only happen under an explicit ticket.

### Tests
+8 unit tests (372 total). All assert secret **absence** (raw + encoded) and the elision/matcher/header behaviors. Build / `go vet` / gofmt / race / `make scan-fixtures` all clean.

### Deferred follow-ups (tracked, not in this PR)
- `WithMatcher` integration-level test (only option-wiring is unit-tested today).
- `Content-Length` not recomputed when a kept response body shrinks after redaction (advisory in cassettes; pre-existing behavior).
- Legacy/empty-schema YAML migration (the 10 documented inert files) — needs per-validator rule_ids + ground-truth; belongs with the validator effort.
