### PR TITLE
fix(enum): include renames and copies in commit-metadata collection (--diff-filter=ARC)

### DIFF
--- a/pkg/enum/commit_metadata.go
+++ b/pkg/enum/commit_metadata.go
@@ -12,13 +12,17 @@ import (
 )
 
 // collectCommitMetadataForRepo runs git log to build a map of file path → commit metadata.
-// When firstAdded is true, uses --diff-filter=A to find the commit that first added each path.
+// When firstAdded is true, uses --diff-filter=ARC to find the commit that first
+// introduced each path — this includes Adds, Renames, and Copies. Rename detection
+// is on by default in git's log machinery, so a `git mv old new` is recorded as an
+// `R` entry rather than a delete + add; filtering on `A` alone would miss the
+// post-rename path and leave its blobs without commit metadata.
 // When false, finds the most recent commit that touched each path.
 func collectCommitMetadataForRepo(ctx context.Context, repoPath string, firstAdded bool) (map[string]*types.CommitMetadata, error) {
 	args := []string{"log", "--all",
 		"--format=%H%x00%an%x00%ae%x00%aI%x00%cn%x00%ce%x00%cI%x00%s", "--name-only"}
 	if firstAdded {
-		args = append(args, "--diff-filter=A")
+		args = append(args, "--diff-filter=ARC")
 	}
 
 	cmd := exec.CommandContext(ctx, "git", args...)

--- a/pkg/enum/commit_metadata_test.go
+++ b/pkg/enum/commit_metadata_test.go
@@ -1,0 +1,89 @@
+package enum
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+// TestCollectCommitMetadata_RenamedPath verifies that paths introduced by a
+// rename are still mapped to the introducing commit. Git's log machinery
+// reports `git mv old new` as a rename (`R`) rather than a delete + add, so
+// filtering on `--diff-filter=A` alone misses the post-rename path and leaves
+// every blob committed at that path without commit metadata. The filter must
+// also include `R` (and `C` for copies).
+func TestCollectCommitMetadata_RenamedPath(t *testing.T) {
+	skipIfNoGit(t)
+
+	tmpDir := t.TempDir()
+	initGitRepo(t, tmpDir)
+
+	// Add a file at the original path.
+	writeFile(t, filepath.Join(tmpDir, "old.txt"), "hello")
+	gitAddCommit(t, tmpDir, "Add old.txt")
+
+	// Rename it.
+	runGit(t, tmpDir, "mv", "old.txt", "new.txt")
+	runGit(t, tmpDir, "commit", "-m", "Rename to new.txt")
+
+	// Modify the renamed file so there's a post-rename commit too.
+	writeFile(t, filepath.Join(tmpDir, "new.txt"), "hello world")
+	gitAddCommit(t, tmpDir, "Update new.txt")
+
+	commitMap, err := collectCommitMetadataForRepo(context.Background(), tmpDir, true /* firstAdded */)
+	if err != nil {
+		t.Fatalf("collectCommitMetadataForRepo: %v", err)
+	}
+
+	if _, ok := commitMap["old.txt"]; !ok {
+		t.Errorf("expected old.txt in commit map, got keys: %v", keys(commitMap))
+	}
+	if _, ok := commitMap["new.txt"]; !ok {
+		t.Errorf("expected new.txt in commit map (rename target), got keys: %v", keys(commitMap))
+	}
+}
+
+// TestCollectCommitMetadata_PlainAdd verifies the unchanged behaviour for
+// regular file additions: every newly added path lands in the commit map
+// and is mapped to the commit that introduced it.
+func TestCollectCommitMetadata_PlainAdd(t *testing.T) {
+	skipIfNoGit(t)
+
+	tmpDir := t.TempDir()
+	initGitRepo(t, tmpDir)
+
+	writeFile(t, filepath.Join(tmpDir, "a.txt"), "a")
+	gitAddCommit(t, tmpDir, "Add a.txt")
+	writeFile(t, filepath.Join(tmpDir, "b.txt"), "b")
+	gitAddCommit(t, tmpDir, "Add b.txt")
+
+	commitMap, err := collectCommitMetadataForRepo(context.Background(), tmpDir, true)
+	if err != nil {
+		t.Fatalf("collectCommitMetadataForRepo: %v", err)
+	}
+
+	for _, want := range []string{"a.txt", "b.txt"} {
+		meta, ok := commitMap[want]
+		if !ok {
+			t.Errorf("expected %s in commit map, got keys: %v", want, keys(commitMap))
+			continue
+		}
+		if meta.CommitID == "" {
+			t.Errorf("%s: empty CommitID", want)
+		}
+		if meta.AuthorEmail == "" {
+			t.Errorf("%s: empty AuthorEmail", want)
+		}
+		if meta.AuthorTimestamp.IsZero() {
+			t.Errorf("%s: zero AuthorTimestamp", want)
+		}
+	}
+}
+
+func keys[K comparable, V any](m map[K]V) []K {
+	out := make([]K, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}


### PR DESCRIPTION
## Problem

`collectCommitMetadataForRepo` (in `pkg/enum/commit_metadata.go`) builds a map
of `file path → first-introducing commit` by running

```
git log --all --diff-filter=A --name-only ...
```

`--diff-filter=A` matches only "Added" entries. Git's log machinery has rename
detection on by default, so a `git mv old new` (or any rename heuristic match)
is recorded as a single `R` entry rather than a delete + add. The post-rename
path therefore never appears under `--diff-filter=A`, and `commitMap[<new-path>]`
is never populated.

The downstream effect: every blob committed at the post-rename path is enumerated
with `Commit: nil`, which then writes an empty `commit_hash` (and empty author /
committer / timestamp fields) into the SQLite `provenance` table. Findings from
those blobs lose their commit attribution entirely.

## Reproduction

```bash
$ git init repo && cd repo
$ git config user.email t@t && git config user.name t
$ mkdir old && echo v1 > old/file.txt && git add . && git commit -m v1
$ mkdir new && git mv old/file.txt new/file.txt && git commit -m rename
$ echo v2 > new/file.txt && git commit -am v2

$ git log --all --diff-filter=A --name-only
<commit-hash>

old/file.txt

$ git log --all --diff-filter=ARC --name-only
<rename-commit>

new/file.txt
<original-commit>

old/file.txt
```

Running `titus scan --git` against this repo produces a `provenance` row for the
post-rename blob with empty `commit_hash`. Any finding inside that blob loses its
commit metadata.

## Fix

Change the filter to `--diff-filter=ARC` so renames (`R`) and copies (`C`) are
treated as path introductions alongside adds (`A`). For renamed paths, the
introducing commit is correctly the rename commit; for copies it's the copy
commit. Behaviour for plain adds is unchanged.

## Tests

Two new tests in `pkg/enum/commit_metadata_test.go`:

1. `TestCollectCommitMetadata_RenamedPath` — builds a repo with an add, a
   rename, and a post-rename modification; asserts both `old.txt` and `new.txt`
   appear in the commit map. Fails on the current code (only `old.txt` shown);
   passes with `=ARC`.
2. `TestCollectCommitMetadata_PlainAdd` — regression check that the unchanged
   plain-add behaviour still maps each newly added path to the introducing
   commit with non-empty author/timestamp.

`make test` passes for the full `pkg/enum` package with the change applied.