### PR TITLE
feat(validator): add Exa validator + context-aware header scanning (LAB-4068)

### DIFF
--- a/pkg/validator/exa_cassette_test.go
+++ b/pkg/validator/exa_cassette_test.go
@@ -1,0 +1,23 @@
+// pkg/validator/exa_cassette_test.go
+//
+// VCR replay tests for the exa-api-key validator (LAB-4068).
+// These tests skip gracefully when cassettes have not been recorded yet.
+//
+// To record:
+//
+//	SECRET_PLAINTEXT=<exa_api_key> RECORD=1 make record-fixtures SVC=exa
+package validator
+
+import (
+	"testing"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+)
+
+func Test_exa_Valid(t *testing.T) {
+	runCassetteCase(t, "exa.yaml", "kingfisher.exa.1", "testdata/exa/valid", types.StatusValid)
+}
+
+func Test_exa_Invalid(t *testing.T) {
+	runCassetteCase(t, "exa.yaml", "kingfisher.exa.1", "testdata/exa/invalid", types.StatusInvalid)
+}

--- a/pkg/validator/internal/vcrtest/vcrtest.go
+++ b/pkg/validator/internal/vcrtest/vcrtest.go
@@ -207,6 +207,9 @@ func redactHook(isRecording bool, keepResponseBody bool) recorder.HookFunc {
 				// Also collect each non-empty capture group so the bare secret
 				// (e.g. the UUID from "x-api-key: <uuid>") is included in the
 				// redaction set even when detection required surrounding context.
+				// All current rule capture groups are >= 8 chars (e.g. the Exa UUID is 36),
+				// so no min-length guard is needed here; revisit if a rule introduces a
+				// very short (1-2 char) capture group that could cause spurious ReplaceAll.
 				for _, g := range m.Groups {
 					if len(g) > 0 {
 						secrets = append(secrets, string(g))

--- a/pkg/validator/internal/vcrtest/vcrtest.go
+++ b/pkg/validator/internal/vcrtest/vcrtest.go
@@ -176,14 +176,24 @@ func redactHook(isRecording bool, keepResponseBody bool) recorder.HookFunc {
 			{"request.url", i.Request.URL},
 			{"request.body", i.Request.Body},
 		}
-		// Include all request header values in request auth material.
+		// Include all request headers in request auth material as "Name: Value" so
+		// context-dependent rules (e.g. kingfisher.exa.1 which requires an x-api-key
+		// keyword near the UUID) fire correctly. Scanning the bare header value alone
+		// would miss those rules because the keyword context would be absent.
 		for h, vals := range i.Request.Headers {
 			for _, v := range vals {
-				requestFields = append(requestFields, field{"request.header." + h, v})
+				requestFields = append(requestFields, field{"request.header." + h, h + ": " + v})
 			}
 		}
 
 		// scanAndCollect scans a field and returns all matched secret strings.
+		//
+		// It collects BOTH the full match (Snippet.Matching, which may include keyword
+		// context like "x-api-key: <uuid>") AND each non-empty positional capture group
+		// (Groups[i]). This is required for context-dependent rules (e.g. kingfisher.exa.1)
+		// where detection fires on the contextual form but the actual secret is in a
+		// capture group (the bare UUID). Including the capture group ensures redactIn
+		// scrubs the bare secret from field values even though detection required context.
 		scanAndCollect := func(f field) ([]string, error) {
 			result, scanErr := core.Scan(f.content, f.name)
 			if scanErr != nil {
@@ -193,6 +203,14 @@ func redactHook(isRecording bool, keepResponseBody bool) recorder.HookFunc {
 			for _, m := range result.Matches {
 				if len(m.Snippet.Matching) > 0 {
 					secrets = append(secrets, string(m.Snippet.Matching))
+				}
+				// Also collect each non-empty capture group so the bare secret
+				// (e.g. the UUID from "x-api-key: <uuid>") is included in the
+				// redaction set even when detection required surrounding context.
+				for _, g := range m.Groups {
+					if len(g) > 0 {
+						secrets = append(secrets, string(g))
+					}
 				}
 			}
 			return secrets, nil
@@ -236,7 +254,7 @@ func redactHook(isRecording bool, keepResponseBody bool) recorder.HookFunc {
 		copy(allSecrets, requestSecrets)
 		for h, vals := range i.Response.Headers {
 			for _, v := range vals {
-				secrets, scanErr := scanAndCollect(field{"response.header." + h, v})
+				secrets, scanErr := scanAndCollect(field{"response.header." + h, h + ": " + v})
 				if scanErr != nil {
 					return scanErr
 				}

--- a/pkg/validator/internal/vcrtest/vcrtest_test.go
+++ b/pkg/validator/internal/vcrtest/vcrtest_test.go
@@ -492,6 +492,8 @@ func TestRedactHook_RecordMode_ContextDependentHeaderSecret(t *testing.T) {
 	//     capture group (not just Snippet.Matching) is included in the redaction set.
 	assert.NotContains(t, i.Request.Headers.Get("x-api-key"), exaExampleKey,
 		"x-api-key header value must not contain the bare UUID after capture-group redaction")
+	assert.Contains(t, i.Request.Headers.Get("x-api-key"), Placeholder,
+		"x-api-key header must contain Placeholder after capture-group redaction")
 }
 
 // TestRedactHook_RecordMode_SelfContainedTokenStillWorks is a regression test

--- a/pkg/validator/internal/vcrtest/vcrtest_test.go
+++ b/pkg/validator/internal/vcrtest/vcrtest_test.go
@@ -444,3 +444,72 @@ func TestMinimizeInteraction_StripsHeadersPreservesEssentials(t *testing.T) {
 	assert.Equal(t, int64(len(i.Request.Body)), i.Request.ContentLength, "request ContentLength must equal len(body)")
 	assert.Equal(t, int64(len(i.Response.Body)), i.Response.ContentLength, "response ContentLength must equal len(body)")
 }
+
+// ---- Fix 5: Context-aware header scanning + capture-group redaction ----
+
+// exaExampleKey is the public example key from kingfisher.exa.1's examples list.
+// It is NOT a real credential; the rule's own documentation uses this value.
+// The pattern requires context (exa/x-api-key keyword) — scanning the bare UUID
+// alone would yield no match, which is the bug this test exercises.
+const exaExampleKey = "3f5a9c1e-2b4d-4a6f-8c10-1d2e3f4a5b6c"
+
+// TestRedactHook_RecordMode_ContextDependentHeaderSecret verifies that a secret
+// carried in an x-api-key request header (Exa-style, requires context to match)
+// is detected via the reconstructed "Name: Value" form and that the bare UUID
+// capture group is redacted from the header value.
+//
+// Before the fix, scanning the bare value ("3f5a9c1e-...") yielded no match
+// because kingfisher.exa.1 requires an "x-api-key" keyword near the UUID.
+// The fix reconstructs "x-api-key: 3f5a9c1e-..." before scanning, which fires
+// the rule, and then redacts using the capture group (bare UUID) not the full
+// match, so the bare UUID is scrubbed from the header value.
+func TestRedactHook_RecordMode_ContextDependentHeaderSecret(t *testing.T) {
+	hook := redactHook(true, false)
+
+	i := &cassette.Interaction{
+		Request: cassette.Request{
+			Method:  "POST",
+			URL:     "https://api.exa.ai/answer",
+			Body:    `{"query":"ping","text":false}`,
+			Headers: make(http.Header),
+		},
+		Response: cassette.Response{
+			Code:    200,
+			Body:    "",
+			Headers: make(http.Header),
+		},
+	}
+	// Secret is in x-api-key header — context-dependent: bare UUID alone is no match.
+	i.Request.Headers.Set("x-api-key", exaExampleKey)
+
+	err := hook(i)
+
+	// (a) Hook must NOT error: dogfood assertion satisfied because scanning
+	//     "x-api-key: 3f5a9c1e-..." fires the rule.
+	require.NoError(t, err, "context-dependent header secret must satisfy dogfood assertion")
+
+	// (b) The bare UUID must be scrubbed from the header value because the
+	//     capture group (not just Snippet.Matching) is included in the redaction set.
+	assert.NotContains(t, i.Request.Headers.Get("x-api-key"), exaExampleKey,
+		"x-api-key header value must not contain the bare UUID after capture-group redaction")
+}
+
+// TestRedactHook_RecordMode_SelfContainedTokenStillWorks is a regression test
+// confirming that the existing bare-value scanning path for self-contained tokens
+// (e.g. AKIA-style AWS keys, hf_-style HuggingFace tokens) continues to work
+// after the context-aware scanning change. The AWS fake key AKIADEADBEEFDEADBEEF
+// matches np.aws.1 without any surrounding context keyword.
+func TestRedactHook_RecordMode_SelfContainedTokenStillWorks(t *testing.T) {
+	hook := redactHook(true, false)
+
+	// testSecret (AKIADEADBEEFDEADBEEF) matches np.aws.1 on the bare value.
+	i := makeInteraction("", "", "", testSecret)
+
+	err := hook(i)
+
+	require.NoError(t, err, "self-contained token in header must still satisfy dogfood assertion")
+	assert.NotContains(t, i.Request.Headers.Get("Authorization"), testSecret,
+		"self-contained token must be redacted from Authorization header")
+	assert.Contains(t, i.Request.Headers.Get("Authorization"), Placeholder,
+		"Placeholder must appear after redaction of self-contained token")
+}

--- a/pkg/validator/testdata/exa/invalid.yaml
+++ b/pkg/validator/testdata/exa/invalid.yaml
@@ -1,0 +1,23 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 29
+        host: api.exa.ai
+        body: '{"query":"ping","text":false}'
+        url: https://api.exa.ai/answer
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers: {}
+        status: 401 Unauthorized
+        code: 401
+        duration: 0s

--- a/pkg/validator/testdata/exa/provenance.yaml
+++ b/pkg/validator/testdata/exa/provenance.yaml
@@ -1,0 +1,24 @@
+# Cassette provenance for Exa API key validator (LAB-4068)
+#
+# TODO: Fill in all fields at record time.
+# Run:
+#   SECRET_PLAINTEXT=<exa_api_key> RECORD=1 make record-fixtures SVC=exa
+# Then revoke the key at https://dashboard.exa.ai
+
+service: exa
+ticket: LAB-4068
+captured: TBD
+account_type: free
+key_revoked: TBD
+valid_response: {status: 200, discriminator: "HTTP status only (response body elided)"}
+invalid_response: {status: 401 or 403}
+notes: |
+  Recorded against https://api.exa.ai/answer with a throwaway free-tier API key.
+  Validation is status-code based (200=valid, 401/403=invalid); response body is
+  elided by the vcrtest harness (no WithResponseBody), so no account PII is stored.
+  kingfisher.exa.1 pattern: context-dependent UUID (requires exa/x-api-key keyword);
+  validator uses auth type=header, header_name=x-api-key, secret_group: "1"
+  (maps to positional Groups[0], the bare UUID capture).
+  The vcrtest harness scans request headers as "Name: Value" so the x-api-key
+  keyword context triggers the rule; capture-group redaction scrubs the bare UUID.
+  Cassettes are minimized (headers stripped, duration zeroed) via BeforeSaveHook.

--- a/pkg/validator/testdata/exa/provenance.yaml
+++ b/pkg/validator/testdata/exa/provenance.yaml
@@ -7,9 +7,9 @@
 
 service: exa
 ticket: LAB-4068
-captured: TBD
+captured: 2026-06-08
 account_type: free
-key_revoked: TBD
+key_revoked: true
 valid_response: {status: 200, discriminator: "HTTP status only (response body elided)"}
 invalid_response: {status: 401 or 403}
 notes: |

--- a/pkg/validator/testdata/exa/valid.yaml
+++ b/pkg/validator/testdata/exa/valid.yaml
@@ -1,0 +1,24 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 29
+        host: api.exa.ai
+        body: '{"query":"ping","text":false}'
+        url: https://api.exa.ai/answer
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        uncompressed: true
+        body: ""
+        headers: {}
+        status: 200 OK
+        code: 200
+        duration: 0s

--- a/pkg/validator/validators/exa.yaml
+++ b/pkg/validator/validators/exa.yaml
@@ -1,0 +1,20 @@
+validators:
+  - name: exa-api-key
+    rule_ids:
+      - kingfisher.exa.1
+    http:
+      method: POST
+      url: "https://api.exa.ai/answer"
+      auth:
+        type: header
+        header_name: x-api-key
+        # kingfisher.exa.1 uses one unnamed positional capture group containing
+        # the bare UUID; the cassette helper sets Groups[0] = Placeholder so
+        # replay works. Use "1" to reference positional group index 1.
+        secret_group: "1"
+      headers:
+        - {name: Content-Type, value: application/json}
+        - {name: Accept, value: application/json}
+      body: '{"query":"ping","text":false}'
+      success_codes: [200]
+      failure_codes: [401, 403]


### PR DESCRIPTION
## Add Exa API-key validator + context-aware header scanning (LAB-4068)

Second Phase-1 validator. Adds an active validator for `kingfisher.exa.1` and — because Exa surfaced a real gap — a harness improvement that benefits every context-dependent validator going forward.

Closes LAB-4068.

### What's added
- **`validators/exa.yaml`** — validates `kingfisher.exa.1` via `POST https://api.exa.ai/answer` (`x-api-key` header, static `{"query":"ping","text":false}` body; 200=valid, 401/403=invalid). `secret_group: "1"` (unnamed positional capture group).
- **`exa_cassette_test.go`** — valid + invalid replay tests using the shared `runCassetteCase` driver.
- **`testdata/exa/{valid,invalid}.yaml`** + `provenance.yaml`.

### Harness fix (the reason this validator touched shared code)
Exa's rule matches a bare UUID **only with context** (an `x-api-key`/`exa` keyword nearby). The dogfood scanner previously scanned each header value in isolation (bare UUID → no match → recording would fail). Fix in `vcrtest.go` `redactHook`:
1. Scan request/response headers as reconstructed `"Name: Value"` strings so context-dependent rules fire.
2. Collect **capture groups** (the bare secret) in addition to the full match, so redaction scrubs the bare UUID even when detection needed surrounding context.

Proven with the rule's own example key: bare UUID → no scanner match; `x-api-key: <uuid>` → match. This makes the harness correct for all future UUID/keyword-context validators, not just Exa.

### Recording & secret hygiene (verified)
- Recorded against the live API with a throwaway free-tier key; **key revoked** (`key_revoked: true`).
- Cassettes contain **zero** UUID patterns; the `x-api-key` header is stripped entirely by minimization (two independent leak guards: minimization + capture-group redaction).
- Response bodies elided; `make scan-fixtures` (Titus self-scan) = **0 findings**; replay tests pass with no network.

### No regression / scope discipline
- HuggingFace tests still pass (the header-scan change only affects record mode; replay unaffected).
- No pre-existing validator definitions or tests modified — only new files + the shared harness.
- Reviewed (backend-reviewer): approved; over-redaction risk assessed as none (all ruleset capture groups ≥8 chars; documented inline).
