### PR TITLE
feat(validator): Confluent Cloud API-key validator — Cloud + Cluster keys (LAB-4050)

### DIFF
--- a/pkg/validator/confluent.go
+++ b/pkg/validator/confluent.go
@@ -24,20 +24,44 @@ var confluentClientIDPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`(?i)(?:client[_-]?id|api[_-]?key)\s*[=:]\s*["'\s]?([A-Z0-9]{16})\b`),
 }
 
-// ConfluentValidator validates Confluent Cloud API-key credentials using Basic
-// authentication against the Confluent Cloud IAM API.
+// confluentClusterEndpointPattern matches a Confluent Dedicated cluster REST
+// endpoint (Bootstrap server URL). Example:
+//
+//	https://pkc-419q3.us-east4.gcp.confluent.cloud:443
+var confluentClusterEndpointPattern = regexp.MustCompile(
+	`https?://pkc-[a-z0-9]+\.[a-z0-9.-]+\.confluent\.cloud(?::\d+)?`,
+)
+
+// confluentLKCPattern matches a Confluent logical Kafka cluster ID.
+// Example: lkc-nvodzyv
+var confluentLKCPattern = regexp.MustCompile(`lkc-[a-z0-9]+`)
+
+// ConfluentValidator validates Confluent Cloud API-key credentials.
 //
 // Confluent API keys consist of two parts:
 //   - client_id: a 16-character uppercase alphanumeric key ID
 //   - secret:    a 64-character base64 string (confluent.2) or a cflt-prefixed
 //     token (confluent.3)
 //
-// Validation uses GET https://api.confluent.cloud/iam/v2/api-keys with
-// Authorization: Basic base64(client_id:secret). A 200 response means valid;
-// 401/403 means invalid; anything else is undetermined.
+// Two validation paths are supported:
+//
+//  1. Cloud/Global key path (default): GET https://api.confluent.cloud/iam/v2/api-keys
+//     Used when no cluster endpoint or lkc-id is found in the snippet context.
+//
+//  2. Cluster key path: GET {clusterEndpoint}/kafka/v3/clusters/{lkc_id}/topics
+//     Used when BOTH a cluster endpoint (pkc-...confluent.cloud) AND a logical
+//     cluster ID (lkc-...) are found in the snippet context.
+//
+// Status mapping for both paths:
+//
+//	200 -> Valid   (authenticated)
+//	403 -> Valid   (authenticated; key lacks authorization for this resource -- but the key is live)
+//	401 -> Invalid (authentication failed -- key is not active)
+//	any other -> Undetermined
 type ConfluentValidator struct {
-	client  *http.Client
-	baseURL string // overridable for tests; defaults to https://api.confluent.cloud
+	client         *http.Client
+	baseURL        string // overridable for tests; defaults to https://api.confluent.cloud
+	clusterBaseURL string // overridable for tests; replaces the extracted cluster endpoint
 }
 
 // NewConfluentValidator creates a Confluent API-key validator using the default HTTP client.
@@ -73,7 +97,7 @@ func (v *ConfluentValidator) CanValidate(ruleID string) bool {
 	return false
 }
 
-// Validate authenticates with the Confluent Cloud IAM API and maps the HTTP
+// Validate authenticates with the Confluent Cloud API and maps the HTTP
 // response to a ValidationStatus.
 //
 // Missing or incomplete credentials return StatusUndetermined without making an
@@ -89,10 +113,29 @@ func (v *ConfluentValidator) Validate(ctx context.Context, match *types.Match) (
 		), nil
 	}
 
+	// Attempt to extract cluster endpoint and lkc-id from snippet context.
+	// If BOTH are present we use the cluster validation path; otherwise we fall
+	// back to the cloud/global key path (no error -- it may simply be a global key).
+	clusterEndpoint, lkcID := v.extractClusterContext(match)
+
+	var url string
+	if clusterEndpoint != "" && lkcID != "" {
+		// Cluster key path: validate against the specific Kafka cluster.
+		// In tests, clusterBaseURL overrides the extracted endpoint so requests
+		// route to the httptest server instead of the real cluster host.
+		effectiveEndpoint := clusterEndpoint
+		if v.clusterBaseURL != "" {
+			effectiveEndpoint = v.clusterBaseURL
+		}
+		url = effectiveEndpoint + "/kafka/v3/clusters/" + lkcID + "/topics"
+	} else {
+		// Cloud/Global key path.
+		url = v.baseURL + "/iam/v2/api-keys"
+	}
+
 	// Build Basic auth header: base64(client_id:secret)
 	creds := base64.StdEncoding.EncodeToString([]byte(clientID + ":" + secret))
 
-	url := v.baseURL + "/iam/v2/api-keys"
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return types.NewValidationResult(
@@ -120,7 +163,15 @@ func (v *ConfluentValidator) Validate(ctx context.Context, match *types.Match) (
 			1.0,
 			fmt.Sprintf("valid Confluent API key for client %s", clientID),
 		), nil
-	case http.StatusUnauthorized, http.StatusForbidden:
+	case http.StatusForbidden:
+		// 403 means the credential authenticated successfully but the key lacks
+		// permission for this specific resource or cluster. The key is live.
+		return types.NewValidationResult(
+			types.StatusValid,
+			1.0,
+			fmt.Sprintf("valid Confluent API key for client %s (authenticated; insufficient cluster permissions)", clientID),
+		), nil
+	case http.StatusUnauthorized:
 		return types.NewValidationResult(
 			types.StatusInvalid,
 			1.0,
@@ -135,11 +186,39 @@ func (v *ConfluentValidator) Validate(ctx context.Context, match *types.Match) (
 	}
 }
 
+// extractClusterContext scans the snippet context for a Confluent cluster
+// endpoint (pkc-...confluent.cloud) and a logical cluster ID (lkc-...).
+// Both values must be present for the cluster validation path to be used;
+// if either is missing the caller falls back to the cloud/global key path.
+func (v *ConfluentValidator) extractClusterContext(match *types.Match) (clusterEndpoint, lkcID string) {
+	parts := [][]byte{
+		match.Snippet.Before,
+		match.Snippet.Matching,
+		match.Snippet.After,
+	}
+	for _, part := range parts {
+		if clusterEndpoint == "" {
+			if m := confluentClusterEndpointPattern.Find(part); m != nil {
+				clusterEndpoint = string(m)
+			}
+		}
+		if lkcID == "" {
+			if m := confluentLKCPattern.Find(part); m != nil {
+				lkcID = string(m)
+			}
+		}
+		if clusterEndpoint != "" && lkcID != "" {
+			break
+		}
+	}
+	return clusterEndpoint, lkcID
+}
+
 // extractCredentials extracts the Confluent client_id and secret from a match.
 //
 // Secret resolution (in priority order):
-//  1. NamedGroups["secret"] — set by confluent.2 (64-char base64 string)
-//  2. Groups[0]            — set by confluent.3 (full cflt… token)
+//  1. NamedGroups["secret"] -- set by confluent.2 (64-char base64 string)
+//  2. Groups[0]             -- set by confluent.3 (full cflt... token)
 //
 // Client ID resolution: scan Snippet.Before / .Matching / .After with
 // confluentClientIDPatterns (keyword-proximity or explicit label).
@@ -153,7 +232,7 @@ func (v *ConfluentValidator) extractCredentials(match *types.Match) (clientID, s
 			secret = string(s)
 		}
 	}
-	// Fallback: confluent.3 stores the full cflt… token in Groups[0].
+	// Fallback: confluent.3 stores the full cflt... token in Groups[0].
 	if secret == "" && len(match.Groups) > 0 && len(match.Groups[0]) > 0 {
 		secret = string(match.Groups[0])
 	}

--- a/pkg/validator/confluent.go
+++ b/pkg/validator/confluent.go
@@ -1,0 +1,177 @@
+// pkg/validator/confluent.go
+package validator
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+)
+
+// Pre-compiled patterns for extracting the Confluent key ID from snippet context.
+// The Confluent API key ID is a 16-character uppercase alphanumeric string
+// (e.g. "ABCD1234EFGH5678"). We look for it near keyword indicators.
+var confluentClientIDPatterns = []*regexp.Regexp{
+	// Keyword-proximity: confluent/ccloud/cpdev/kafka followed by the key ID.
+	regexp.MustCompile(`(?i)(?:confluent|ccloud|cpdev|kafka)[^A-Z0-9]{0,32}([A-Z0-9]{16})`),
+	// Explicit label: client_id= or api_key= followed by the key ID.
+	regexp.MustCompile(`(?i)(?:client[_-]?id|api[_-]?key)\s*[=:]\s*["'\s]?([A-Z0-9]{16})`),
+}
+
+// ConfluentValidator validates Confluent Cloud API-key credentials using Basic
+// authentication against the Confluent Cloud IAM API.
+//
+// Confluent API keys consist of two parts:
+//   - client_id: a 16-character uppercase alphanumeric key ID
+//   - secret:    a 64-character base64 string (confluent.2) or a cflt-prefixed
+//               token (confluent.3)
+//
+// Validation uses GET https://api.confluent.cloud/iam/v2/api-keys with
+// Authorization: Basic base64(client_id:secret). A 200 response means valid;
+// 401/403 means invalid; anything else is undetermined.
+type ConfluentValidator struct {
+	client  *http.Client
+	baseURL string // overridable for tests; defaults to https://api.confluent.cloud
+}
+
+// NewConfluentValidator creates a Confluent API-key validator using the default HTTP client.
+func NewConfluentValidator() *ConfluentValidator {
+	return &ConfluentValidator{
+		client:  http.DefaultClient,
+		baseURL: "https://api.confluent.cloud",
+	}
+}
+
+// NewConfluentValidatorWithClient creates a Confluent API-key validator with a
+// custom HTTP client (used in tests to inject a VCR or httptest client).
+func NewConfluentValidatorWithClient(client *http.Client) *ConfluentValidator {
+	return &ConfluentValidator{
+		client:  client,
+		baseURL: "https://api.confluent.cloud",
+	}
+}
+
+// Name returns the validator identifier.
+func (v *ConfluentValidator) Name() string {
+	return "confluent"
+}
+
+// CanValidate returns true for the three Confluent Cloud API-key rule IDs.
+func (v *ConfluentValidator) CanValidate(ruleID string) bool {
+	switch ruleID {
+	case "kingfisher.confluent.1",
+		"kingfisher.confluent.2",
+		"kingfisher.confluent.3":
+		return true
+	}
+	return false
+}
+
+// Validate authenticates with the Confluent Cloud IAM API and maps the HTTP
+// response to a ValidationStatus.
+//
+// Missing or incomplete credentials return StatusUndetermined without making an
+// HTTP request. The method never returns a non-nil error; network and protocol
+// failures are surfaced as StatusUndetermined with a descriptive message.
+func (v *ConfluentValidator) Validate(ctx context.Context, match *types.Match) (*types.ValidationResult, error) {
+	clientID, secret, err := v.extractCredentials(match)
+	if err != nil {
+		return types.NewValidationResult(
+			types.StatusUndetermined,
+			0,
+			fmt.Sprintf("cannot validate confluent credentials: %v", err),
+		), nil
+	}
+
+	// Build Basic auth header: base64(client_id:secret)
+	creds := base64.StdEncoding.EncodeToString([]byte(clientID + ":" + secret))
+
+	url := v.baseURL + "/iam/v2/api-keys"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return types.NewValidationResult(
+			types.StatusUndetermined,
+			0,
+			fmt.Sprintf("failed to build request: %v", err),
+		), nil
+	}
+	req.Header.Set("Authorization", "Basic "+creds)
+
+	resp, err := v.client.Do(req)
+	if err != nil {
+		return types.NewValidationResult(
+			types.StatusUndetermined,
+			0,
+			fmt.Sprintf("request failed: %v", err),
+		), nil
+	}
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return types.NewValidationResult(
+			types.StatusValid,
+			1.0,
+			fmt.Sprintf("valid Confluent API key for client %s", clientID),
+		), nil
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return types.NewValidationResult(
+			types.StatusInvalid,
+			1.0,
+			fmt.Sprintf("credentials rejected: HTTP %d", resp.StatusCode),
+		), nil
+	default:
+		return types.NewValidationResult(
+			types.StatusUndetermined,
+			0.5,
+			fmt.Sprintf("unexpected status code: HTTP %d", resp.StatusCode),
+		), nil
+	}
+}
+
+// extractCredentials extracts the Confluent client_id and secret from a match.
+//
+// Secret resolution (in priority order):
+//  1. NamedGroups["secret"] — set by confluent.2 (64-char base64 string)
+//  2. Groups[0]            — set by confluent.3 (full cflt… token)
+//
+// Client ID resolution: scan Snippet.Before / .Matching / .After with
+// confluentClientIDPatterns (keyword-proximity or explicit label).
+//
+// Returns an error when either piece is missing; callers map errors to
+// StatusUndetermined without making a network request.
+func (v *ConfluentValidator) extractCredentials(match *types.Match) (clientID, secret string, err error) {
+	// --- Extract secret ---
+	if match.NamedGroups != nil {
+		if s, ok := match.NamedGroups["secret"]; ok && len(s) > 0 {
+			secret = string(s)
+		}
+	}
+	// Fallback: confluent.3 stores the full cflt… token in Groups[0].
+	if secret == "" && len(match.Groups) > 0 && len(match.Groups[0]) > 0 {
+		secret = string(match.Groups[0])
+	}
+	if secret == "" {
+		return "", "", fmt.Errorf("secret not found in named groups or positional groups")
+	}
+
+	// --- Extract client_id from snippet context ---
+	snippetParts := [][]byte{
+		match.Snippet.Before,
+		match.Snippet.Matching,
+		match.Snippet.After,
+	}
+	for _, pattern := range confluentClientIDPatterns {
+		for _, part := range snippetParts {
+			if sub := pattern.FindSubmatch(part); len(sub) >= 2 {
+				return string(sub[1]), secret, nil
+			}
+		}
+	}
+
+	return "", "", fmt.Errorf("partial credentials: found secret but client_id not in snippet context")
+}

--- a/pkg/validator/confluent.go
+++ b/pkg/validator/confluent.go
@@ -17,9 +17,11 @@ import (
 // (e.g. "ABCD1234EFGH5678"). We look for it near keyword indicators.
 var confluentClientIDPatterns = []*regexp.Regexp{
 	// Keyword-proximity: confluent/ccloud/cpdev/kafka followed by the key ID.
-	regexp.MustCompile(`(?i)(?:confluent|ccloud|cpdev|kafka)[^A-Z0-9]{0,32}([A-Z0-9]{16})`),
+	// \b ensures we do not grab the leading 16 chars of a longer base64 string.
+	regexp.MustCompile(`(?i)(?:confluent|ccloud|cpdev|kafka)[^A-Z0-9]{0,32}([A-Z0-9]{16})\b`),
 	// Explicit label: client_id= or api_key= followed by the key ID.
-	regexp.MustCompile(`(?i)(?:client[_-]?id|api[_-]?key)\s*[=:]\s*["'\s]?([A-Z0-9]{16})`),
+	// \b prevents mis-grabbing the first 16 chars of a 64-char secret value.
+	regexp.MustCompile(`(?i)(?:client[_-]?id|api[_-]?key)\s*[=:]\s*["'\s]?([A-Z0-9]{16})\b`),
 }
 
 // ConfluentValidator validates Confluent Cloud API-key credentials using Basic

--- a/pkg/validator/confluent.go
+++ b/pkg/validator/confluent.go
@@ -28,7 +28,7 @@ var confluentClientIDPatterns = []*regexp.Regexp{
 // Confluent API keys consist of two parts:
 //   - client_id: a 16-character uppercase alphanumeric key ID
 //   - secret:    a 64-character base64 string (confluent.2) or a cflt-prefixed
-//               token (confluent.3)
+//     token (confluent.3)
 //
 // Validation uses GET https://api.confluent.cloud/iam/v2/api-keys with
 // Authorization: Basic base64(client_id:secret). A 200 response means valid;

--- a/pkg/validator/confluent_cassette_test.go
+++ b/pkg/validator/confluent_cassette_test.go
@@ -84,8 +84,15 @@ func runConfluentCassetteCase(t *testing.T, cassette string, want types.Validati
 		secretVal = []byte(pt)
 		clientIDVal = []byte(clientID)
 	} else {
+		// In replay mode the secret placeholder is fine as-is; the cassette
+		// matcher ignores the Authorization header. The client_id placeholder
+		// must be 16 chars of [A-Z0-9] so that confluentClientIDPatterns can
+		// extract it from Snippet.Before — vcrtest.Placeholder ("REDACTED_SECRET")
+		// is 15 chars with underscores and lowercase letters, which the regex
+		// \b-bounded pattern cannot match.
+		const replayClientID = "REDACTED0SECRET1" // 16 chars, all [A-Z0-9]
 		secretVal = []byte(vcrtest.Placeholder)
-		clientIDVal = []byte(vcrtest.Placeholder)
+		clientIDVal = []byte(replayClientID)
 	}
 
 	// Build the Match. Snippet.Before carries the client_id so that

--- a/pkg/validator/confluent_cassette_test.go
+++ b/pkg/validator/confluent_cassette_test.go
@@ -60,8 +60,8 @@ func runConfluentCassetteCase(t *testing.T, cassette string, want types.Validati
 	if !isRecording {
 		if _, err := os.Stat(cassetteFile); os.IsNotExist(err) {
 			t.Skipf(
-				"cassette not recorded yet; run:\n"+
-					"  SECRET_PLAINTEXT=<secret> CONFLUENT_CLIENT_ID=<key-id> RECORD=1 "+
+				"cassette not recorded yet; run:\n" +
+					"  SECRET_PLAINTEXT=<secret> CONFLUENT_CLIENT_ID=<key-id> RECORD=1 " +
 					"go test ./pkg/validator/ -run Test_confluent_",
 			)
 		}

--- a/pkg/validator/confluent_cassette_test.go
+++ b/pkg/validator/confluent_cassette_test.go
@@ -114,3 +114,142 @@ func runConfluentCassetteCase(t *testing.T, cassette string, want types.Validati
 	assert.Equal(t, want, result.Status,
 		"confluent cassette %s: unexpected validation status", cassette)
 }
+
+// Test_confluent_cluster_Valid replays the cassette for a valid Confluent cluster
+// API-key pair and asserts StatusValid. Skips when the cassette has not been
+// recorded yet.
+func Test_confluent_cluster_Valid(t *testing.T) {
+	runConfluentClusterCassetteCase(t, "testdata/confluent/cluster_valid", types.StatusValid)
+}
+
+// Test_confluent_cluster_Invalid replays the cassette for an invalid Confluent
+// cluster API-key pair and asserts StatusInvalid. Skips when the cassette has
+// not been recorded yet.
+func Test_confluent_cluster_Invalid(t *testing.T) {
+	runConfluentClusterCassetteCase(t, "testdata/confluent/cluster_invalid", types.StatusInvalid)
+}
+
+// runConfluentClusterCassetteCase is the VCR replay driver for the Confluent
+// cluster-key validation path.
+//
+// Cluster URL structure: {endpoint}/kafka/v3/clusters/{lkc_id}/topics
+// where endpoint = https://pkc-xxx.region.provider.confluent.cloud[:port]
+// and   lkc_id   = lkc-xxxxx
+//
+// Record mode (RECORD=1):
+//   - SECRET_PLAINTEXT: real API secret.
+//   - CONFLUENT_CLIENT_ID: real key ID (16 uppercase alphanumeric chars).
+//   - CONFLUENT_CLUSTER_ENDPOINT: real cluster bootstrap URL, e.g.
+//     "https://pkc-419q3.us-east4.gcp.confluent.cloud:443"
+//   - CONFLUENT_LKC_ID: real logical cluster ID, e.g. "lkc-nvodzyv"
+//
+// The vcrtest redaction hook scrubs the real secret to vcrtest.Placeholder.
+// WithExtraRedactions replaces the real cluster endpoint and lkc-id with fixed
+// replay-safe placeholders so no account-identifying data is committed:
+//   - cluster endpoint -> "https://pkc-REDACTED0.example.confluent.cloud:443"
+//   - lkc-id           -> "lkc-redacted"
+//
+// Both placeholders match the extraction regexes so replay works correctly.
+//
+// Replay mode (default):
+//   - Snippet context contains the placeholder cluster endpoint and lkc-id.
+//   - extractClusterContext extracts them; Validate builds the request URL from
+//     the placeholder endpoint, which the VCR transport matches against the
+//     cassette (no real TCP connection is made).
+func runConfluentClusterCassetteCase(t *testing.T, cassette string, want types.ValidationStatus) {
+	t.Helper()
+
+	// Fixed replay placeholders: both must match the extraction regexes.
+	// - confluentClusterEndpointPattern: https?://pkc-[a-z0-9]+\.[a-z0-9.-]+\.confluent\.cloud(?::\d+)?
+	// - confluentLKCPattern:              lkc-[a-z0-9]+
+	const (
+		placeholderEndpoint = "https://pkc-REDACTED0.example.confluent.cloud:443"
+		placeholderLKC      = "lkc-redacted"
+		replayClientID      = "REDACTED0SECRET1" // 16 chars, all [A-Z0-9]
+	)
+
+	isRecording := os.Getenv("RECORD") == "1"
+	cassetteFile := cassette + ".yaml"
+	if !isRecording {
+		if _, err := os.Stat(cassetteFile); os.IsNotExist(err) {
+			t.Skipf(
+				"cassette not recorded yet; run:\n" +
+					"  SECRET_PLAINTEXT=<secret> CONFLUENT_CLIENT_ID=<key-id> " +
+					"CONFLUENT_CLUSTER_ENDPOINT=<endpoint> CONFLUENT_LKC_ID=<lkc-id> " +
+					"RECORD=1 go test ./pkg/validator/ -run Test_confluent_cluster_",
+			)
+		}
+	}
+
+	var (
+		secretVal       []byte
+		clientIDVal     []byte
+		clusterEndpoint string
+		lkcID           string
+		clientOpts      []vcrtest.Option
+	)
+
+	if isRecording {
+		pt := os.Getenv("SECRET_PLAINTEXT")
+		if pt == "" {
+			t.Fatal("RECORD=1 requires SECRET_PLAINTEXT=<real-secret>")
+		}
+		clientID := os.Getenv("CONFLUENT_CLIENT_ID")
+		if clientID == "" {
+			t.Fatal("RECORD=1 requires CONFLUENT_CLIENT_ID=<real-key-id>")
+		}
+		clusterEndpoint = os.Getenv("CONFLUENT_CLUSTER_ENDPOINT")
+		if clusterEndpoint == "" {
+			t.Fatal("RECORD=1 requires CONFLUENT_CLUSTER_ENDPOINT=<endpoint>")
+		}
+		lkcID = os.Getenv("CONFLUENT_LKC_ID")
+		if lkcID == "" {
+			t.Fatal("RECORD=1 requires CONFLUENT_LKC_ID=<lkc-id>")
+		}
+		secretVal = []byte(pt)
+		clientIDVal = []byte(clientID)
+		// Redact real cluster endpoint and lkc-id from the cassette so no
+		// account-identifying data is committed to testdata/.
+		clientOpts = append(clientOpts,
+			vcrtest.WithExtraRedactions(
+				[2]string{clusterEndpoint, placeholderEndpoint},
+				[2]string{lkcID, placeholderLKC},
+			),
+		)
+	} else {
+		// In replay mode use the fixed placeholder credentials. The cassette
+		// was written with the placeholder cluster endpoint and lkc-id, so the
+		// VCR transport matches against them directly.
+		const replayClientIDLocal = replayClientID
+		secretVal = []byte(vcrtest.Placeholder)
+		clientIDVal = []byte(replayClientIDLocal)
+		clusterEndpoint = placeholderEndpoint
+		lkcID = placeholderLKC
+	}
+
+	// Build the Match with cluster context in Snippet.Before.
+	// extractClusterContext reads clusterEndpoint and lkcID from Before.
+	// extractCredentials reads clientIDVal from Before (keyword-proximity pattern).
+	snippetBefore := []byte(
+		"confluent api_key=" + string(clientIDVal) +
+			" bootstrap=" + clusterEndpoint +
+			" cluster=" + lkcID,
+	)
+
+	match := &types.Match{
+		RuleID:      "kingfisher.confluent.2",
+		NamedGroups: map[string][]byte{"secret": secretVal},
+		Snippet:     types.Snippet{Before: snippetBefore},
+	}
+
+	client := vcrtest.Client(t, cassette, clientOpts...)
+	v := NewConfluentValidatorWithClient(client)
+	// No clusterBaseURL override: in record mode, the real endpoint is used
+	// directly; in replay mode, go-vcr intercepts the request without a real
+	// TCP connection, so the placeholder hostname is fine.
+
+	result, err := v.Validate(context.Background(), match)
+	require.NoError(t, err, "Validate must not return a non-nil error")
+	assert.Equal(t, want, result.Status,
+		"confluent cluster cassette %s: unexpected validation status", cassette)
+}

--- a/pkg/validator/confluent_cassette_test.go
+++ b/pkg/validator/confluent_cassette_test.go
@@ -26,6 +26,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Package-level replay placeholder constants shared between the cassette driver
+// functions and the guard test (TestClusterReplayPlaceholders_MatchExtractionRegexes).
+// Keeping them here ensures the guard test exercises the exact values the drivers use.
+const (
+	// cassetteReplayClientID is the replay placeholder for the Confluent API key ID.
+	// Must be exactly 16 chars of [A-Z0-9] so that confluentClientIDPatterns (which
+	// requires [A-Z0-9]{16}) can extract it from Snippet.Before during replay.
+	// vcrtest.Placeholder ("REDACTED_SECRET") fails this constraint (15 chars, lowercase, underscores).
+	cassetteReplayClientID = "REDACTED0SECRET1"
+
+	// cassettePlaceholderEndpoint is the replay placeholder for the Confluent cluster
+	// bootstrap endpoint.  Must match confluentClusterEndpointPattern
+	// (pkc-[a-z0-9]+\.[a-z0-9.-]+\.confluent\.cloud…) — lowercase only after pkc-.
+	cassettePlaceholderEndpoint = "https://pkc-redacted0.example.confluent.cloud:443"
+
+	// cassettePlaceholderLKC is the replay placeholder for the Confluent logical
+	// cluster ID (lkc-…).  Must match confluentLKCPattern (lkc-[a-z0-9]+).
+	cassettePlaceholderLKC = "lkc-redacted"
+)
+
 // Test_confluent_Valid replays the cassette for a valid Confluent API-key pair
 // and asserts StatusValid. Skips when the cassette has not been recorded yet.
 func Test_confluent_Valid(t *testing.T) {
@@ -90,9 +110,8 @@ func runConfluentCassetteCase(t *testing.T, cassette string, want types.Validati
 		// extract it from Snippet.Before — vcrtest.Placeholder ("REDACTED_SECRET")
 		// is 15 chars with underscores and lowercase letters, which the regex
 		// \b-bounded pattern cannot match.
-		const replayClientID = "REDACTED0SECRET1" // 16 chars, all [A-Z0-9]
 		secretVal = []byte(vcrtest.Placeholder)
-		clientIDVal = []byte(replayClientID)
+		clientIDVal = []byte(cassetteReplayClientID)
 	}
 
 	// Build the Match. Snippet.Before carries the client_id so that
@@ -159,16 +178,6 @@ func Test_confluent_cluster_Invalid(t *testing.T) {
 func runConfluentClusterCassetteCase(t *testing.T, cassette string, want types.ValidationStatus) {
 	t.Helper()
 
-	// Fixed replay placeholders: both must match the extraction regexes.
-	// - confluentClusterEndpointPattern: https?://pkc-[a-z0-9]+\.[a-z0-9.-]+\.confluent\.cloud(?::\d+)?
-	//   NOTE: pkc- segment is [a-z0-9] only; "pkc-redacted0" matches, "pkc-REDACTED0" does NOT.
-	// - confluentLKCPattern:              lkc-[a-z0-9]+
-	const (
-		placeholderEndpoint = "https://pkc-redacted0.example.confluent.cloud:443"
-		placeholderLKC      = "lkc-redacted"
-		replayClientID      = "REDACTED0SECRET1" // 16 chars, all [A-Z0-9]
-	)
-
 	isRecording := os.Getenv("RECORD") == "1"
 	cassetteFile := cassette + ".yaml"
 	if !isRecording {
@@ -213,19 +222,18 @@ func runConfluentClusterCassetteCase(t *testing.T, cassette string, want types.V
 		// account-identifying data is committed to testdata/.
 		clientOpts = append(clientOpts,
 			vcrtest.WithExtraRedactions(
-				[2]string{clusterEndpoint, placeholderEndpoint},
-				[2]string{lkcID, placeholderLKC},
+				[2]string{clusterEndpoint, cassettePlaceholderEndpoint},
+				[2]string{lkcID, cassettePlaceholderLKC},
 			),
 		)
 	} else {
 		// In replay mode use the fixed placeholder credentials. The cassette
 		// was written with the placeholder cluster endpoint and lkc-id, so the
 		// VCR transport matches against them directly.
-		const replayClientIDLocal = replayClientID
 		secretVal = []byte(vcrtest.Placeholder)
-		clientIDVal = []byte(replayClientIDLocal)
-		clusterEndpoint = placeholderEndpoint
-		lkcID = placeholderLKC
+		clientIDVal = []byte(cassetteReplayClientID)
+		clusterEndpoint = cassettePlaceholderEndpoint
+		lkcID = cassettePlaceholderLKC
 	}
 
 	// Build the Match with cluster context in Snippet.Before.
@@ -269,26 +277,20 @@ func runConfluentClusterCassetteCase(t *testing.T, cassette string, want types.V
 // This is the cluster-key analog of the replayClientID-vs-confluentClientIDPatterns
 // check introduced for the cloud cassette tests (C-1 reviewer finding).
 func TestClusterReplayPlaceholders_MatchExtractionRegexes(t *testing.T) {
-	// These constants MUST be kept in sync with runConfluentClusterCassetteCase.
-	const (
-		placeholderEndpoint = "https://pkc-redacted0.example.confluent.cloud:443"
-		placeholderLKC      = "lkc-redacted"
-	)
-
-	// confluentClusterEndpointPattern must match placeholderEndpoint so that
+	// confluentClusterEndpointPattern must match cassettePlaceholderEndpoint so that
 	// extractClusterContext can extract it from the snippet during replay.
 	assert.True(t,
-		confluentClusterEndpointPattern.MatchString(placeholderEndpoint),
-		"placeholderEndpoint %q must match confluentClusterEndpointPattern; "+
+		confluentClusterEndpointPattern.MatchString(cassettePlaceholderEndpoint),
+		"cassettePlaceholderEndpoint %q must match confluentClusterEndpointPattern; "+
 			"if it does not, replay falls back to the cloud path and the cassette never matches",
-		placeholderEndpoint,
+		cassettePlaceholderEndpoint,
 	)
 
-	// confluentLKCPattern must match placeholderLKC for the same reason.
+	// confluentLKCPattern must match cassettePlaceholderLKC for the same reason.
 	assert.True(t,
-		confluentLKCPattern.MatchString(placeholderLKC),
-		"placeholderLKC %q must match confluentLKCPattern; "+
+		confluentLKCPattern.MatchString(cassettePlaceholderLKC),
+		"cassettePlaceholderLKC %q must match confluentLKCPattern; "+
 			"if it does not, extractClusterContext returns empty lkcID and replay falls back to cloud path",
-		placeholderLKC,
+		cassettePlaceholderLKC,
 	)
 }

--- a/pkg/validator/confluent_cassette_test.go
+++ b/pkg/validator/confluent_cassette_test.go
@@ -1,0 +1,109 @@
+// pkg/validator/confluent_cassette_test.go
+//
+// VCR replay tests for the Confluent Cloud API-key validator (LAB-4050).
+// These tests skip gracefully when cassettes have not been recorded yet.
+//
+// To record:
+//
+//	SECRET_PLAINTEXT=<secret> CONFLUENT_CLIENT_ID=<key-id> RECORD=1 \
+//	    go test ./pkg/validator/ -run Test_confluent_
+//
+// The cassette harness uses the default secretInsensitiveMatcher (method + host +
+// path + query). Because the validation URL is FIXED (no client_id in the path),
+// replay matching is trivial: any GET to /iam/v2/api-keys matches regardless of
+// the Authorization header (which is stripped by the minimization hook before
+// the cassette is written to disk).
+package validator
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+	"github.com/praetorian-inc/titus/pkg/validator/internal/vcrtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test_confluent_Valid replays the cassette for a valid Confluent API-key pair
+// and asserts StatusValid. Skips when the cassette has not been recorded yet.
+func Test_confluent_Valid(t *testing.T) {
+	runConfluentCassetteCase(t, "testdata/confluent/valid", types.StatusValid)
+}
+
+// Test_confluent_Invalid replays the cassette for an invalid Confluent API-key
+// pair and asserts StatusInvalid. Skips when the cassette has not been recorded yet.
+func Test_confluent_Invalid(t *testing.T) {
+	runConfluentCassetteCase(t, "testdata/confluent/invalid", types.StatusInvalid)
+}
+
+// runConfluentCassetteCase is the VCR replay driver for the Confluent Go validator.
+//
+// Record mode (RECORD=1):
+//   - SECRET_PLAINTEXT must contain the real API secret (t.Fatal if absent).
+//   - CONFLUENT_CLIENT_ID must contain the real key ID (t.Fatal if absent).
+//   - Both are placed into the Match so the validator builds a real Basic auth
+//     header; the vcrtest redaction hook scrubs them before writing to disk.
+//
+// Replay mode (default):
+//   - secret = vcrtest.Placeholder; client_id = vcrtest.Placeholder.
+//   - Snippet.Before = "confluent api_key=REDACTED_SECRET" so the keyword-
+//     proximity regex in extractCredentials finds the Placeholder as the client_id.
+//   - The cassette matcher ignores the Authorization header (stripped by the
+//     minimization hook), so the fixed URL matches regardless of credentials.
+func runConfluentCassetteCase(t *testing.T, cassette string, want types.ValidationStatus) {
+	t.Helper()
+
+	isRecording := os.Getenv("RECORD") == "1"
+	cassetteFile := cassette + ".yaml"
+	if !isRecording {
+		if _, err := os.Stat(cassetteFile); os.IsNotExist(err) {
+			t.Skipf(
+				"cassette not recorded yet; run:\n"+
+					"  SECRET_PLAINTEXT=<secret> CONFLUENT_CLIENT_ID=<key-id> RECORD=1 "+
+					"go test ./pkg/validator/ -run Test_confluent_",
+			)
+		}
+	}
+
+	var (
+		secretVal   []byte
+		clientIDVal []byte
+	)
+
+	if isRecording {
+		pt := os.Getenv("SECRET_PLAINTEXT")
+		if pt == "" {
+			t.Fatal("RECORD=1 requires SECRET_PLAINTEXT=<real-secret>")
+		}
+		clientID := os.Getenv("CONFLUENT_CLIENT_ID")
+		if clientID == "" {
+			t.Fatal("RECORD=1 requires CONFLUENT_CLIENT_ID=<real-key-id>")
+		}
+		secretVal = []byte(pt)
+		clientIDVal = []byte(clientID)
+	} else {
+		secretVal = []byte(vcrtest.Placeholder)
+		clientIDVal = []byte(vcrtest.Placeholder)
+	}
+
+	// Build the Match. Snippet.Before carries the client_id so that
+	// extractCredentials can find it via the keyword-proximity pattern.
+	snippetBefore := []byte("confluent api_key=" + string(clientIDVal))
+
+	match := &types.Match{
+		RuleID:      "kingfisher.confluent.2",
+		NamedGroups: map[string][]byte{"secret": secretVal},
+		Snippet:     types.Snippet{Before: snippetBefore},
+	}
+
+	// status-only validator: response body is elided (no WithResponseBody).
+	client := vcrtest.Client(t, cassette)
+	v := NewConfluentValidatorWithClient(client)
+
+	result, err := v.Validate(context.Background(), match)
+	require.NoError(t, err, "Validate must not return a non-nil error")
+	assert.Equal(t, want, result.Status,
+		"confluent cassette %s: unexpected validation status", cassette)
+}

--- a/pkg/validator/confluent_cassette_test.go
+++ b/pkg/validator/confluent_cassette_test.go
@@ -146,7 +146,7 @@ func Test_confluent_cluster_Invalid(t *testing.T) {
 // The vcrtest redaction hook scrubs the real secret to vcrtest.Placeholder.
 // WithExtraRedactions replaces the real cluster endpoint and lkc-id with fixed
 // replay-safe placeholders so no account-identifying data is committed:
-//   - cluster endpoint -> "https://pkc-REDACTED0.example.confluent.cloud:443"
+//   - cluster endpoint -> "https://pkc-redacted0.example.confluent.cloud:443"
 //   - lkc-id           -> "lkc-redacted"
 //
 // Both placeholders match the extraction regexes so replay works correctly.
@@ -161,9 +161,10 @@ func runConfluentClusterCassetteCase(t *testing.T, cassette string, want types.V
 
 	// Fixed replay placeholders: both must match the extraction regexes.
 	// - confluentClusterEndpointPattern: https?://pkc-[a-z0-9]+\.[a-z0-9.-]+\.confluent\.cloud(?::\d+)?
+	//   NOTE: pkc- segment is [a-z0-9] only; "pkc-redacted0" matches, "pkc-REDACTED0" does NOT.
 	// - confluentLKCPattern:              lkc-[a-z0-9]+
 	const (
-		placeholderEndpoint = "https://pkc-REDACTED0.example.confluent.cloud:443"
+		placeholderEndpoint = "https://pkc-redacted0.example.confluent.cloud:443"
 		placeholderLKC      = "lkc-redacted"
 		replayClientID      = "REDACTED0SECRET1" // 16 chars, all [A-Z0-9]
 	)
@@ -252,4 +253,42 @@ func runConfluentClusterCassetteCase(t *testing.T, cassette string, want types.V
 	require.NoError(t, err, "Validate must not return a non-nil error")
 	assert.Equal(t, want, result.Status,
 		"confluent cluster cassette %s: unexpected validation status", cassette)
+}
+
+// TestClusterReplayPlaceholders_MatchExtractionRegexes is a compile-time
+// contract guard: it asserts that the fixed replay placeholders used by the
+// cluster cassette tests are actually extractable by the production regex
+// patterns in confluent.go.
+//
+// Without this guard a placeholder typo (e.g. uppercase in a [a-z0-9] class)
+// silently breaks replay: extractClusterContext returns empty strings, Validate
+// falls back to the cloud IAM path, and the cassette matcher misses — but no
+// test failure surfaces until after a cassette has been recorded and the replay
+// is attempted.
+//
+// This is the cluster-key analog of the replayClientID-vs-confluentClientIDPatterns
+// check introduced for the cloud cassette tests (C-1 reviewer finding).
+func TestClusterReplayPlaceholders_MatchExtractionRegexes(t *testing.T) {
+	// These constants MUST be kept in sync with runConfluentClusterCassetteCase.
+	const (
+		placeholderEndpoint = "https://pkc-redacted0.example.confluent.cloud:443"
+		placeholderLKC      = "lkc-redacted"
+	)
+
+	// confluentClusterEndpointPattern must match placeholderEndpoint so that
+	// extractClusterContext can extract it from the snippet during replay.
+	assert.True(t,
+		confluentClusterEndpointPattern.MatchString(placeholderEndpoint),
+		"placeholderEndpoint %q must match confluentClusterEndpointPattern; "+
+			"if it does not, replay falls back to the cloud path and the cassette never matches",
+		placeholderEndpoint,
+	)
+
+	// confluentLKCPattern must match placeholderLKC for the same reason.
+	assert.True(t,
+		confluentLKCPattern.MatchString(placeholderLKC),
+		"placeholderLKC %q must match confluentLKCPattern; "+
+			"if it does not, extractClusterContext returns empty lkcID and replay falls back to cloud path",
+		placeholderLKC,
+	)
 }

--- a/pkg/validator/confluent_test.go
+++ b/pkg/validator/confluent_test.go
@@ -134,6 +134,21 @@ func TestConfluentValidator_ExtractCredentials(t *testing.T) {
 			wantClient: validClientID,
 			wantSecret: validSecret64,
 		},
+		{
+			// Regression: api_key=<64-char-base64-secret> must NOT mis-grab the
+			// first 16 chars of the secret as the client_id. The 16-char match is
+			// not a word boundary (more [A-Z0-9] chars follow), so \b prevents it.
+			// Extraction must return an error (no real 16-char client_id present).
+			name: "64-char secret after api_key= is not mis-extracted as client_id",
+			match: &types.Match{
+				RuleID:      "kingfisher.confluent.2",
+				NamedGroups: map[string][]byte{"secret": []byte(validSecret64)},
+				Snippet: types.Snippet{
+					Before: []byte("api_key=" + validSecret64),
+				},
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/validator/confluent_test.go
+++ b/pkg/validator/confluent_test.go
@@ -1,0 +1,235 @@
+// pkg/validator/confluent_test.go
+package validator
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConfluentValidator_Name verifies the validator identifies itself as "confluent".
+func TestConfluentValidator_Name(t *testing.T) {
+	v := NewConfluentValidator()
+	assert.Equal(t, "confluent", v.Name())
+}
+
+// TestConfluentValidator_CanValidate verifies that the validator accepts exactly the
+// three confluent rule IDs and rejects unrelated ones.
+func TestConfluentValidator_CanValidate(t *testing.T) {
+	v := NewConfluentValidator()
+
+	tests := []struct {
+		ruleID string
+		want   bool
+	}{
+		{"kingfisher.confluent.1", true},
+		{"kingfisher.confluent.2", true},
+		{"kingfisher.confluent.3", true},
+		{"np.aws.1", false},
+		{"np.github.3", false},
+		{"titus.wandb.1", false},
+		{"", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.ruleID, func(t *testing.T) {
+			assert.Equal(t, tc.want, v.CanValidate(tc.ruleID),
+				"CanValidate(%q) should be %v", tc.ruleID, tc.want)
+		})
+	}
+}
+
+// TestConfluentValidator_ExtractCredentials verifies credential extraction for all
+// match shapes produced by the three confluent rules.
+func TestConfluentValidator_ExtractCredentials(t *testing.T) {
+	const (
+		validSecret64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ01" // 64 chars
+		validCflt     = "cfltqPLd2lLPAtWtHGNhN32WlZxoEj30pcg8mzaPlPJ937JlMa7n9YCRLooqgifw"
+		validClientID = "ABCD1234EFGH5678" // 16 uppercase alphanumeric
+	)
+
+	snippetWithClientID := []byte(fmt.Sprintf("confluent api_key=%s\n", validClientID))
+
+	tests := []struct {
+		name       string
+		match      *types.Match
+		wantClient string
+		wantSecret string
+		wantErr    bool
+	}{
+		{
+			name: "confluent.2: secret from NamedGroups, client_id from snippet Before",
+			match: &types.Match{
+				RuleID:      "kingfisher.confluent.2",
+				NamedGroups: map[string][]byte{"secret": []byte(validSecret64)},
+				Snippet:     types.Snippet{Before: snippetWithClientID},
+			},
+			wantClient: validClientID,
+			wantSecret: validSecret64,
+		},
+		{
+			name: "confluent.3: secret from Groups[0] (cflt token), client_id from snippet",
+			match: &types.Match{
+				RuleID:      "kingfisher.confluent.3",
+				Groups:      [][]byte{[]byte(validCflt)},
+				NamedGroups: map[string][]byte{},
+				Snippet:     types.Snippet{Before: snippetWithClientID},
+			},
+			wantClient: validClientID,
+			wantSecret: validCflt,
+		},
+		{
+			name: "confluent.2: secret present but no client_id in snippet",
+			match: &types.Match{
+				RuleID:      "kingfisher.confluent.2",
+				NamedGroups: map[string][]byte{"secret": []byte(validSecret64)},
+				Snippet:     types.Snippet{Before: []byte("some unrelated context")},
+			},
+			wantErr: true,
+		},
+		{
+			name: "confluent.1: client_id only, no secret",
+			match: &types.Match{
+				RuleID:      "kingfisher.confluent.1",
+				NamedGroups: map[string][]byte{"client_id": []byte(validClientID)},
+				Snippet:     types.Snippet{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "nil NamedGroups, no Groups",
+			match: &types.Match{
+				RuleID:  "kingfisher.confluent.2",
+				Snippet: types.Snippet{Before: snippetWithClientID},
+			},
+			wantErr: true,
+		},
+		{
+			name: "client_id from snippet Matching field",
+			match: &types.Match{
+				RuleID:      "kingfisher.confluent.2",
+				NamedGroups: map[string][]byte{"secret": []byte(validSecret64)},
+				Snippet: types.Snippet{
+					Matching: []byte(fmt.Sprintf("kafka api_key=%s some text", validClientID)),
+				},
+			},
+			wantClient: validClientID,
+			wantSecret: validSecret64,
+		},
+		{
+			name: "client_id from snippet After field",
+			match: &types.Match{
+				RuleID:      "kingfisher.confluent.2",
+				NamedGroups: map[string][]byte{"secret": []byte(validSecret64)},
+				Snippet: types.Snippet{
+					After: []byte(fmt.Sprintf("confluent client_id=%s more", validClientID)),
+				},
+			},
+			wantClient: validClientID,
+			wantSecret: validSecret64,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v := NewConfluentValidator()
+			clientID, secret, err := v.extractCredentials(tc.match)
+			if tc.wantErr {
+				require.Error(t, err, "expected error for match shape")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantClient, clientID, "client ID mismatch")
+			assert.Equal(t, tc.wantSecret, secret, "secret mismatch")
+		})
+	}
+}
+
+// TestConfluentValidator_Validate verifies HTTP status to ValidationStatus mapping.
+func TestConfluentValidator_Validate(t *testing.T) {
+	const (
+		validSecret64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ01"
+		validClientID = "ABCD1234EFGH5678"
+	)
+	snippetWithClientID := []byte(fmt.Sprintf("confluent api_key=%s\n", validClientID))
+
+	tests := []struct {
+		name       string
+		httpStatus int
+		match      *types.Match
+		wantStatus types.ValidationStatus
+	}{
+		{
+			name:       "HTTP 200 maps to StatusValid",
+			httpStatus: http.StatusOK,
+			match: &types.Match{
+				RuleID:      "kingfisher.confluent.2",
+				NamedGroups: map[string][]byte{"secret": []byte(validSecret64)},
+				Snippet:     types.Snippet{Before: snippetWithClientID},
+			},
+			wantStatus: types.StatusValid,
+		},
+		{
+			name:       "HTTP 401 maps to StatusInvalid",
+			httpStatus: http.StatusUnauthorized,
+			match: &types.Match{
+				RuleID:      "kingfisher.confluent.2",
+				NamedGroups: map[string][]byte{"secret": []byte(validSecret64)},
+				Snippet:     types.Snippet{Before: snippetWithClientID},
+			},
+			wantStatus: types.StatusInvalid,
+		},
+		{
+			name:       "HTTP 403 maps to StatusInvalid",
+			httpStatus: http.StatusForbidden,
+			match: &types.Match{
+				RuleID:      "kingfisher.confluent.2",
+				NamedGroups: map[string][]byte{"secret": []byte(validSecret64)},
+				Snippet:     types.Snippet{Before: snippetWithClientID},
+			},
+			wantStatus: types.StatusInvalid,
+		},
+		{
+			name:       "HTTP 500 maps to StatusUndetermined",
+			httpStatus: http.StatusInternalServerError,
+			match: &types.Match{
+				RuleID:      "kingfisher.confluent.2",
+				NamedGroups: map[string][]byte{"secret": []byte(validSecret64)},
+				Snippet:     types.Snippet{Before: snippetWithClientID},
+			},
+			wantStatus: types.StatusUndetermined,
+		},
+		{
+			name:       "missing client_id maps to StatusUndetermined without HTTP request",
+			httpStatus: http.StatusOK,
+			match: &types.Match{
+				RuleID:      "kingfisher.confluent.1",
+				NamedGroups: map[string][]byte{"client_id": []byte(validClientID)},
+				Snippet:     types.Snippet{},
+			},
+			wantStatus: types.StatusUndetermined,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.httpStatus)
+			}))
+			defer ts.Close()
+
+			v := NewConfluentValidatorWithClient(ts.Client())
+			v.baseURL = ts.URL
+
+			result, err := v.Validate(context.Background(), tc.match)
+			require.NoError(t, err, "Validate must never return a non-nil error")
+			assert.Equal(t, tc.wantStatus, result.Status)
+		})
+	}
+}

--- a/pkg/validator/confluent_test.go
+++ b/pkg/validator/confluent_test.go
@@ -201,14 +201,16 @@ func TestConfluentValidator_Validate(t *testing.T) {
 			wantStatus: types.StatusInvalid,
 		},
 		{
-			name:       "HTTP 403 maps to StatusInvalid",
+			// 403 = authenticated but not authorized for the resource.
+			// The key is live; the caller may lack cloud-global API permissions.
+			name:       "HTTP 403 maps to StatusValid (authenticated, key is live)",
 			httpStatus: http.StatusForbidden,
 			match: &types.Match{
 				RuleID:      "kingfisher.confluent.2",
 				NamedGroups: map[string][]byte{"secret": []byte(validSecret64)},
 				Snippet:     types.Snippet{Before: snippetWithClientID},
 			},
-			wantStatus: types.StatusInvalid,
+			wantStatus: types.StatusValid,
 		},
 		{
 			name:       "HTTP 500 maps to StatusUndetermined",
@@ -245,6 +247,204 @@ func TestConfluentValidator_Validate(t *testing.T) {
 			result, err := v.Validate(context.Background(), tc.match)
 			require.NoError(t, err, "Validate must never return a non-nil error")
 			assert.Equal(t, tc.wantStatus, result.Status)
+		})
+	}
+}
+
+// TestConfluentValidator_ExtractClusterContext verifies extraction of cluster
+// endpoint and lkc-id from snippet context.
+func TestConfluentValidator_ExtractClusterContext(t *testing.T) {
+	const (
+		realEndpoint = "https://pkc-419q3.us-east4.gcp.confluent.cloud:443"
+		realLKC      = "lkc-nvodzyv"
+	)
+
+	tests := []struct {
+		name         string
+		snippet      types.Snippet
+		wantEndpoint string
+		wantLKC      string
+	}{
+		{
+			name: "endpoint and lkc in Before",
+			snippet: types.Snippet{
+				Before: []byte("bootstrap=" + realEndpoint + " cluster=" + realLKC),
+			},
+			wantEndpoint: realEndpoint,
+			wantLKC:      realLKC,
+		},
+		{
+			name: "endpoint in Before, lkc in After",
+			snippet: types.Snippet{
+				Before: []byte("bootstrap=" + realEndpoint),
+				After:  []byte("cluster=" + realLKC),
+			},
+			wantEndpoint: realEndpoint,
+			wantLKC:      realLKC,
+		},
+		{
+			name: "no cluster context -> both empty (falls back to cloud path)",
+			snippet: types.Snippet{
+				Before: []byte("confluent api_key=ABCD1234EFGH5678"),
+			},
+			wantEndpoint: "",
+			wantLKC:      "",
+		},
+		{
+			name: "endpoint without port",
+			snippet: types.Snippet{
+				Before: []byte("host=https://pkc-xyz99.eu-west1.gcp.confluent.cloud cluster=" + realLKC),
+			},
+			wantEndpoint: "https://pkc-xyz99.eu-west1.gcp.confluent.cloud",
+			wantLKC:      realLKC,
+		},
+		{
+			name: "endpoint only, no lkc -> no cluster path",
+			snippet: types.Snippet{
+				Before: []byte("bootstrap=" + realEndpoint),
+			},
+			wantEndpoint: realEndpoint,
+			wantLKC:      "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v := NewConfluentValidator()
+			ep, lkc := v.extractClusterContext(&types.Match{Snippet: tc.snippet})
+			assert.Equal(t, tc.wantEndpoint, ep)
+			assert.Equal(t, tc.wantLKC, lkc)
+		})
+	}
+}
+
+// TestConfluentValidator_ClusterPath verifies that when BOTH a cluster endpoint
+// and lkc-id are found in the snippet, Validate uses the cluster-specific URL
+// and maps responses correctly (200=Valid, 403=Valid, 401=Invalid, 5xx=Undetermined).
+func TestConfluentValidator_ClusterPath(t *testing.T) {
+	const (
+		validSecret64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ01"
+		validClientID = "ABCD1234EFGH5678"
+		clusterLKC    = "lkc-nvodzyv"
+	)
+
+	tests := []struct {
+		name           string
+		httpStatus     int
+		wantStatus     types.ValidationStatus
+		wantPathPrefix string // expected URL path prefix
+	}{
+		{
+			name:           "cluster 200 -> StatusValid",
+			httpStatus:     http.StatusOK,
+			wantStatus:     types.StatusValid,
+			wantPathPrefix: "/kafka/v3/clusters/" + clusterLKC + "/topics",
+		},
+		{
+			// 403 = authenticated but the cluster key lacks topic-list permission.
+			// The key is live; mark Valid.
+			name:           "cluster 403 -> StatusValid (key authenticated, insufficient permissions)",
+			httpStatus:     http.StatusForbidden,
+			wantStatus:     types.StatusValid,
+			wantPathPrefix: "/kafka/v3/clusters/" + clusterLKC + "/topics",
+		},
+		{
+			name:           "cluster 401 -> StatusInvalid",
+			httpStatus:     http.StatusUnauthorized,
+			wantStatus:     types.StatusInvalid,
+			wantPathPrefix: "/kafka/v3/clusters/" + clusterLKC + "/topics",
+		},
+		{
+			name:           "cluster 500 -> StatusUndetermined",
+			httpStatus:     http.StatusInternalServerError,
+			wantStatus:     types.StatusUndetermined,
+			wantPathPrefix: "/kafka/v3/clusters/" + clusterLKC + "/topics",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotPath string
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				w.WriteHeader(tc.httpStatus)
+			}))
+			defer ts.Close()
+
+			// Put a realistic confluent cluster endpoint in the snippet so
+			// extractClusterContext succeeds (matches pkc-...confluent.cloud regex).
+			// The actual HTTP request is redirected to the httptest server via
+			// the clusterBaseURL test override.
+			const fakeEndpoint = "https://pkc-419q3.us-east4.gcp.confluent.cloud:443"
+			snippetContext := []byte("bootstrap=" + fakeEndpoint + " cluster=" + clusterLKC)
+			match := &types.Match{
+				RuleID:      "kingfisher.confluent.2",
+				NamedGroups: map[string][]byte{"secret": []byte(validSecret64)},
+				Snippet: types.Snippet{
+					Before: snippetContext,
+					After:  []byte("api_key=" + validClientID),
+				},
+			}
+
+			v := NewConfluentValidatorWithClient(ts.Client())
+			v.baseURL = ts.URL        // cloud fallback (not used in this test)
+			v.clusterBaseURL = ts.URL // redirect cluster requests to httptest server
+
+			result, err := v.Validate(context.Background(), match)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantStatus, result.Status)
+			assert.Equal(t, tc.wantPathPrefix, gotPath, "request must hit cluster topic-list endpoint")
+		})
+	}
+}
+
+// TestConfluentValidator_CloudFallback verifies that when cluster context is
+// absent (no pkc endpoint or no lkc-id), Validate falls back to the cloud/global
+// key path and does NOT return an error.
+func TestConfluentValidator_CloudFallback(t *testing.T) {
+	const (
+		validSecret64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ01"
+		validClientID = "ABCD1234EFGH5678"
+	)
+	snippetWithClientID := []byte(fmt.Sprintf("confluent api_key=%s\n", validClientID))
+
+	tests := []struct {
+		name    string
+		snippet types.Snippet
+	}{
+		{
+			name:    "no cluster context at all",
+			snippet: types.Snippet{Before: snippetWithClientID},
+		},
+		{
+			name: "endpoint without lkc -> fallback",
+			snippet: types.Snippet{
+				Before: append(snippetWithClientID, []byte(" bootstrap=https://pkc-xyz.confluent.cloud:443")...),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotPath string
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer ts.Close()
+
+			v := NewConfluentValidatorWithClient(ts.Client())
+			v.baseURL = ts.URL
+
+			match := &types.Match{
+				RuleID:      "kingfisher.confluent.2",
+				NamedGroups: map[string][]byte{"secret": []byte(validSecret64)},
+				Snippet:     tc.snippet,
+			}
+			result, err := v.Validate(context.Background(), match)
+			require.NoError(t, err)
+			assert.Equal(t, types.StatusValid, result.Status)
+			assert.Equal(t, "/iam/v2/api-keys", gotPath, "fallback must hit cloud IAM endpoint")
 		})
 	}
 }

--- a/pkg/validator/engine.go
+++ b/pkg/validator/engine.go
@@ -34,6 +34,7 @@ func NewDefaultEngine(workers int) *Engine {
 	validators = append(validators, NewGitHubAppTokenValidator())
 	validators = append(validators, NewPubNubValidator())
 	validators = append(validators, NewAtlassianValidator())
+	validators = append(validators, NewConfluentValidator())
 
 	// Embedded YAML validators
 	embedded, err := LoadEmbeddedValidators()

--- a/pkg/validator/internal/vcrtest/vcrtest.go
+++ b/pkg/validator/internal/vcrtest/vcrtest.go
@@ -385,6 +385,11 @@ func minimizeInteraction(i *cassette.Interaction) error {
 	i.Response.Duration = 0
 	i.Request.ContentLength = int64(len(i.Request.Body))
 	i.Response.ContentLength = int64(len(i.Response.Body))
+	// Blank the host field: go-vcr persists request.host separately from
+	// request.url. The field is redundant for matching (secretInsensitiveMatcher
+	// derives the host from url.Parse(i.URL).Host, not from i.Request.Host) and
+	// can carry account-identifying cluster hostnames that must not be committed.
+	i.Request.Host = ""
 	return nil
 }
 

--- a/pkg/validator/internal/vcrtest/vcrtest.go
+++ b/pkg/validator/internal/vcrtest/vcrtest.go
@@ -311,6 +311,31 @@ func redactHookWithExtras(isRecording bool, keepResponseBody bool, extras [][2]s
 			allSecrets = append(allSecrets, pt)
 		}
 
+		// Elide response body if not needed (secure-by-default).
+		if !keepResponseBody {
+			i.Response.Body = ""
+			i.Response.Headers.Del("Content-Length")
+		}
+
+		// Perform all redactions across every text field that is kept.
+		for _, secret := range allSecrets {
+			i.Request.URL = redactIn(i.Request.URL, secret)
+			i.Request.Body = redactIn(i.Request.Body, secret)
+			if keepResponseBody {
+				i.Response.Body = redactIn(i.Response.Body, secret)
+			}
+			for h, vals := range i.Request.Headers {
+				for idx, v := range vals {
+					i.Request.Headers[h][idx] = redactIn(v, secret)
+				}
+			}
+			for h, vals := range i.Response.Headers {
+				for idx, v := range vals {
+					i.Response.Headers[h][idx] = redactIn(v, secret)
+				}
+			}
+		}
+
 		// Apply extra (old, new) replacements: account-identifying values such as
 		// cluster endpoint hostnames or cluster IDs that are not secrets but must
 		// not be committed to testdata/ in plain form. These replacements happen
@@ -334,31 +359,6 @@ func redactHookWithExtras(isRecording bool, keepResponseBody bool, extras [][2]s
 			for h, vals := range i.Response.Headers {
 				for idx, v := range vals {
 					i.Response.Headers[h][idx] = strings.ReplaceAll(v, old, newVal)
-				}
-			}
-		}
-
-		// Elide response body if not needed (secure-by-default).
-		if !keepResponseBody {
-			i.Response.Body = ""
-			i.Response.Headers.Del("Content-Length")
-		}
-
-		// Perform all redactions across every text field that is kept.
-		for _, secret := range allSecrets {
-			i.Request.URL = redactIn(i.Request.URL, secret)
-			i.Request.Body = redactIn(i.Request.Body, secret)
-			if keepResponseBody {
-				i.Response.Body = redactIn(i.Response.Body, secret)
-			}
-			for h, vals := range i.Request.Headers {
-				for idx, v := range vals {
-					i.Request.Headers[h][idx] = redactIn(v, secret)
-				}
-			}
-			for h, vals := range i.Response.Headers {
-				for idx, v := range vals {
-					i.Response.Headers[h][idx] = redactIn(v, secret)
 				}
 			}
 		}

--- a/pkg/validator/internal/vcrtest/vcrtest.go
+++ b/pkg/validator/internal/vcrtest/vcrtest.go
@@ -56,6 +56,14 @@ type options struct {
 	// matcher overrides the default secretInsensitiveMatcher for the cassette.
 	// Useful for the rare validator that routes by query string rather than path.
 	matcher cassette.MatcherFunc
+
+	// extraRedactions holds (old, new) string pairs applied during record mode
+	// after all scanner-based redactions. Each old value is replaced with its
+	// corresponding new value across every cassette field. Use this for
+	// account-identifying (but non-secret) values like cluster endpoint hostnames
+	// or cluster IDs that appear in the request URL and must not be committed to
+	// testdata/ as-is.
+	extraRedactions [][2]string
 }
 
 // Option is a functional option for Client.
@@ -83,6 +91,25 @@ func WithResponseBody() Option {
 func WithMatcher(fn cassette.MatcherFunc) Option {
 	return func(o *options) {
 		o.matcher = fn
+	}
+}
+
+// WithExtraRedactions registers additional (old, new) string replacement pairs
+// applied during record mode after scanner-based redaction. Each pair replaces
+// every occurrence of old with new across the request URL, request body,
+// response body (when kept), and all header values before the cassette is
+// written to disk.
+//
+// Use this for account-identifying values that are NOT secrets but should not
+// be committed to testdata/ in plain form — for example, a Kafka cluster
+// endpoint hostname (pkc-xxx.confluent.cloud) or a cluster ID (lkc-yyy).
+// Unlike the scanner-based redaction, these replacements are literal and
+// deterministic: the caller controls both the value to scrub and the fixed
+// placeholder to write instead, ensuring the cassette matcher can match the
+// recorded cassette against replay requests that use the same placeholders.
+func WithExtraRedactions(pairs ...[2]string) Option {
+	return func(o *options) {
+		o.extraRedactions = append(o.extraRedactions, pairs...)
 	}
 }
 
@@ -115,7 +142,7 @@ func Client(t *testing.T, cassettePath string, opts ...Option) *http.Client {
 		cassettePath,
 		recorder.WithMode(mode),
 		recorder.WithSkipRequestLatency(true),
-		recorder.WithHook(redactHook(isRecording, o.keepResponseBody), recorder.AfterCaptureHook),
+		recorder.WithHook(redactHookWithExtras(isRecording, o.keepResponseBody, o.extraRedactions), recorder.AfterCaptureHook),
 		recorder.WithHook(minimizeInteraction, recorder.BeforeSaveHook),
 		recorder.WithMatcher(matcherFn),
 	)
@@ -133,6 +160,12 @@ func Client(t *testing.T, cassettePath string, opts ...Option) *http.Client {
 }
 
 // redactHook returns an AfterCaptureHook that is mode-aware.
+// It delegates to redactHookWithExtras with an empty extra-redaction set.
+func redactHook(isRecording bool, keepResponseBody bool) recorder.HookFunc {
+	return redactHookWithExtras(isRecording, keepResponseBody, nil)
+}
+
+// redactHookWithExtras returns an AfterCaptureHook that is mode-aware.
 //
 // In replay mode the hook is a no-op: no live network call was made so there
 // is no live secret to redact, and mutating cassette interactions during replay
@@ -154,7 +187,7 @@ func Client(t *testing.T, cassettePath string, opts ...Option) *http.Client {
 // the raw value and its URL-encoded form AFTER the dogfood assertion has already
 // passed. It does not satisfy or bypass the assertion; it is an extra safety net
 // for service-specific token formats the scanner's ruleset may not cover.
-func redactHook(isRecording bool, keepResponseBody bool) recorder.HookFunc {
+func redactHookWithExtras(isRecording bool, keepResponseBody bool, extras [][2]string) recorder.HookFunc {
 	return func(i *cassette.Interaction) error {
 		if !isRecording {
 			// Replay mode: no-op.
@@ -276,6 +309,33 @@ func redactHook(isRecording bool, keepResponseBody bool) recorder.HookFunc {
 		// Backup scrub from SECRET_PLAINTEXT if provided.
 		if pt := os.Getenv("SECRET_PLAINTEXT"); pt != "" {
 			allSecrets = append(allSecrets, pt)
+		}
+
+		// Apply extra (old, new) replacements: account-identifying values such as
+		// cluster endpoint hostnames or cluster IDs that are not secrets but must
+		// not be committed to testdata/ in plain form. These replacements happen
+		// AFTER scanner-based redaction and are applied directly to all kept fields,
+		// using the caller-supplied replacement string (not Placeholder).
+		for _, pair := range extras {
+			old, newVal := pair[0], pair[1]
+			if old == "" {
+				continue
+			}
+			i.Request.URL = strings.ReplaceAll(i.Request.URL, old, newVal)
+			i.Request.Body = strings.ReplaceAll(i.Request.Body, old, newVal)
+			if keepResponseBody {
+				i.Response.Body = strings.ReplaceAll(i.Response.Body, old, newVal)
+			}
+			for h, vals := range i.Request.Headers {
+				for idx, v := range vals {
+					i.Request.Headers[h][idx] = strings.ReplaceAll(v, old, newVal)
+				}
+			}
+			for h, vals := range i.Response.Headers {
+				for idx, v := range vals {
+					i.Response.Headers[h][idx] = strings.ReplaceAll(v, old, newVal)
+				}
+			}
 		}
 
 		// Elide response body if not needed (secure-by-default).

--- a/pkg/validator/internal/vcrtest/vcrtest_test.go
+++ b/pkg/validator/internal/vcrtest/vcrtest_test.go
@@ -515,3 +515,64 @@ func TestRedactHook_RecordMode_SelfContainedTokenStillWorks(t *testing.T) {
 	assert.Contains(t, i.Request.Headers.Get("Authorization"), Placeholder,
 		"Placeholder must appear after redaction of self-contained token")
 }
+
+// ---- WithExtraRedactions option ----
+
+// TestWithExtraRedactions_ReplacesOldWithNew verifies that extra (old, new) pairs
+// provided via WithExtraRedactions are applied during record mode, replacing each
+// old value with the corresponding new placeholder across all cassette fields.
+func TestWithExtraRedactions_ReplacesOldWithNew(t *testing.T) {
+	// Build a hook with one extra redaction pair: replace "realhost.confluent.cloud"
+	// with "pkc-REDACTED0.example.confluent.cloud".
+	const realHost = "pkc-abc123.us-east4.gcp.confluent.cloud"
+	const fakeHost = "pkc-REDACTED0.example.confluent.cloud"
+
+	hook := redactHookWithExtras(true, false, [][2]string{{realHost, fakeHost}})
+
+	i := &cassette.Interaction{
+		Request: cassette.Request{
+			Method:  "GET",
+			URL:     "https://" + realHost + "/kafka/v3/clusters/lkc-nvodzyv/topics",
+			Headers: make(http.Header),
+		},
+		Response: cassette.Response{
+			Code:    200,
+			Body:    "",
+			Headers: make(http.Header),
+		},
+	}
+	// Satisfy the dogfood assertion by putting a detectable secret in the header.
+	i.Request.Headers.Set("Authorization", "Basic AKIADEADBEEFDEADBEEF")
+
+	err := hook(i)
+
+	require.NoError(t, err)
+	assert.NotContains(t, i.Request.URL, realHost,
+		"real host must be replaced in the URL")
+	assert.Contains(t, i.Request.URL, fakeHost,
+		"fake placeholder host must appear in the URL")
+}
+
+// TestWithExtraRedactions_ReplayModeIsNoop verifies that extra redactions are
+// not applied during replay mode (no live secrets to scrub).
+func TestWithExtraRedactions_ReplayModeIsNoop(t *testing.T) {
+	const realHost = "pkc-abc123.us-east4.gcp.confluent.cloud"
+	const fakeHost = "pkc-REDACTED0.example.confluent.cloud"
+
+	hook := redactHookWithExtras(false, false, [][2]string{{realHost, fakeHost}})
+
+	i := &cassette.Interaction{
+		Request: cassette.Request{
+			Method: "GET",
+			URL:    "https://" + realHost + "/kafka/v3/clusters/lkc-nvodzyv/topics",
+		},
+		Response: cassette.Response{},
+	}
+	origURL := i.Request.URL
+
+	err := hook(i)
+
+	require.NoError(t, err)
+	assert.Equal(t, origURL, i.Request.URL,
+		"replay mode must not modify the URL even with extra redaction pairs")
+}

--- a/pkg/validator/internal/vcrtest/vcrtest_test.go
+++ b/pkg/validator/internal/vcrtest/vcrtest_test.go
@@ -523,9 +523,9 @@ func TestRedactHook_RecordMode_SelfContainedTokenStillWorks(t *testing.T) {
 // old value with the corresponding new placeholder across all cassette fields.
 func TestWithExtraRedactions_ReplacesOldWithNew(t *testing.T) {
 	// Build a hook with one extra redaction pair: replace "realhost.confluent.cloud"
-	// with "pkc-REDACTED0.example.confluent.cloud".
+	// with "pkc-redacted0.example.confluent.cloud".
 	const realHost = "pkc-abc123.us-east4.gcp.confluent.cloud"
-	const fakeHost = "pkc-REDACTED0.example.confluent.cloud"
+	const fakeHost = "pkc-redacted0.example.confluent.cloud"
 
 	hook := redactHookWithExtras(true, false, [][2]string{{realHost, fakeHost}})
 
@@ -557,7 +557,7 @@ func TestWithExtraRedactions_ReplacesOldWithNew(t *testing.T) {
 // not applied during replay mode (no live secrets to scrub).
 func TestWithExtraRedactions_ReplayModeIsNoop(t *testing.T) {
 	const realHost = "pkc-abc123.us-east4.gcp.confluent.cloud"
-	const fakeHost = "pkc-REDACTED0.example.confluent.cloud"
+	const fakeHost = "pkc-redacted0.example.confluent.cloud"
 
 	hook := redactHookWithExtras(false, false, [][2]string{{realHost, fakeHost}})
 

--- a/pkg/validator/internal/vcrtest/vcrtest_test.go
+++ b/pkg/validator/internal/vcrtest/vcrtest_test.go
@@ -581,3 +581,58 @@ func TestWithExtraRedactions_ReplayModeIsNoop(t *testing.T) {
 	assert.Equal(t, origURL, i.Request.URL,
 		"replay mode must not modify the URL even with extra redaction pairs")
 }
+
+// TestWithExtraRedactions_PlaceholderSurvivesSecretRedaction verifies that when
+// an extras newVal contains a substring that is also a detected secret, the
+// placeholder survives intact.
+//
+// Ordering requirement: scanner-based redaction (allSecrets) must run BEFORE
+// extras substitution. If extras runs first, the substituted newVal is in the
+// URL when allSecrets processes it, and any secret substring inside newVal gets
+// re-scrubbed to Placeholder — corrupting the placeholder string.
+//
+// This is a RED-GREEN regression test:
+//   - OLD order (extras then allSecrets): URL becomes
+//     "https://pkc-REDACTED_SECRET.example.confluent.cloud/..." (corrupted)
+//   - NEW order (allSecrets then extras): URL becomes
+//     "https://pkc-AKIADEADBEEFDEADBEEF.example.confluent.cloud/..." (intact)
+func TestWithExtraRedactions_PlaceholderSurvivesSecretRedaction(t *testing.T) {
+	// realHost is the account-identifying hostname that will be swapped out.
+	const realHost = "pkc-abc123.us-east4.gcp.confluent.cloud"
+	// newHost is the fixed replay placeholder. It deliberately contains the
+	// detectable fake secret (AKIADEADBEEFDEADBEEF, matches np.aws.1) embedded in
+	// the subdomain. With the old (wrong) ordering, allSecrets would scrub it to
+	// Placeholder after extras put it in the URL; with the correct ordering, extras
+	// runs after allSecrets so it is never touched by the scanner pass.
+	const newHost = "pkc-AKIADEADBEEFDEADBEEF.example.confluent.cloud"
+
+	hook := redactHookWithExtras(true, false, [][2]string{{realHost, newHost}})
+
+	i := &cassette.Interaction{
+		Request: cassette.Request{
+			Method:  "GET",
+			URL:     "https://" + realHost + "/kafka/v3/clusters/lkc-nvodzyv/topics",
+			Headers: make(http.Header),
+		},
+		Response: cassette.Response{
+			Code:    200,
+			Body:    "",
+			Headers: make(http.Header),
+		},
+	}
+	// Put the same fake secret in the Authorization header to satisfy the dogfood
+	// assertion AND to seed allSecrets with the value that (with the old ordering)
+	// would corrupt the placeholder after extras substitutes it into the URL.
+	i.Request.Headers.Set("Authorization", "Basic AKIADEADBEEFDEADBEEF")
+
+	err := hook(i)
+
+	require.NoError(t, err, "hook must not fail the dogfood assertion")
+	// The full newHost must appear in the URL intact — no substring of it may have
+	// been replaced by Placeholder. With the old (extras-first) ordering this
+	// assertion fails because AKIADEADBEEFDEADBEEF inside newHost becomes
+	// REDACTED_SECRET after the allSecrets pass.
+	assert.Contains(t, i.Request.URL, newHost,
+		"placeholder newHost must appear intact in the URL; "+
+			"if it is corrupted, extras is running before allSecrets (wrong order)")
+}

--- a/pkg/validator/internal/vcrtest/vcrtest_test.go
+++ b/pkg/validator/internal/vcrtest/vcrtest_test.go
@@ -413,6 +413,7 @@ func TestMinimizeInteraction_StripsHeadersPreservesEssentials(t *testing.T) {
 		Request: cassette.Request{
 			Method:  "GET",
 			URL:     "https://huggingface.co/api/whoami-v2",
+			Host:    "huggingface.co",
 			Headers: http.Header{"Authorization": []string{"Bearer " + Placeholder}},
 		},
 		Response: cassette.Response{
@@ -443,6 +444,10 @@ func TestMinimizeInteraction_StripsHeadersPreservesEssentials(t *testing.T) {
 	// ContentLength normalized to match actual body length.
 	assert.Equal(t, int64(len(i.Request.Body)), i.Request.ContentLength, "request ContentLength must equal len(body)")
 	assert.Equal(t, int64(len(i.Response.Body)), i.Response.ContentLength, "response ContentLength must equal len(body)")
+
+	// Host field blanked: go-vcr stores request.host separately from request.url;
+	// blanking prevents account-identifying cluster hostnames leaking into cassettes.
+	assert.Empty(t, i.Request.Host, "request Host must be blanked by minimizeInteraction")
 }
 
 // ---- Fix 5: Context-aware header scanning + capture-group redaction ----

--- a/pkg/validator/testdata/confluent/cluster_invalid.yaml
+++ b/pkg/validator/testdata/confluent/cluster_invalid.yaml
@@ -1,0 +1,22 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: ""
+        url: https://pkc-redacted0.example.confluent.cloud:443/kafka/v3/clusters/lkc-redacted/topics
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        body: ""
+        headers: {}
+        status: 401 Unauthorized
+        code: 401
+        duration: 0s

--- a/pkg/validator/testdata/confluent/cluster_valid.yaml
+++ b/pkg/validator/testdata/confluent/cluster_valid.yaml
@@ -1,0 +1,25 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: ""
+        url: https://pkc-redacted0.example.confluent.cloud:443/kafka/v3/clusters/lkc-redacted/topics
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        transfer_encoding:
+            - chunked
+        content_length: 0
+        uncompressed: true
+        body: ""
+        headers: {}
+        status: 200 OK
+        code: 200
+        duration: 0s

--- a/pkg/validator/testdata/confluent/invalid.yaml
+++ b/pkg/validator/testdata/confluent/invalid.yaml
@@ -1,0 +1,22 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: ""
+        url: https://api.confluent.cloud/iam/v2/api-keys
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers: {}
+        status: 401 Unauthorized
+        code: 401
+        duration: 0s

--- a/pkg/validator/testdata/confluent/provenance.yaml
+++ b/pkg/validator/testdata/confluent/provenance.yaml
@@ -1,43 +1,56 @@
 # Cassette provenance for Confluent Cloud API-key validator (LAB-4050)
 #
-# TODO: Fill in all fields at record time.
-# Run:
-#   SECRET_PLAINTEXT=<secret> CONFLUENT_CLIENT_ID=<key-id> RECORD=1 \
-#       go test ./pkg/validator/ -run Test_confluent_
-# Then revoke the API key at https://confluent.cloud/settings/api-keys
+# Recorded both validation paths. To re-record:
+#   Cloud/Global key:
+#     SECRET_PLAINTEXT=<secret> CONFLUENT_CLIENT_ID=<key-id> RECORD=1 \
+#         go test ./pkg/validator/ -run Test_confluent_Valid
+#   Cluster key:
+#     SECRET_PLAINTEXT=<secret> CONFLUENT_CLIENT_ID=<key-id> \
+#       CONFLUENT_CLUSTER_ENDPOINT=<https://pkc-...confluent.cloud:443> \
+#       CONFLUENT_LKC_ID=<lkc-...> RECORD=1 \
+#         go test ./pkg/validator/ -run Test_confluent_cluster_Valid
+# Revoke keys at https://confluent.cloud after recording.
 
 service: confluent
 ticket: LAB-4050
-captured: TBD          # ISO date when cassette was recorded (YYYY-MM-DD)
-account_type: free-trial  # Confluent Cloud free trial account
-key_revoked: TBD       # MUST be set to true before committing
-valid_response: {status: 200, discriminator: "HTTP status only (response body elided)"}
-invalid_response: {status: 401}  # or 403 - confirm at record time
+captured: 2026-06-09
+account_type: free-trial   # Confluent Cloud free trial
+key_revoked: true          # both the cluster key and the global key were revoked after recording
+
+# TWO validation paths (Confluent key types are indistinguishable from the secret;
+# the validator selects the path from co-located snippet context).
+cloud_path:
+  used_by: Cloud / Global API keys
+  endpoint: https://api.confluent.cloud/iam/v2/api-keys
+  cassettes: {valid: 200, invalid: 401}
+  recorded_with: a throwaway Global API key (revoked)
+cluster_path:
+  used_by: Cluster (Kafka) API keys
+  endpoint: "{pkc-endpoint}/kafka/v3/clusters/{lkc-id}/topics"
+  cassettes: {cluster_valid: 200, cluster_invalid: 401}
+  recorded_with: a throwaway Cluster API key + its REST endpoint + lkc id (all revoked/redacted)
+
+status_mapping:
+  "200": Valid    # authenticated
+  "403": Valid    # authenticated; key is LIVE even if not authorized for the resource
+  "401": Invalid  # authentication failed (key not active)
+  other: Undetermined
+
 notes: |
-  Validation method: Basic auth base64(client_id:secret) against the
-  fixed endpoint https://api.confluent.cloud/iam/v2/api-keys (list endpoint;
-  returns 200 for any valid key pair regardless of key-specific permissions).
+  The validator (pkg/validator/confluent.go) is a Go validator covering
+  kingfisher.confluent.1/2/3. It extracts:
+    - secret from NamedGroups["secret"] (confluent.2) or Groups[0] (confluent.3 cflt token)
+    - client_id (key id, [A-Z0-9]{16}) from snippet context (keyword-proximity / client_id= / api_key=)
+    - cluster endpoint (pkc-...confluent.cloud) + lkc id (lkc-...) from snippet, when present
+  Path selection: if a pkc endpoint AND an lkc id are present in the snippet -> cluster path;
+  otherwise -> cloud control-plane path. Missing secret or client_id -> Undetermined (graceful).
 
-  The validator extracts:
-    - secret from NamedGroups["secret"] (kingfisher.confluent.2) or
-      Groups[0] (kingfisher.confluent.3 cflt-prefixed token)
-    - client_id from snippet context via keyword-proximity regex
-      (confluent/ccloud/cpdev/kafka near [A-Z0-9]{16}) or explicit label
-      (client_id=/api_key= followed by [A-Z0-9]{16})
-
-  kingfisher.confluent.1 (client_id only, no secret) always returns
-  Undetermined — there is nothing to validate without the secret.
-
-  cassette matching: the URL is FIXED (no client_id in path), so the
-  secretInsensitiveMatcher (method + host + path + query) trivially matches
-  on replay. The Authorization header containing base64(client_id:secret)
-  is stripped by the minimization hook (BeforeSaveHook) before the cassette
-  is written to disk; no credential reaches testdata/.
-
-  Response body is elided (no WithResponseBody) — status code alone
-  discriminates valid/invalid; no account PII is stored.
-
-  Secret is redacted to REDACTED_SECRET in both cassettes via the
-  scanner-driven redaction hook (vcrtest AfterCaptureHook). The
-  Basic auth blob is high-entropy and should be detected by the generic
-  scanner rule, satisfying the dogfood assertion.
+  Secret/credential hygiene (verified leak-free, raw + base64):
+    - Authorization header (Basic base64(client_id:secret)) is stripped by minimizeInteraction.
+    - request.host is blanked by minimizeInteraction (the matcher uses the URL host, not host:),
+      so account-identifying cluster hostnames are never committed.
+    - For the cluster path, the real cluster endpoint + lkc id are redacted to fixed placeholders
+      (pkc-redacted0.example.confluent.cloud / lkc-redacted) via vcrtest.WithExtraRedactions; the
+      placeholders match the production extraction regexes (guarded by a unit test) so replay works.
+    - Response body elided (status/body discriminates without storing PII).
+    - The high-entropy Basic blob satisfies the record-time dogfood assertion.

--- a/pkg/validator/testdata/confluent/provenance.yaml
+++ b/pkg/validator/testdata/confluent/provenance.yaml
@@ -1,0 +1,43 @@
+# Cassette provenance for Confluent Cloud API-key validator (LAB-4050)
+#
+# TODO: Fill in all fields at record time.
+# Run:
+#   SECRET_PLAINTEXT=<secret> CONFLUENT_CLIENT_ID=<key-id> RECORD=1 \
+#       go test ./pkg/validator/ -run Test_confluent_
+# Then revoke the API key at https://confluent.cloud/settings/api-keys
+
+service: confluent
+ticket: LAB-4050
+captured: TBD          # ISO date when cassette was recorded (YYYY-MM-DD)
+account_type: free-trial  # Confluent Cloud free trial account
+key_revoked: TBD       # MUST be set to true before committing
+valid_response: {status: 200, discriminator: "HTTP status only (response body elided)"}
+invalid_response: {status: 401}  # or 403 - confirm at record time
+notes: |
+  Validation method: Basic auth base64(client_id:secret) against the
+  fixed endpoint https://api.confluent.cloud/iam/v2/api-keys (list endpoint;
+  returns 200 for any valid key pair regardless of key-specific permissions).
+
+  The validator extracts:
+    - secret from NamedGroups["secret"] (kingfisher.confluent.2) or
+      Groups[0] (kingfisher.confluent.3 cflt-prefixed token)
+    - client_id from snippet context via keyword-proximity regex
+      (confluent/ccloud/cpdev/kafka near [A-Z0-9]{16}) or explicit label
+      (client_id=/api_key= followed by [A-Z0-9]{16})
+
+  kingfisher.confluent.1 (client_id only, no secret) always returns
+  Undetermined — there is nothing to validate without the secret.
+
+  cassette matching: the URL is FIXED (no client_id in path), so the
+  secretInsensitiveMatcher (method + host + path + query) trivially matches
+  on replay. The Authorization header containing base64(client_id:secret)
+  is stripped by the minimization hook (BeforeSaveHook) before the cassette
+  is written to disk; no credential reaches testdata/.
+
+  Response body is elided (no WithResponseBody) — status code alone
+  discriminates valid/invalid; no account PII is stored.
+
+  Secret is redacted to REDACTED_SECRET in both cassettes via the
+  scanner-driven redaction hook (vcrtest AfterCaptureHook). The
+  Basic auth blob is high-entropy and should be detected by the generic
+  scanner rule, satisfying the dogfood assertion.

--- a/pkg/validator/testdata/confluent/valid.yaml
+++ b/pkg/validator/testdata/confluent/valid.yaml
@@ -1,0 +1,23 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: ""
+        url: https://api.confluent.cloud/iam/v2/api-keys
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        uncompressed: true
+        body: ""
+        headers: {}
+        status: 200 OK
+        code: 200
+        duration: 0s


### PR DESCRIPTION
## Add Confluent Cloud API-key validator — both key types (LAB-4050)

First **Go validator** in the record/replay initiative. Covers `kingfisher.confluent.1/2/3` (Urgent; 1,075 triage instances / 23 tenants) and resolves the `web-secret-confluent-api-secret` signature too.

Closes LAB-4050.

### What it does
A Confluent Cloud API key is a **key-id + secret pair** (like AWS) — both detected together, so it's validatable from the detected context with no external user input. The validator (`pkg/validator/confluent.go`, modeled on `helpscout.go`/`aws.go`) extracts the secret from the match and the `client_id` (key id) from the snippet, then authenticates with `Basic base64(client_id:secret)`. It handles **both** Confluent key types (indistinguishable from the secret alone), selecting the path from co-located snippet context:

| Key type | Endpoint | Extra context needed |
|---|---|---|
| **Cloud / Global** | `GET https://api.confluent.cloud/iam/v2/api-keys` | none (key+secret) |
| **Cluster** | `GET {pkc-endpoint}/kafka/v3/clusters/{lkc-id}/topics` | `pkc-…` endpoint + `lkc-…` id, snippet-extracted |

If a `pkc` endpoint **and** `lkc` id are present → cluster path; else → cloud path. Missing secret/client_id → `Undetermined` (graceful, never errors).

### Status mapping (live-probed for both paths)
- **200 → Valid** (authenticated)
- **403 → Valid** — a 403 means the key authenticated (it's **live**), just unauthorized for that resource; treating it otherwise would be a false negative
- **401 → Invalid** (authentication failed)
- other → Undetermined

### Recording & secret hygiene (verified leak-free)
All four cassettes recorded against the live API with throwaway keys, **all revoked**. Verified (raw **and** base64): no key id, secret, cluster host, or lkc id appears in any cassette.
- `Authorization: Basic base64(key:secret)` header stripped by minimization.
- **`request.host` blanked** by `minimizeInteraction` (the matcher uses the URL host, not `host:`) — prevents account-identifying cluster hostnames leaking.
- Cluster endpoint + lkc id redacted to fixed placeholders (`pkc-redacted0…` / `lkc-redacted`) via the new `vcrtest.WithExtraRedactions`; placeholders match the production extraction regexes (guarded by a unit test).
- Response bodies elided; `make scan-fixtures` = 0 findings.

### Harness improvements (shared, benefit all future validators)
- `vcrtest.WithExtraRedactions` — redact co-located non-secret context (endpoints/ids) from cassettes.
- `minimizeInteraction` now blanks `request.host` — stops hostname leakage in the separate go-vcr host field.

### Tests
- Unit (httptest): CanValidate (3 rule_ids), extraction (incl. graceful errors + the 64-char-secret mis-grab guard), Validate status mapping, cluster path selection + cloud fallback.
- Cassette replay: cloud valid/invalid + cluster valid/invalid (all PASS).
- Guard test: replay placeholders must match the production extraction regexes.
- Full suite green; no regression to huggingface/exa/wandb.

### Review
Implemented + iteratively reviewed (backend-reviewer). Multiple issues caught **before** recording (replay placeholder/regex mismatches ×2, the host-field leak) — the review-before-record gate did its job. Final state APPROVED.
