### PR TITLE
feat(validator): add wandb validator + titus.wandb.1 rule + body-match support (LAB-4065)

### DIFF
--- a/pkg/rule/rules/weightsandbiases.yml
+++ b/pkg/rule/rules/weightsandbiases.yml
@@ -36,3 +36,37 @@ rules:
             - type: WordMatch
               words:
                 - '"username"'
+
+  - name: Weights and Biases API Key (v1)
+    id: titus.wandb.1
+    base_score: 55
+    pattern: |
+      (?xi)
+      \b
+      (
+        wandb_v1_[A-Za-z0-9_]{40,200}
+      )
+      \b
+    pattern_requirements:
+      min_digits: 1
+    confidence: high
+    min_entropy: 4.0
+    examples:
+      - "export WANDB_API_KEY=wandb_v1_ABC123def456GHI789jkl012MNO345pqr678STU901vwx234YZa567bcd890ef0"
+      - "wandb login wandb_v1_XYZ987wvu654TSR321qpo098NML765kji432HGF109edc876BAZ543yxw210vut"
+    validation:
+      type: Http
+      content:
+        request:
+          method: POST
+          url: "https://api.wandb.ai/graphql"
+          headers:
+            Authorization: "Basic {{ 'api:' | append: TOKEN | b64enc }}"
+            Content-Type: "application/json"
+          body: |
+            {"query":"query { viewer { id } }"}
+          response_matcher:
+            - report_response: true
+            - type: JsonValid
+            - type: WordMatch
+              words: ['"id"']

--- a/pkg/rule/weightsandbiases_test.go
+++ b/pkg/rule/weightsandbiases_test.go
@@ -1,0 +1,171 @@
+package rule
+
+import (
+	"testing"
+
+	"github.com/praetorian-inc/titus/pkg/matcher"
+	"github.com/praetorian-inc/titus/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTitusWandb1_Detection verifies the titus.wandb.1 rule correctly
+// detects the new wandb_v1_ key format and rejects unrelated inputs.
+//
+// This is the first titus.* rule; it covers the self-contained wandb_v1_ prefix
+// format which does not require keyword context (unlike kingfisher.wandb.1).
+func TestTitusWandb1_Detection(t *testing.T) {
+	loader := NewLoader()
+	rules, err := loader.LoadBuiltinRules()
+	require.NoError(t, err)
+
+	var wandbRule *types.Rule
+	for _, r := range rules {
+		if r.ID == "titus.wandb.1" {
+			wandbRule = r
+			break
+		}
+	}
+	require.NotNil(t, wandbRule, "titus.wandb.1 rule must exist in built-in rules")
+
+	m, err := matcher.NewPortableRegexp([]*types.Rule{wandbRule}, 0, nil)
+	require.NoError(t, err)
+
+	// fakeToken is a clearly synthetic wandb_v1_ token: 77 [A-Za-z0-9_] chars after the prefix.
+	const fakeToken = "wandb_v1_ABC123def456GHI789jkl012MNO345pqr678STU901vwx234YZa567bcd890ef"
+
+	testCases := []struct {
+		name        string
+		input       string
+		shouldMatch bool
+		// expectedGroup1, when non-empty, asserts that the first capture group
+		// equals this value.  Only checked when shouldMatch is true.
+		expectedGroup1 string
+	}{
+		// --- Positive cases ---
+		{
+			name:           "bare token with no surrounding keyword context",
+			input:          fakeToken,
+			shouldMatch:    true,
+			expectedGroup1: fakeToken,
+		},
+		{
+			name:           "token embedded in export statement",
+			input:          "export WANDB_API_KEY=" + fakeToken,
+			shouldMatch:    true,
+			expectedGroup1: fakeToken,
+		},
+		{
+			name:           "token in quoted config value",
+			input:          `api_key="` + fakeToken + `"`,
+			shouldMatch:    true,
+			expectedGroup1: fakeToken,
+		},
+		{
+			name:           "token in YAML-style assignment",
+			input:          "wandb_api_key: " + fakeToken,
+			shouldMatch:    true,
+			expectedGroup1: fakeToken,
+		},
+		{
+			name:           "token in wandb login command",
+			input:          "wandb login " + fakeToken,
+			shouldMatch:    true,
+			expectedGroup1: fakeToken,
+		},
+
+		// --- Negative cases ---
+		{
+			name:        "legacy 40-hex key without keyword context does not match",
+			input:       "872ab943740b34157041da2529fb160d89632710",
+			shouldMatch: false,
+		},
+		{
+			name:        "wandb_v1_ prefix with too-short body (38 chars, below 40 minimum) does not match",
+			input:       "wandb_v1_ABC123def456GHI789jkl012MNO345pqr678ST",
+			shouldMatch: false,
+		},
+		{
+			name:        "random UUID-style token without wandb_v1_ prefix does not match",
+			input:       "550e8400-e29b-41d4-a716-446655440000",
+			shouldMatch: false,
+		},
+		{
+			name:        "generic non-wandb_v1_ string does not match",
+			input:       "generic-non-wandb-token-1234567890-abcdef",
+			shouldMatch: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			matches, err := m.Match([]byte(tc.input))
+			require.NoError(t, err)
+
+			if tc.shouldMatch {
+				require.NotEmpty(t, matches, "expected titus.wandb.1 to match: %s", tc.input)
+				if tc.expectedGroup1 != "" {
+					require.NotEmpty(t, matches[0].Groups,
+						"expected capture group 1 to be present in match")
+					assert.Equal(t, tc.expectedGroup1, string(matches[0].Groups[0]),
+						"capture group 1 must equal the full wandb_v1_ token")
+				}
+			} else {
+				assert.Empty(t, matches, "expected no match from titus.wandb.1 for: %s", tc.input)
+			}
+		})
+	}
+}
+
+// TestTitusWandb1_NoKeywordContextRequired verifies that the titus.wandb.1
+// rule fires on a bare wandb_v1_ token with no surrounding "wandb" keyword.
+// This distinguishes it from kingfisher.wandb.1 which requires keyword context.
+func TestTitusWandb1_NoKeywordContextRequired(t *testing.T) {
+	loader := NewLoader()
+	rules, err := loader.LoadBuiltinRules()
+	require.NoError(t, err)
+
+	var wandbRule *types.Rule
+	for _, r := range rules {
+		if r.ID == "titus.wandb.1" {
+			wandbRule = r
+			break
+		}
+	}
+	require.NotNil(t, wandbRule, "titus.wandb.1 rule must exist")
+
+	m, err := matcher.NewPortableRegexp([]*types.Rule{wandbRule}, 0, nil)
+	require.NoError(t, err)
+
+	// Input contains ONLY the token — no "wandb" keyword anywhere in context.
+	// kingfisher.wandb.1 would require a keyword; titus.wandb.1 must not.
+	bareToken := "wandb_v1_XYZ987wvu654TSR321qpo098NML765kji432HGF109edc876BAZ543yxw210vut"
+	neutralContext := "SECRET_KEY=" + bareToken + " DATABASE_URL=postgres://localhost/db"
+
+	matches, err := m.Match([]byte(neutralContext))
+	require.NoError(t, err)
+	assert.NotEmpty(t, matches,
+		"titus.wandb.1 must fire on a wandb_v1_ token without a 'wandb' keyword in context")
+}
+
+// TestTitusWandb1_RuleMetadata verifies that the titus.wandb.1 rule is
+// properly loaded with the expected metadata fields.
+func TestTitusWandb1_RuleMetadata(t *testing.T) {
+	loader := NewLoader()
+	rules, err := loader.LoadBuiltinRules()
+	require.NoError(t, err)
+
+	var wandbRule *types.Rule
+	for _, r := range rules {
+		if r.ID == "titus.wandb.1" {
+			wandbRule = r
+			break
+		}
+	}
+	require.NotNil(t, wandbRule, "titus.wandb.1 rule must exist")
+
+	assert.Equal(t, "titus.wandb.1", wandbRule.ID)
+	assert.Equal(t, "Weights and Biases API Key (v1)", wandbRule.Name)
+	assert.NotEmpty(t, wandbRule.Pattern, "rule must have a non-empty pattern")
+	assert.NotEmpty(t, wandbRule.Examples, "rule must have at least one example")
+}

--- a/pkg/validator/cassette_http_test.go
+++ b/pkg/validator/cassette_http_test.go
@@ -36,6 +36,11 @@ import (
 // Skip behaviour: if not in RECORD mode and the cassette file (<cassette>.yaml)
 // does not exist, the test is skipped with a message showing the exact
 // one-command record invocation.
+//
+// Body-matching validators: if the YAML definition specifies success_body_contains
+// or failure_body_contains, vcrtest.WithResponseBody is automatically passed to
+// vcrtest.Client so the response body is retained in the cassette. Status-only
+// validators keep the default behaviour (response body elided).
 func runCassetteCase(t *testing.T, yamlFile, ruleID, cassette string, want types.ValidationStatus) {
 	t.Helper()
 
@@ -70,7 +75,13 @@ func runCassetteCase(t *testing.T, yamlFile, ruleID, cassette string, want types
 	require.NotNil(t, def, "no validator for rule %s found in %s", ruleID, yamlFile)
 
 	// Build the VCR-backed HTTP client.
-	client := vcrtest.Client(t, cassette)
+	// Body-matching validators (SuccessBodyContains or FailureBodyContains) need the
+	// response body retained in the cassette; status-only validators keep eliding it.
+	var clientOpts []vcrtest.Option
+	if def.HTTP.SuccessBodyContains != "" || def.HTTP.FailureBodyContains != "" {
+		clientOpts = append(clientOpts, vcrtest.WithResponseBody())
+	}
+	client := vcrtest.Client(t, cassette, clientOpts...)
 
 	// Determine the secret value fed into the Match.
 	//

--- a/pkg/validator/testdata/wandb/invalid.yaml
+++ b/pkg/validator/testdata/wandb/invalid.yaml
@@ -1,0 +1,24 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 35
+        host: api.wandb.ai
+        body: '{"query":"query { viewer { id } }"}'
+        url: https://api.wandb.ai/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 24
+        uncompressed: true
+        body: '{"data":{"viewer":null}}'
+        headers: {}
+        status: 200 OK
+        code: 200
+        duration: 0s

--- a/pkg/validator/testdata/wandb/provenance.yaml
+++ b/pkg/validator/testdata/wandb/provenance.yaml
@@ -7,9 +7,9 @@
 
 service: wandb
 ticket: LAB-4065
-captured: TBD
+captured: 2026-06-08
 account_type: free
-key_revoked: TBD
+key_revoked: true
 valid_response: {status: 200, discriminator: "HTTP 200 + body contains '\"id\"' (viewer non-null)"}
 invalid_response: {status: 200, discriminator: "HTTP 200 + body is '{\"data\":{\"viewer\":null}}' (viewer null)"}
 validation: >

--- a/pkg/validator/testdata/wandb/provenance.yaml
+++ b/pkg/validator/testdata/wandb/provenance.yaml
@@ -1,0 +1,31 @@
+# Cassette provenance for wandb API key validator (LAB-4065)
+#
+# TODO: Fill in captured/key_revoked fields at record time.
+# Run:
+#   SECRET_PLAINTEXT=<wandb_v1_token> RECORD=1 make record-fixtures SVC=wandb
+# Then revoke the key at https://wandb.ai/settings
+
+service: wandb
+ticket: LAB-4065
+captured: TBD
+account_type: free
+key_revoked: TBD
+valid_response: {status: 200, discriminator: "HTTP 200 + body contains '\"id\"' (viewer non-null)"}
+invalid_response: {status: 200, discriminator: "HTTP 200 + body is '{\"data\":{\"viewer\":null}}' (viewer null)"}
+validation: >
+  POST /graphql, basic auth api:TOKEN; wandb returns HTTP 200 for both valid and
+  invalid keys. Discriminator is the response body: valid yields
+  {"data":{"viewer":{"id":"..."}}} (viewer non-null, body contains '"id"');
+  invalid yields {"data":{"viewer":null}} (viewer null, body does not contain '"id"').
+  success_body_contains: '"id"' maps 200+body-has-id to StatusValid,
+  200+no-id to StatusInvalid via evaluateResponse. Response body is RETAINED
+  (WithResponseBody auto-enabled by runCassetteCase for body-matching validators).
+  Query deliberately uses viewer { id } only (no email/username) to minimise PII
+  stored in cassette; id is an opaque numeric identifier, not personal data.
+notes: |
+  kingfisher.wandb.1 (legacy 40-hex format) shares this validator via rule_ids but
+  has no recorded cassette — no legacy key was available. Test_wandb_CanValidateBothRuleIDs
+  documents that the rule_id is wired in the YAML without requiring a live recording.
+  New-format keys (titus.wandb.1, wandb_v1_* prefix) are the primary target.
+  Secret redacted to REDACTED_SECRET in cassettes via scanner-driven redaction.
+  Cassettes minimized (headers stripped, duration zeroed) via vcrtest BeforeSaveHook.

--- a/pkg/validator/testdata/wandb/provenance.yaml
+++ b/pkg/validator/testdata/wandb/provenance.yaml
@@ -10,15 +10,18 @@ ticket: LAB-4065
 captured: 2026-06-08
 account_type: free
 key_revoked: true
-valid_response: {status: 200, discriminator: "HTTP 200 + body contains '\"id\"' (viewer non-null)"}
-invalid_response: {status: 200, discriminator: "HTTP 200 + body is '{\"data\":{\"viewer\":null}}' (viewer null)"}
+valid_response: {status: 200, discriminator: "HTTP 200 + body contains '\"viewer\":{' (non-null authenticated viewer object)"}
+invalid_response: {status: 200 (unknown key) or 401 (revoked/malformed), discriminator: "200 body '{\"data\":{\"viewer\":null}}' lacks '\"viewer\":{'; or 401 caught by failure_codes"}
 validation: >
   POST /graphql, basic auth api:TOKEN; wandb returns HTTP 200 for both valid and
   invalid keys. Discriminator is the response body: valid yields
   {"data":{"viewer":{"id":"..."}}} (viewer non-null, body contains '"id"');
   invalid yields {"data":{"viewer":null}} (viewer null, body does not contain '"id"').
-  success_body_contains: '"id"' maps 200+body-has-id to StatusValid,
-  200+no-id to StatusInvalid via evaluateResponse. Response body is RETAINED
+  success_body_contains: '"viewer":{' maps 200+non-null-viewer to StatusValid,
+  200+viewer:null to StatusInvalid via evaluateResponse. Probed invalid space
+  (revoked/junk/malformed/empty keys): no invalid response contains '"viewer":{',
+  so no false positives; revoked/malformed keys return 401 (caught by failure_codes).
+  Response body is RETAINED
   (WithResponseBody auto-enabled by runCassetteCase for body-matching validators).
   Query deliberately uses viewer { id } only (no email/username) to minimise PII
   stored in cassette; id is an opaque numeric identifier, not personal data.

--- a/pkg/validator/testdata/wandb/valid.yaml
+++ b/pkg/validator/testdata/wandb/valid.yaml
@@ -1,0 +1,24 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 35
+        host: api.wandb.ai
+        body: '{"query":"query { viewer { id } }"}'
+        url: https://api.wandb.ai/graphql
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 45
+        uncompressed: true
+        body: '{"data":{"viewer":{"id":"VXNlcjo0MDQ4NDA5"}}}'
+        headers: {}
+        status: 200 OK
+        code: 200
+        duration: 0s

--- a/pkg/validator/validators/wandb.yaml
+++ b/pkg/validator/validators/wandb.yaml
@@ -1,0 +1,18 @@
+validators:
+  - name: wandb-api-key
+    rule_ids:
+      - kingfisher.wandb.1
+      - titus.wandb.1
+    http:
+      method: POST
+      url: "https://api.wandb.ai/graphql"
+      auth:
+        type: basic
+        username: api
+        secret_group: "1"
+      headers:
+        - {name: Content-Type, value: application/json}
+      body: '{"query":"query { viewer { id } }"}'
+      success_codes: [200]
+      success_body_contains: '"id"'
+      failure_codes: [401, 403]

--- a/pkg/validator/validators/wandb.yaml
+++ b/pkg/validator/validators/wandb.yaml
@@ -14,5 +14,11 @@ validators:
         - {name: Content-Type, value: application/json}
       body: '{"query":"query { viewer { id } }"}'
       success_codes: [200]
-      success_body_contains: '"id"'
+      # wandb returns HTTP 200 for BOTH valid and invalid keys; the body is the
+      # discriminator. Require a non-null authenticated viewer OBJECT ('"viewer":{')
+      # rather than the bare substring '"id"', which could theoretically appear in
+      # an error/trace field of a 200 response. Biases against FALSE POSITIVES.
+      #   Valid:   {"data":{"viewer":{"id":...}}}  -> contains '"viewer":{'
+      #   Invalid: {"data":{"viewer":null}}        -> does NOT -> StatusInvalid
+      success_body_contains: '"viewer":{'
       failure_codes: [401, 403]

--- a/pkg/validator/wandb_cassette_test.go
+++ b/pkg/validator/wandb_cassette_test.go
@@ -1,0 +1,51 @@
+// pkg/validator/wandb_cassette_test.go
+//
+// VCR replay tests for the wandb-api-key validator (LAB-4065).
+// These tests skip gracefully when cassettes have not been recorded yet.
+//
+// To record (new wandb_v1_ format key):
+//
+//	SECRET_PLAINTEXT=<wandb_v1_token> RECORD=1 make record-fixtures SVC=wandb
+package validator
+
+import (
+	"testing"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func Test_wandb_Valid(t *testing.T) {
+	runCassetteCase(t, "wandb.yaml", "titus.wandb.1", "testdata/wandb/valid", types.StatusValid)
+}
+
+func Test_wandb_Invalid(t *testing.T) {
+	runCassetteCase(t, "wandb.yaml", "titus.wandb.1", "testdata/wandb/invalid", types.StatusInvalid)
+}
+
+// Test_wandb_CanValidateBothRuleIDs asserts that the wandb validator wires both
+// rule IDs (the new titus.wandb.1 and the legacy kingfisher.wandb.1). No live
+// cassette is needed — CanValidate exercises only in-memory YAML parsing.
+//
+// Note: live cassettes for kingfisher.wandb.1 are deferred (no legacy 40-hex key
+// available for recording). This test documents that the rule_id is wired even
+// though its cassette recording is not yet included.
+func Test_wandb_CanValidateBothRuleIDs(t *testing.T) {
+	data, err := validatorsFS.ReadFile("validators/wandb.yaml")
+	require.NoError(t, err, "reading embedded wandb.yaml")
+
+	var cfg ValidatorsConfig
+	require.NoError(t, yaml.Unmarshal(data, &cfg), "parsing wandb.yaml")
+	require.NotEmpty(t, cfg.Validators, "wandb.yaml must define at least one validator")
+
+	v := NewHTTPValidator(cfg.Validators[0], nil)
+
+	assert.True(t, v.CanValidate("titus.wandb.1"),
+		"validator must handle titus.wandb.1 (new wandb_v1_ format)")
+	assert.True(t, v.CanValidate("kingfisher.wandb.1"),
+		"validator must handle kingfisher.wandb.1 (legacy 40-hex format, cassette deferred)")
+	assert.False(t, v.CanValidate("np.some.other.rule"),
+		"validator must not handle unrelated rule IDs")
+}


### PR DESCRIPTION
## Add wandb validator + new-format detection rule + body-match support (LAB-4065)

Third Phase-1 validator. Surfaced and closed a real **detection gap**: wandb now issues `wandb_v1_` keys, but the scanner only matched the legacy 40-hex format. Also adds the harness's first body-matching path.

Closes LAB-4065.

### What's added
- **New rule `titus.wandb.1`** (in `weightsandbiases.yml`) for the self-contained `wandb_v1_[A-Za-z0-9_]{40,200}` format. Legacy `kingfisher.wandb.1` left **byte-for-byte unchanged**. First `titus.*`-prefixed rule — provenance convention: `np.*`=noseyparker, `kingfisher.*`=kingfisher, `titus.*`=authored here. Rule IDs are free-form strings (no loader allowlist), confirmed safe.
- **`validators/wandb.yaml`** — validates BOTH `kingfisher.wandb.1` and `titus.wandb.1` via `POST https://api.wandb.ai/graphql`, basic auth `api:<key>`. Validation is format-agnostic at the HTTP layer, so one validator covers both formats.
- **Body-match support (new harness capability):** wandb returns **HTTP 200 for both valid and invalid** keys; the discriminator is the body (`viewer` populated vs `null`). So `success_body_contains: '"id"'` is used, and `runCassetteCase` now auto-enables `vcrtest.WithResponseBody()` for any body-matching validator (status-only validators like exa/huggingface keep eliding). wandb is the first body-matcher.
- **`titus.wandb.1` pattern tests** (`pkg/rule/weightsandbiases_test.go`) — positive (bare token, embedded, capture-group = full token, no-keyword-context), negative (legacy hex alone, too-short body, UUID, generic non-prefixed string).
- **Cassettes** + `provenance.yaml`.

### PII-minimal recording
- Validation query is `viewer { id }` (deliberately NOT `email username`) → the retained valid body is only `{"data":{"viewer":{"id":"<opaque node id>"}}}`. No email/username/name stored.
- Recorded with a throwaway free key; **key revoked** (`key_revoked: true`).
- Verified clean: no key in raw OR `base64("api:"+key)` form; basic-auth header stripped by minimization; `make scan-fixtures` = 0 findings.

### Both-format coverage
The validator handles legacy and new formats (rule_ids lists both; same endpoint; validation is format-agnostic). `Test_wandb_CanValidateBothRuleIDs` documents the wiring. A live legacy-format cassette is deferred (no legacy 40-hex key available to record) — documented in provenance.

### No regression / scope discipline
- exa + huggingface tests still pass (driver change is additive; status-only path unchanged).
- No pre-existing rule/validator/test modified — only additive new rule + new validator + the shared-driver enhancement.
- Reviewed (backend-reviewer): approved, no blocking issues. Rule + validator suites green (226 rule tests, full validator suite).
