### PR TITLE
feat(scoring): GitLab PAT scope enumeration and admin detection (LAB-3360)

### DIFF
--- a/pkg/scoring/gitlab.go
+++ b/pkg/scoring/gitlab.go
@@ -1,0 +1,549 @@
+package scoring
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+)
+
+// Pre-compiled patterns for extracting GitLab host from snippet context.
+var gitlabHostPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)https?://([a-zA-Z0-9][a-zA-Z0-9.\-]+\.[a-zA-Z]{2,})(?:/api/|/[a-zA-Z0-9])`),
+	regexp.MustCompile(`(?i)(?:GITLAB_HOST|CI_SERVER_HOST|CI_SERVER_URL)\s*=\s*['"]?(?:https?://)?([a-zA-Z0-9][a-zA-Z0-9.\-]+\.[a-zA-Z]{2,})`),
+}
+
+const gitlabDefaultHost = "gitlab.com"
+
+// extractGitLabToken extracts the token from match.NamedGroups["1"].
+// GitLab PAT rules use unnamed capture groups.
+func extractGitLabToken(m *types.Match) (string, bool) {
+	if m == nil {
+		return "", false
+	}
+	tok, ok := m.NamedGroups["1"]
+	if !ok || len(tok) == 0 {
+		return "", false
+	}
+	return string(tok), true
+}
+
+// extractGitLabHost extracts the GitLab host from snippet context.
+// Defaults to "gitlab.com" if not found.
+func extractGitLabHost(m *types.Match) string {
+	if m == nil {
+		return gitlabDefaultHost
+	}
+	host := searchSnippetForScoring(m.Snippet, gitlabHostPatterns)
+	if host == "" {
+		return gitlabDefaultHost
+	}
+	// Exclude Atlassian-style domains that may match the generic URL pattern.
+	if strings.Contains(strings.ToLower(host), "atlassian.net") {
+		return gitlabDefaultHost
+	}
+	return host
+}
+
+// gitlabHTTPClient is an interface for making HTTP requests (allows testing).
+type gitlabHTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// gitlabTokenSelfResponse holds the relevant fields from /personal_access_tokens/self.
+type gitlabTokenSelfResponse struct {
+	Scopes    []string `json:"scopes"`
+	Revoked   bool     `json:"revoked"`
+	ExpiresAt string   `json:"expires_at"`
+}
+
+// gitlabUserResponse holds the relevant fields from /user.
+type gitlabUserResponse struct {
+	IsAdmin bool `json:"is_admin"`
+}
+
+// gitlabFetchTokenSelf calls GET /api/v4/personal_access_tokens/self and returns
+// the parsed response along with the HTTP status code.
+func gitlabFetchTokenSelf(ctx context.Context, client gitlabHTTPClient, host, token string) (*gitlabTokenSelfResponse, int, error) {
+	url := fmt.Sprintf("https://%s/api/v4/personal_access_tokens/self", host)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	req.Header.Set("PRIVATE-TOKEN", token)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, resp.StatusCode, nil
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, resp.StatusCode, err
+	}
+
+	var info gitlabTokenSelfResponse
+	if err := json.Unmarshal(body, &info); err != nil {
+		return nil, resp.StatusCode, err
+	}
+	return &info, resp.StatusCode, nil
+}
+
+// gitlabFetchUser calls GET /api/v4/user and returns the parsed response.
+func gitlabFetchUser(ctx context.Context, client gitlabHTTPClient, host, token string) (*gitlabUserResponse, error) {
+	url := fmt.Sprintf("https://%s/api/v4/user", host)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("PRIVATE-TOKEN", token)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, nil
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var user gitlabUserResponse
+	if err := json.Unmarshal(body, &user); err != nil {
+		return nil, err
+	}
+	return &user, nil
+}
+
+// gitlabHasGroupOwnerAccess calls GET /api/v4/groups?min_access_level=50&per_page=5
+// and returns true if at least one group is returned.
+func gitlabHasGroupOwnerAccess(ctx context.Context, client gitlabHTTPClient, host, token string) (bool, error) {
+	url := fmt.Sprintf("https://%s/api/v4/groups?min_access_level=50&per_page=5", host)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return false, err
+	}
+	req.Header.Set("PRIVATE-TOKEN", token)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return false, nil
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false, err
+	}
+
+	var groups []json.RawMessage
+	if err := json.Unmarshal(body, &groups); err != nil {
+		return false, err
+	}
+	return len(groups) > 0, nil
+}
+
+// gitlabTokenIsActive returns true when the token is not revoked and not expired.
+// Scope conditions must guard with this to prevent a revoked token's scopes from
+// overwriting the lower score set by token-revoked-expired.
+func gitlabTokenIsActive(info *gitlabTokenSelfResponse) bool {
+	return info != nil && !gitlabTokenExpired(info)
+}
+
+// gitlabTokenExpired returns true when the token is revoked or has a past expiry.
+func gitlabTokenExpired(info *gitlabTokenSelfResponse) bool {
+	if info.Revoked {
+		return true
+	}
+	if info.ExpiresAt == "" {
+		return false
+	}
+	t, err := time.Parse("2006-01-02", info.ExpiresAt)
+	if err != nil {
+		return false
+	}
+	return time.Now().UTC().After(t.UTC())
+}
+
+// gitlabScopesContain reports whether the target scope is in the scopes list.
+func gitlabScopesContain(scopes []string, target string) bool {
+	for _, s := range scopes {
+		if s == target {
+			return true
+		}
+	}
+	return false
+}
+
+// gitlabOnlyHasScopes returns true when every scope in the list is one of the
+// allowed values and at least one scope is present.
+func gitlabOnlyHasScopes(scopes []string, allowed ...string) bool {
+	if len(scopes) == 0 {
+		return false
+	}
+	allowSet := make(map[string]bool, len(allowed))
+	for _, a := range allowed {
+		allowSet[a] = true
+	}
+	for _, s := range scopes {
+		if !allowSet[s] {
+			return false
+		}
+	}
+	return true
+}
+
+// ----------------------------------------------------------------------------
+// Condition implementations
+// ----------------------------------------------------------------------------
+
+// gitlabTokenRevokedCondition fires when the token returns 401/403 or is
+// revoked/expired according to /personal_access_tokens/self.
+type gitlabTokenRevokedCondition struct {
+	client gitlabHTTPClient
+}
+
+func (c *gitlabTokenRevokedCondition) markDynamic() {}
+
+func (c *gitlabTokenRevokedCondition) Evaluate(ctx context.Context, m *types.Match) (bool, error) {
+	token, ok := extractGitLabToken(m)
+	if !ok {
+		return false, nil
+	}
+	host := extractGitLabHost(m)
+
+	info, status, err := gitlabFetchTokenSelf(ctx, c.httpClient(), host, token)
+	if err != nil {
+		return false, nil
+	}
+	if status == http.StatusUnauthorized || status == http.StatusForbidden {
+		return true, nil
+	}
+	if info == nil {
+		return false, nil
+	}
+	return gitlabTokenExpired(info), nil
+}
+
+func (c *gitlabTokenRevokedCondition) httpClient() gitlabHTTPClient {
+	if c.client != nil {
+		return c.client
+	}
+	return defaultHTTPClient
+}
+
+// gitlabSudoScopeCondition fires when the token's scopes contain "sudo".
+type gitlabSudoScopeCondition struct {
+	client gitlabHTTPClient
+}
+
+func (c *gitlabSudoScopeCondition) markDynamic() {}
+
+func (c *gitlabSudoScopeCondition) Evaluate(ctx context.Context, m *types.Match) (bool, error) {
+	token, ok := extractGitLabToken(m)
+	if !ok {
+		return false, nil
+	}
+	host := extractGitLabHost(m)
+
+	info, _, err := gitlabFetchTokenSelf(ctx, c.httpClient(), host, token)
+	if err != nil || info == nil {
+		return false, nil
+	}
+	if !gitlabTokenIsActive(info) {
+		return false, nil
+	}
+	return gitlabScopesContain(info.Scopes, "sudo"), nil
+}
+
+func (c *gitlabSudoScopeCondition) httpClient() gitlabHTTPClient {
+	if c.client != nil {
+		return c.client
+	}
+	return defaultHTTPClient
+}
+
+// gitlabAdminAPIScopeCondition fires when is_admin=true AND the token has the "api" scope.
+type gitlabAdminAPIScopeCondition struct {
+	client gitlabHTTPClient
+}
+
+func (c *gitlabAdminAPIScopeCondition) markDynamic() {}
+
+func (c *gitlabAdminAPIScopeCondition) Evaluate(ctx context.Context, m *types.Match) (bool, error) {
+	token, ok := extractGitLabToken(m)
+	if !ok {
+		return false, nil
+	}
+	host := extractGitLabHost(m)
+	cl := c.httpClient()
+
+	info, _, err := gitlabFetchTokenSelf(ctx, cl, host, token)
+	if err != nil || info == nil {
+		return false, nil
+	}
+	if !gitlabTokenIsActive(info) {
+		return false, nil
+	}
+	if !gitlabScopesContain(info.Scopes, "api") {
+		return false, nil
+	}
+	if gitlabScopesContain(info.Scopes, "sudo") {
+		return false, nil
+	}
+
+	user, err := gitlabFetchUser(ctx, cl, host, token)
+	if err != nil || user == nil {
+		return false, nil
+	}
+	return user.IsAdmin, nil
+}
+
+func (c *gitlabAdminAPIScopeCondition) httpClient() gitlabHTTPClient {
+	if c.client != nil {
+		return c.client
+	}
+	return defaultHTTPClient
+}
+
+// gitlabReadUserOnlyCondition fires when the token only has the "read_user" scope.
+type gitlabReadUserOnlyCondition struct {
+	client gitlabHTTPClient
+}
+
+func (c *gitlabReadUserOnlyCondition) markDynamic() {}
+
+func (c *gitlabReadUserOnlyCondition) Evaluate(ctx context.Context, m *types.Match) (bool, error) {
+	token, ok := extractGitLabToken(m)
+	if !ok {
+		return false, nil
+	}
+	host := extractGitLabHost(m)
+
+	info, _, err := gitlabFetchTokenSelf(ctx, c.httpClient(), host, token)
+	if err != nil || info == nil {
+		return false, nil
+	}
+	if !gitlabTokenIsActive(info) {
+		return false, nil
+	}
+	return gitlabOnlyHasScopes(info.Scopes, "read_user"), nil
+}
+
+func (c *gitlabReadUserOnlyCondition) httpClient() gitlabHTTPClient {
+	if c.client != nil {
+		return c.client
+	}
+	return defaultHTTPClient
+}
+
+// gitlabAPIScopeGroupOwnerCondition fires when the token has the "api" scope
+// AND the user has Owner access to at least one group.
+type gitlabAPIScopeGroupOwnerCondition struct {
+	client gitlabHTTPClient
+}
+
+func (c *gitlabAPIScopeGroupOwnerCondition) markDynamic() {}
+
+func (c *gitlabAPIScopeGroupOwnerCondition) Evaluate(ctx context.Context, m *types.Match) (bool, error) {
+	token, ok := extractGitLabToken(m)
+	if !ok {
+		return false, nil
+	}
+	host := extractGitLabHost(m)
+	cl := c.httpClient()
+
+	info, _, err := gitlabFetchTokenSelf(ctx, cl, host, token)
+	if err != nil || info == nil {
+		return false, nil
+	}
+	if !gitlabTokenIsActive(info) {
+		return false, nil
+	}
+	if !gitlabScopesContain(info.Scopes, "api") {
+		return false, nil
+	}
+
+	hasOwner, err := gitlabHasGroupOwnerAccess(ctx, cl, host, token)
+	if err != nil {
+		return false, nil
+	}
+	return hasOwner, nil
+}
+
+func (c *gitlabAPIScopeGroupOwnerCondition) httpClient() gitlabHTTPClient {
+	if c.client != nil {
+		return c.client
+	}
+	return defaultHTTPClient
+}
+
+// gitlabSelfHostedCondition fires when the host is not gitlab.com (static).
+type gitlabSelfHostedCondition struct{}
+
+func (c *gitlabSelfHostedCondition) Evaluate(_ context.Context, m *types.Match) (bool, error) {
+	host := extractGitLabHost(m)
+	return !strings.EqualFold(host, gitlabDefaultHost), nil
+}
+
+// gitlabWriteRepoMultiGroupCondition fires when the token has "write_repository"
+// scope AND the user has Owner access to at least one group.
+type gitlabWriteRepoMultiGroupCondition struct {
+	client gitlabHTTPClient
+}
+
+func (c *gitlabWriteRepoMultiGroupCondition) markDynamic() {}
+
+func (c *gitlabWriteRepoMultiGroupCondition) Evaluate(ctx context.Context, m *types.Match) (bool, error) {
+	token, ok := extractGitLabToken(m)
+	if !ok {
+		return false, nil
+	}
+	host := extractGitLabHost(m)
+	cl := c.httpClient()
+
+	info, _, err := gitlabFetchTokenSelf(ctx, cl, host, token)
+	if err != nil || info == nil {
+		return false, nil
+	}
+	if !gitlabTokenIsActive(info) {
+		return false, nil
+	}
+	if !gitlabScopesContain(info.Scopes, "write_repository") {
+		return false, nil
+	}
+
+	hasOwner, err := gitlabHasGroupOwnerAccess(ctx, cl, host, token)
+	if err != nil {
+		return false, nil
+	}
+	return hasOwner, nil
+}
+
+func (c *gitlabWriteRepoMultiGroupCondition) httpClient() gitlabHTTPClient {
+	if c.client != nil {
+		return c.client
+	}
+	return defaultHTTPClient
+}
+
+// gitlabReadAPIOnlyNonAdminCondition fires when the token only has "read_api"
+// scope AND the user is not an admin.
+type gitlabReadAPIOnlyNonAdminCondition struct {
+	client gitlabHTTPClient
+}
+
+func (c *gitlabReadAPIOnlyNonAdminCondition) markDynamic() {}
+
+func (c *gitlabReadAPIOnlyNonAdminCondition) Evaluate(ctx context.Context, m *types.Match) (bool, error) {
+	token, ok := extractGitLabToken(m)
+	if !ok {
+		return false, nil
+	}
+	host := extractGitLabHost(m)
+	cl := c.httpClient()
+
+	info, _, err := gitlabFetchTokenSelf(ctx, cl, host, token)
+	if err != nil || info == nil {
+		return false, nil
+	}
+	if !gitlabTokenIsActive(info) {
+		return false, nil
+	}
+	if !gitlabOnlyHasScopes(info.Scopes, "read_api") {
+		return false, nil
+	}
+
+	user, err := gitlabFetchUser(ctx, cl, host, token)
+	if err != nil || user == nil {
+		return false, nil
+	}
+	return !user.IsAdmin, nil
+}
+
+func (c *gitlabReadAPIOnlyNonAdminCondition) httpClient() gitlabHTTPClient {
+	if c.client != nil {
+		return c.client
+	}
+	return defaultHTTPClient
+}
+
+// gitlabNoGroupOwnerCondition fires when the user has NO Owner access to any group.
+type gitlabNoGroupOwnerCondition struct {
+	client gitlabHTTPClient
+}
+
+func (c *gitlabNoGroupOwnerCondition) markDynamic() {}
+
+func (c *gitlabNoGroupOwnerCondition) Evaluate(ctx context.Context, m *types.Match) (bool, error) {
+	token, ok := extractGitLabToken(m)
+	if !ok {
+		return false, nil
+	}
+	host := extractGitLabHost(m)
+	cl := c.httpClient()
+
+	info, _, err := gitlabFetchTokenSelf(ctx, cl, host, token)
+	if err != nil || info == nil {
+		return false, nil
+	}
+	if !gitlabTokenIsActive(info) {
+		return false, nil
+	}
+	if !gitlabScopesContain(info.Scopes, "api") && !gitlabScopesContain(info.Scopes, "read_api") {
+		return false, nil
+	}
+
+	hasOwner, err := gitlabHasGroupOwnerAccess(ctx, cl, host, token)
+	if err != nil {
+		return false, nil
+	}
+	return !hasOwner, nil
+}
+
+func (c *gitlabNoGroupOwnerCondition) httpClient() gitlabHTTPClient {
+	if c.client != nil {
+		return c.client
+	}
+	return defaultHTTPClient
+}
+
+// GitLabGoScorer returns the GitLab PAT scoring configuration for np.gitlab.2
+// and np.gitlab.4 (LAB-3360).
+func GitLabGoScorer() *Scorer {
+	return &Scorer{
+		Name:    "gitlab-pat-scope",
+		RuleIDs: []string{"np.gitlab.2", "np.gitlab.4"},
+		Modifiers: []Modifier{
+			{Name: "token-revoked-expired", Priority: 100, Kind: ModifierKindSetScore, Value: 5, Condition: &gitlabTokenRevokedCondition{}},
+			{Name: "sudo-scope", Priority: 95, Kind: ModifierKindSetScore, Value: 99, Condition: &gitlabSudoScopeCondition{}},
+			{Name: "admin-api-scope", Priority: 90, Kind: ModifierKindSetScore, Value: 95, Condition: &gitlabAdminAPIScopeCondition{}},
+			{Name: "read-user-only", Priority: 85, Kind: ModifierKindSetScore, Value: 15, Condition: &gitlabReadUserOnlyCondition{}},
+			{Name: "api-scope-group-owner", Priority: 70, Kind: ModifierKindDelta, Value: 15, Condition: &gitlabAPIScopeGroupOwnerCondition{}},
+			{Name: "self-hosted-instance", Priority: 65, Kind: ModifierKindDelta, Value: 10, Condition: &gitlabSelfHostedCondition{}},
+			{Name: "write-repo-multi-group", Priority: 60, Kind: ModifierKindDelta, Value: 10, Condition: &gitlabWriteRepoMultiGroupCondition{}},
+			{Name: "read-api-only-non-admin", Priority: 55, Kind: ModifierKindDelta, Value: -20, Condition: &gitlabReadAPIOnlyNonAdminCondition{}},
+			{Name: "no-group-owner", Priority: 50, Kind: ModifierKindDelta, Value: -10, Condition: &gitlabNoGroupOwnerCondition{}},
+		},
+	}
+}

--- a/pkg/scoring/gitlab.go
+++ b/pkg/scoring/gitlab.go
@@ -21,17 +21,22 @@ var gitlabHostPatterns = []*regexp.Regexp{
 
 const gitlabDefaultHost = "gitlab.com"
 
-// extractGitLabToken extracts the token from match.NamedGroups["1"].
-// GitLab PAT rules use unnamed capture groups.
+// extractGitLabToken extracts the token from the match. It checks positional
+// groups first (m.Groups[0]), then falls back to named groups "token" or "1".
+// GitLab PAT rules use unnamed capture groups which populate m.Groups.
 func extractGitLabToken(m *types.Match) (string, bool) {
 	if m == nil {
 		return "", false
 	}
-	tok, ok := m.NamedGroups["1"]
-	if !ok || len(tok) == 0 {
-		return "", false
+	if len(m.Groups) > 0 && len(m.Groups[0]) > 0 {
+		return string(m.Groups[0]), true
 	}
-	return string(tok), true
+	for _, name := range []string{"token", "1"} {
+		if v, ok := m.NamedGroups[name]; ok && len(v) > 0 {
+			return string(v), true
+		}
+	}
+	return "", false
 }
 
 // extractGitLabHost extracts the GitLab host from snippet context.
@@ -88,7 +93,7 @@ func gitlabFetchTokenSelf(ctx context.Context, client gitlabHTTPClient, host, to
 		return nil, resp.StatusCode, nil
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
 		return nil, resp.StatusCode, err
 	}
@@ -119,7 +124,7 @@ func gitlabFetchUser(ctx context.Context, client gitlabHTTPClient, host, token s
 		return nil, nil
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +156,7 @@ func gitlabHasGroupOwnerAccess(ctx context.Context, client gitlabHTTPClient, hos
 		return false, nil
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
 		return false, err
 	}
@@ -182,7 +187,7 @@ func gitlabTokenExpired(info *gitlabTokenSelfResponse) bool {
 	if err != nil {
 		return false
 	}
-	return time.Now().UTC().After(t.UTC())
+	return time.Now().UTC().After(t.AddDate(0, 0, 1).UTC())
 }
 
 // gitlabScopesContain reports whether the target scope is in the scopes list.
@@ -398,12 +403,37 @@ func (c *gitlabAPIScopeGroupOwnerCondition) httpClient() gitlabHTTPClient {
 	return defaultHTTPClient
 }
 
-// gitlabSelfHostedCondition fires when the host is not gitlab.com (static).
-type gitlabSelfHostedCondition struct{}
+// gitlabSelfHostedCondition fires when the token is active AND the host is not
+// gitlab.com. It is dynamic because it must verify the token is not revoked
+// before firing, preventing the delta from applying to revoked tokens.
+type gitlabSelfHostedCondition struct {
+	client gitlabHTTPClient
+}
 
-func (c *gitlabSelfHostedCondition) Evaluate(_ context.Context, m *types.Match) (bool, error) {
+func (c *gitlabSelfHostedCondition) markDynamic() {}
+
+func (c *gitlabSelfHostedCondition) Evaluate(ctx context.Context, m *types.Match) (bool, error) {
+	token, ok := extractGitLabToken(m)
+	if !ok {
+		return false, nil
+	}
 	host := extractGitLabHost(m)
+
+	info, _, err := gitlabFetchTokenSelf(ctx, c.httpClient(), host, token)
+	if err != nil || info == nil {
+		return false, nil
+	}
+	if !gitlabTokenIsActive(info) {
+		return false, nil
+	}
 	return !strings.EqualFold(host, gitlabDefaultHost), nil
+}
+
+func (c *gitlabSelfHostedCondition) httpClient() gitlabHTTPClient {
+	if c.client != nil {
+		return c.client
+	}
+	return defaultHTTPClient
 }
 
 // gitlabWriteRepoMultiGroupCondition fires when the token has "write_repository"
@@ -430,6 +460,9 @@ func (c *gitlabWriteRepoMultiGroupCondition) Evaluate(ctx context.Context, m *ty
 		return false, nil
 	}
 	if !gitlabScopesContain(info.Scopes, "write_repository") {
+		return false, nil
+	}
+	if !gitlabScopesContain(info.Scopes, "api") && !gitlabScopesContain(info.Scopes, "read_api") {
 		return false, nil
 	}
 

--- a/pkg/scoring/gitlab_test.go
+++ b/pkg/scoring/gitlab_test.go
@@ -1,0 +1,413 @@
+package scoring
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func gitlabMatch(host string) *types.Match {
+	return &types.Match{
+		RuleID: "np.gitlab.2",
+		NamedGroups: map[string][]byte{
+			"1": []byte("glpat-testTOKENforUNIT_test"),
+		},
+		Snippet: types.Snippet{
+			Before:   []byte("GITLAB_HOST=" + host + "\n"),
+			Matching: []byte("PRIVATE_TOKEN=glpat-testTOKENforUNIT_test"),
+			After:    []byte("\n"),
+		},
+	}
+}
+
+// gitlabServer creates a test server that responds to GitLab API endpoints.
+// scopes, revoked, expiresAt configure /personal_access_tokens/self.
+// isAdmin configures /user.
+// groups configures /groups.
+func gitlabServer(t *testing.T, scopes []string, revoked bool, expiresAt string, isAdmin bool, groups []map[string]interface{}) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v4/personal_access_tokens/self":
+			w.WriteHeader(http.StatusOK)
+			resp := map[string]interface{}{
+				"scopes":  scopes,
+				"revoked": revoked,
+			}
+			if expiresAt != "" {
+				resp["expires_at"] = expiresAt
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+		case "/api/v4/user":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"is_admin": isAdmin,
+			})
+		case "/api/v4/groups":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(groups)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+func TestExtractGitLabToken_Present(t *testing.T) {
+	m := &types.Match{
+		NamedGroups: map[string][]byte{
+			"1": []byte("glpat-testTOKENforUNIT_test"),
+		},
+	}
+	tok, ok := extractGitLabToken(m)
+	assert.True(t, ok)
+	assert.Equal(t, "glpat-testTOKENforUNIT_test", tok)
+}
+
+func TestExtractGitLabToken_Missing(t *testing.T) {
+	m := &types.Match{NamedGroups: map[string][]byte{}}
+	_, ok := extractGitLabToken(m)
+	assert.False(t, ok)
+}
+
+func TestExtractGitLabHost_FromSnippet(t *testing.T) {
+	m := gitlabMatch("gitlab.mycompany.com")
+	host := extractGitLabHost(m)
+	assert.Equal(t, "gitlab.mycompany.com", host)
+}
+
+func TestExtractGitLabHost_DefaultsToGitLabCom(t *testing.T) {
+	m := &types.Match{
+		NamedGroups: map[string][]byte{"1": []byte("glpat-test")},
+		Snippet: types.Snippet{
+			Before:   []byte("PRIVATE_TOKEN=glpat-test\n"),
+			Matching: []byte("x=1"),
+			After:    []byte("\n"),
+		},
+	}
+	host := extractGitLabHost(m)
+	assert.Equal(t, "gitlab.com", host)
+}
+
+func TestGitLabTokenRevokedCondition_Revoked(t *testing.T) {
+	server := gitlabServer(t, []string{"api"}, true, "", false, nil)
+	defer server.Close()
+
+	c := &gitlabTokenRevokedCondition{client: &redirectingClient{target: server.URL}}
+	fired, err := c.Evaluate(context.Background(), gitlabMatch("gitlab.com"))
+	require.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestGitLabTokenRevokedCondition_Expired(t *testing.T) {
+	server := gitlabServer(t, []string{"api"}, false, "2000-01-01", false, nil)
+	defer server.Close()
+
+	c := &gitlabTokenRevokedCondition{client: &redirectingClient{target: server.URL}}
+	fired, err := c.Evaluate(context.Background(), gitlabMatch("gitlab.com"))
+	require.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestGitLabTokenRevokedCondition_Unauthorized(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	c := &gitlabTokenRevokedCondition{client: &redirectingClient{target: server.URL}}
+	fired, err := c.Evaluate(context.Background(), gitlabMatch("gitlab.com"))
+	require.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestGitLabTokenRevokedCondition_Active(t *testing.T) {
+	server := gitlabServer(t, []string{"api"}, false, "2099-01-01", false, nil)
+	defer server.Close()
+
+	c := &gitlabTokenRevokedCondition{client: &redirectingClient{target: server.URL}}
+	fired, err := c.Evaluate(context.Background(), gitlabMatch("gitlab.com"))
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestGitLabSudoScopeCondition_HasSudo(t *testing.T) {
+	server := gitlabServer(t, []string{"api", "sudo"}, false, "", false, nil)
+	defer server.Close()
+
+	c := &gitlabSudoScopeCondition{client: &redirectingClient{target: server.URL}}
+	fired, err := c.Evaluate(context.Background(), gitlabMatch("gitlab.com"))
+	require.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestGitLabSudoScopeCondition_NoSudo(t *testing.T) {
+	server := gitlabServer(t, []string{"api", "read_user"}, false, "", false, nil)
+	defer server.Close()
+
+	c := &gitlabSudoScopeCondition{client: &redirectingClient{target: server.URL}}
+	fired, err := c.Evaluate(context.Background(), gitlabMatch("gitlab.com"))
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestGitLabAdminAPIScopeCondition_AdminWithAPI(t *testing.T) {
+	server := gitlabServer(t, []string{"api"}, false, "", true, nil)
+	defer server.Close()
+
+	c := &gitlabAdminAPIScopeCondition{client: &redirectingClient{target: server.URL}}
+	fired, err := c.Evaluate(context.Background(), gitlabMatch("gitlab.com"))
+	require.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestGitLabAdminAPIScopeCondition_AdminNoAPI(t *testing.T) {
+	server := gitlabServer(t, []string{"read_user"}, false, "", true, nil)
+	defer server.Close()
+
+	c := &gitlabAdminAPIScopeCondition{client: &redirectingClient{target: server.URL}}
+	fired, err := c.Evaluate(context.Background(), gitlabMatch("gitlab.com"))
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestGitLabAdminAPIScopeCondition_NonAdminWithAPI(t *testing.T) {
+	server := gitlabServer(t, []string{"api"}, false, "", false, nil)
+	defer server.Close()
+
+	c := &gitlabAdminAPIScopeCondition{client: &redirectingClient{target: server.URL}}
+	fired, err := c.Evaluate(context.Background(), gitlabMatch("gitlab.com"))
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestGitLabReadUserOnlyCondition_OnlyReadUser(t *testing.T) {
+	server := gitlabServer(t, []string{"read_user"}, false, "", false, nil)
+	defer server.Close()
+
+	c := &gitlabReadUserOnlyCondition{client: &redirectingClient{target: server.URL}}
+	fired, err := c.Evaluate(context.Background(), gitlabMatch("gitlab.com"))
+	require.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestGitLabReadUserOnlyCondition_MultipleScopes(t *testing.T) {
+	server := gitlabServer(t, []string{"read_user", "api"}, false, "", false, nil)
+	defer server.Close()
+
+	c := &gitlabReadUserOnlyCondition{client: &redirectingClient{target: server.URL}}
+	fired, err := c.Evaluate(context.Background(), gitlabMatch("gitlab.com"))
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestGitLabAPIScopeGroupOwnerCondition_HasBoth(t *testing.T) {
+	groups := []map[string]interface{}{{"id": 1, "name": "mygroup"}}
+	server := gitlabServer(t, []string{"api"}, false, "", false, groups)
+	defer server.Close()
+
+	c := &gitlabAPIScopeGroupOwnerCondition{client: &redirectingClient{target: server.URL}}
+	fired, err := c.Evaluate(context.Background(), gitlabMatch("gitlab.com"))
+	require.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestGitLabAPIScopeGroupOwnerCondition_NoGroups(t *testing.T) {
+	server := gitlabServer(t, []string{"api"}, false, "", false, []map[string]interface{}{})
+	defer server.Close()
+
+	c := &gitlabAPIScopeGroupOwnerCondition{client: &redirectingClient{target: server.URL}}
+	fired, err := c.Evaluate(context.Background(), gitlabMatch("gitlab.com"))
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestGitLabSelfHostedCondition_SelfHosted(t *testing.T) {
+	c := &gitlabSelfHostedCondition{}
+	fired, err := c.Evaluate(context.Background(), gitlabMatch("gitlab.mycompany.com"))
+	require.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestGitLabSelfHostedCondition_GitLabCom(t *testing.T) {
+	c := &gitlabSelfHostedCondition{}
+	fired, err := c.Evaluate(context.Background(), gitlabMatch("gitlab.com"))
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestGitLabReadAPIOnlyNonAdminCondition_Fires(t *testing.T) {
+	server := gitlabServer(t, []string{"read_api"}, false, "", false, nil)
+	defer server.Close()
+
+	c := &gitlabReadAPIOnlyNonAdminCondition{client: &redirectingClient{target: server.URL}}
+	fired, err := c.Evaluate(context.Background(), gitlabMatch("gitlab.com"))
+	require.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestGitLabReadAPIOnlyNonAdminCondition_AdminDoesNotFire(t *testing.T) {
+	server := gitlabServer(t, []string{"read_api"}, false, "", true, nil)
+	defer server.Close()
+
+	c := &gitlabReadAPIOnlyNonAdminCondition{client: &redirectingClient{target: server.URL}}
+	fired, err := c.Evaluate(context.Background(), gitlabMatch("gitlab.com"))
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestGitLabNoGroupOwnerCondition_NoOwner(t *testing.T) {
+	server := gitlabServer(t, []string{"api"}, false, "", false, []map[string]interface{}{})
+	defer server.Close()
+
+	c := &gitlabNoGroupOwnerCondition{client: &redirectingClient{target: server.URL}}
+	fired, err := c.Evaluate(context.Background(), gitlabMatch("gitlab.com"))
+	require.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestGitLabNoGroupOwnerCondition_HasOwner(t *testing.T) {
+	groups := []map[string]interface{}{{"id": 1, "name": "mygroup"}}
+	server := gitlabServer(t, []string{"api"}, false, "", false, groups)
+	defer server.Close()
+
+	c := &gitlabNoGroupOwnerCondition{client: &redirectingClient{target: server.URL}}
+	fired, err := c.Evaluate(context.Background(), gitlabMatch("gitlab.com"))
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestGitLabAdminAPIScopeCondition_SudoExcluded(t *testing.T) {
+	// Token has sudo + api + is_admin → admin-api-scope should NOT fire
+	// because sudo-scope already covers it at higher priority.
+	server := gitlabServer(t, []string{"sudo", "api"}, false, "", true, nil)
+	defer server.Close()
+
+	c := &gitlabAdminAPIScopeCondition{client: &redirectingClient{target: server.URL}}
+	fired, err := c.Evaluate(context.Background(), gitlabMatch("gitlab.com"))
+	require.NoError(t, err)
+	assert.False(t, fired, "admin-api-scope should not fire when sudo scope is present")
+}
+
+func TestGitLabNoGroupOwnerCondition_SkipsReadUserOnly(t *testing.T) {
+	// Token with only read_user scope can't access groups at all.
+	// no-group-owner should not fire since the check is meaningless.
+	server := gitlabServer(t, []string{"read_user"}, false, "", false, []map[string]interface{}{})
+	defer server.Close()
+
+	c := &gitlabNoGroupOwnerCondition{client: &redirectingClient{target: server.URL}}
+	fired, err := c.Evaluate(context.Background(), gitlabMatch("gitlab.com"))
+	require.NoError(t, err)
+	assert.False(t, fired, "no-group-owner should not fire when token lacks api/read_api scope")
+}
+
+func TestGitLabGoScorer_Structure(t *testing.T) {
+	s := GitLabGoScorer()
+	assert.Equal(t, "gitlab-pat-scope", s.Name)
+	assert.Contains(t, s.RuleIDs, "np.gitlab.2")
+	assert.Contains(t, s.RuleIDs, "np.gitlab.4")
+	assert.Equal(t, 9, len(s.Modifiers), "expected 9 modifiers")
+
+	names := make([]string, len(s.Modifiers))
+	for i, mod := range s.Modifiers {
+		names[i] = mod.Name
+	}
+	assert.Contains(t, names, "token-revoked-expired")
+	assert.Contains(t, names, "sudo-scope")
+	assert.Contains(t, names, "admin-api-scope")
+	assert.Contains(t, names, "read-user-only")
+	assert.Contains(t, names, "api-scope-group-owner")
+	assert.Contains(t, names, "self-hosted-instance")
+	assert.Contains(t, names, "write-repo-multi-group")
+	assert.Contains(t, names, "read-api-only-non-admin")
+	assert.Contains(t, names, "no-group-owner")
+}
+
+func TestGitLabGoScorer_MissingCredentials(t *testing.T) {
+	s := GitLabGoScorer()
+	m := &types.Match{
+		RuleID:      "np.gitlab.2",
+		NamedGroups: map[string][]byte{},
+	}
+
+	for _, mod := range s.Modifiers {
+		fired, err := mod.Condition.Evaluate(context.Background(), m)
+		assert.NoError(t, err, "modifier %s should not error", mod.Name)
+		assert.False(t, fired, "modifier %s should not fire without credentials", mod.Name)
+	}
+}
+
+func TestGitLabSudoScopeCondition_RevokedTokenDoesNotFire(t *testing.T) {
+	// Token is revoked but still has sudo scope in API response.
+	// Condition must NOT fire — revoked overrides all scope checks.
+	server := gitlabServer(t, []string{"sudo", "api"}, true, "", true, nil)
+	defer server.Close()
+
+	c := &gitlabSudoScopeCondition{client: &redirectingClient{target: server.URL}}
+	fired, err := c.Evaluate(context.Background(), gitlabMatch("gitlab.com"))
+	require.NoError(t, err)
+	assert.False(t, fired, "sudo-scope must not fire on revoked token")
+}
+
+func TestGitLabAdminAPIScopeCondition_RevokedTokenDoesNotFire(t *testing.T) {
+	server := gitlabServer(t, []string{"api"}, true, "", true, nil)
+	defer server.Close()
+
+	c := &gitlabAdminAPIScopeCondition{client: &redirectingClient{target: server.URL}}
+	fired, err := c.Evaluate(context.Background(), gitlabMatch("gitlab.com"))
+	require.NoError(t, err)
+	assert.False(t, fired, "admin-api-scope must not fire on revoked token")
+}
+
+func TestGitLabWriteRepoMultiGroupCondition_Fires(t *testing.T) {
+	groups := []map[string]interface{}{{"id": 1, "name": "mygroup"}}
+	server := gitlabServer(t, []string{"write_repository"}, false, "2099-01-01", false, groups)
+	defer server.Close()
+
+	c := &gitlabWriteRepoMultiGroupCondition{client: &redirectingClient{target: server.URL}}
+	fired, err := c.Evaluate(context.Background(), gitlabMatch("gitlab.com"))
+	require.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestGitLabWriteRepoMultiGroupCondition_NoWriteRepo(t *testing.T) {
+	groups := []map[string]interface{}{{"id": 1, "name": "mygroup"}}
+	server := gitlabServer(t, []string{"read_api"}, false, "2099-01-01", false, groups)
+	defer server.Close()
+
+	c := &gitlabWriteRepoMultiGroupCondition{client: &redirectingClient{target: server.URL}}
+	fired, err := c.Evaluate(context.Background(), gitlabMatch("gitlab.com"))
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestGitLabNoGroupOwnerCondition_ReadAPIScope(t *testing.T) {
+	// read_api is sufficient scope to check groups; condition should fire when no groups.
+	server := gitlabServer(t, []string{"read_api"}, false, "2099-01-01", false, []map[string]interface{}{})
+	defer server.Close()
+
+	c := &gitlabNoGroupOwnerCondition{client: &redirectingClient{target: server.URL}}
+	fired, err := c.Evaluate(context.Background(), gitlabMatch("gitlab.com"))
+	require.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestGitLabGoScorer_IsDynamic(t *testing.T) {
+	s := GitLabGoScorer()
+	staticMods := map[string]bool{
+		"self-hosted-instance": true,
+	}
+
+	for _, mod := range s.Modifiers {
+		if staticMods[mod.Name] {
+			assert.False(t, mod.IsDynamic(), "modifier %s should be static", mod.Name)
+		} else {
+			assert.True(t, mod.IsDynamic(), "modifier %s should be dynamic", mod.Name)
+		}
+	}
+}

--- a/pkg/scoring/gitlab_test.go
+++ b/pkg/scoring/gitlab_test.go
@@ -15,8 +15,8 @@ import (
 func gitlabMatch(host string) *types.Match {
 	return &types.Match{
 		RuleID: "np.gitlab.2",
-		NamedGroups: map[string][]byte{
-			"1": []byte("glpat-testTOKENforUNIT_test"),
+		Groups: [][]byte{
+			[]byte("glpat-testTOKENforUNIT_test"),
 		},
 		Snippet: types.Snippet{
 			Before:   []byte("GITLAB_HOST=" + host + "\n"),
@@ -60,8 +60,8 @@ func gitlabServer(t *testing.T, scopes []string, revoked bool, expiresAt string,
 
 func TestExtractGitLabToken_Present(t *testing.T) {
 	m := &types.Match{
-		NamedGroups: map[string][]byte{
-			"1": []byte("glpat-testTOKENforUNIT_test"),
+		Groups: [][]byte{
+			[]byte("glpat-testTOKENforUNIT_test"),
 		},
 	}
 	tok, ok := extractGitLabToken(m)
@@ -70,7 +70,7 @@ func TestExtractGitLabToken_Present(t *testing.T) {
 }
 
 func TestExtractGitLabToken_Missing(t *testing.T) {
-	m := &types.Match{NamedGroups: map[string][]byte{}}
+	m := &types.Match{Groups: [][]byte{}}
 	_, ok := extractGitLabToken(m)
 	assert.False(t, ok)
 }
@@ -83,7 +83,7 @@ func TestExtractGitLabHost_FromSnippet(t *testing.T) {
 
 func TestExtractGitLabHost_DefaultsToGitLabCom(t *testing.T) {
 	m := &types.Match{
-		NamedGroups: map[string][]byte{"1": []byte("glpat-test")},
+		Groups: [][]byte{[]byte("glpat-test")},
 		Snippet: types.Snippet{
 			Before:   []byte("PRIVATE_TOKEN=glpat-test\n"),
 			Matching: []byte("x=1"),
@@ -228,14 +228,20 @@ func TestGitLabAPIScopeGroupOwnerCondition_NoGroups(t *testing.T) {
 }
 
 func TestGitLabSelfHostedCondition_SelfHosted(t *testing.T) {
-	c := &gitlabSelfHostedCondition{}
+	server := gitlabServer(t, []string{"api"}, false, "", false, nil)
+	defer server.Close()
+
+	c := &gitlabSelfHostedCondition{client: &redirectingClient{target: server.URL}}
 	fired, err := c.Evaluate(context.Background(), gitlabMatch("gitlab.mycompany.com"))
 	require.NoError(t, err)
 	assert.True(t, fired)
 }
 
 func TestGitLabSelfHostedCondition_GitLabCom(t *testing.T) {
-	c := &gitlabSelfHostedCondition{}
+	server := gitlabServer(t, []string{"api"}, false, "", false, nil)
+	defer server.Close()
+
+	c := &gitlabSelfHostedCondition{client: &redirectingClient{target: server.URL}}
 	fired, err := c.Evaluate(context.Background(), gitlabMatch("gitlab.com"))
 	require.NoError(t, err)
 	assert.False(t, fired)
@@ -331,8 +337,8 @@ func TestGitLabGoScorer_Structure(t *testing.T) {
 func TestGitLabGoScorer_MissingCredentials(t *testing.T) {
 	s := GitLabGoScorer()
 	m := &types.Match{
-		RuleID:      "np.gitlab.2",
-		NamedGroups: map[string][]byte{},
+		RuleID: "np.gitlab.2",
+		Groups: [][]byte{},
 	}
 
 	for _, mod := range s.Modifiers {
@@ -366,7 +372,7 @@ func TestGitLabAdminAPIScopeCondition_RevokedTokenDoesNotFire(t *testing.T) {
 
 func TestGitLabWriteRepoMultiGroupCondition_Fires(t *testing.T) {
 	groups := []map[string]interface{}{{"id": 1, "name": "mygroup"}}
-	server := gitlabServer(t, []string{"write_repository"}, false, "2099-01-01", false, groups)
+	server := gitlabServer(t, []string{"write_repository", "api"}, false, "2099-01-01", false, groups)
 	defer server.Close()
 
 	c := &gitlabWriteRepoMultiGroupCondition{client: &redirectingClient{target: server.URL}}
@@ -399,15 +405,28 @@ func TestGitLabNoGroupOwnerCondition_ReadAPIScope(t *testing.T) {
 
 func TestGitLabGoScorer_IsDynamic(t *testing.T) {
 	s := GitLabGoScorer()
-	staticMods := map[string]bool{
-		"self-hosted-instance": true,
-	}
-
 	for _, mod := range s.Modifiers {
-		if staticMods[mod.Name] {
-			assert.False(t, mod.IsDynamic(), "modifier %s should be static", mod.Name)
-		} else {
-			assert.True(t, mod.IsDynamic(), "modifier %s should be dynamic", mod.Name)
-		}
+		assert.True(t, mod.IsDynamic(), "modifier %s should be dynamic", mod.Name)
 	}
+}
+
+func TestGitLabSelfHostedCondition_RevokedDoesNotFire(t *testing.T) {
+	server := gitlabServer(t, []string{"api"}, true, "", false, nil)
+	defer server.Close()
+
+	c := &gitlabSelfHostedCondition{client: &redirectingClient{target: server.URL}}
+	fired, err := c.Evaluate(context.Background(), gitlabMatch("gitlab.mycompany.com"))
+	require.NoError(t, err)
+	assert.False(t, fired, "self-hosted delta must not fire on revoked token")
+}
+
+func TestGitLabWriteRepoMultiGroupCondition_NoAPIScope(t *testing.T) {
+	groups := []map[string]interface{}{{"id": 1, "name": "mygroup"}}
+	server := gitlabServer(t, []string{"write_repository"}, false, "2099-01-01", false, groups)
+	defer server.Close()
+
+	c := &gitlabWriteRepoMultiGroupCondition{client: &redirectingClient{target: server.URL}}
+	fired, err := c.Evaluate(context.Background(), gitlabMatch("gitlab.com"))
+	require.NoError(t, err)
+	assert.False(t, fired, "write-repo-multi-group should not fire without api/read_api scope")
 }

--- a/pkg/scoring/go_scorers.go
+++ b/pkg/scoring/go_scorers.go
@@ -11,5 +11,6 @@ func BuiltinGoScorers() []*Scorer {
 		AtlassianGoScorer(),
 		MongoDBGoScorer(),
 		MongoDBAtlasGoScorer(),
+		GitLabGoScorer(),
 	}
 }

--- a/pkg/scoring/go_scorers_test.go
+++ b/pkg/scoring/go_scorers_test.go
@@ -35,3 +35,16 @@ func TestBuiltinGoScorers_IncludesGitHub(t *testing.T) {
 	}
 	assert.True(t, found)
 }
+
+func TestBuiltinGoScorers_IncludesGitLab(t *testing.T) {
+	scorers := BuiltinGoScorers()
+	var found bool
+	for _, s := range scorers {
+		if s.Name == "gitlab-pat-scope" {
+			found = true
+			assert.Contains(t, s.RuleIDs, "np.gitlab.2")
+			assert.Contains(t, s.RuleIDs, "np.gitlab.4")
+		}
+	}
+	assert.True(t, found, "BuiltinGoScorers must include gitlab-pat-scope scorer")
+}


### PR DESCRIPTION
## Summary

- Add Go scorer `gitlab-pat-scope` targeting `np.gitlab.2` and `np.gitlab.4` with 9 conditions covering scope enumeration, admin detection, group Owner access, and self-hosted instance detection
- API calls to `/personal_access_tokens/self`, `/user`, and `/groups?min_access_level=50` determine token risk level
- All scope conditions guard with `gitlabTokenIsActive()` to prevent revoked tokens from overwriting set_score 5

## Scoring modifiers

| Modifier | Priority | Kind | Value | Condition |
|---|---|---|---|---|
| token-revoked-expired | 100 | set_score | 5 | 401/403 or revoked/expired |
| sudo-scope | 95 | set_score | 99 | scopes contain "sudo" |
| admin-api-scope | 90 | set_score | 95 | is_admin + api (excludes sudo) |
| read-user-only | 85 | set_score | 15 | only read_user scope |
| api-scope-group-owner | 70 | delta | +15 | api + group Owner access |
| self-hosted-instance | 65 | delta | +10 | non-gitlab.com host (static) |
| write-repo-multi-group | 60 | delta | +10 | write_repository + group Owner |
| read-api-only-non-admin | 55 | delta | -20 | only read_api, non-admin |
| no-group-owner | 50 | delta | -10 | no group Owner (requires api/read_api) |

## Test plan

- [x] 30 unit tests covering all conditions (positive + negative)
- [x] Revoked token active-guard tests (prevents score overwrite)
- [x] Scorer structure, registration, dynamic/static classification
- [x] Missing credentials graceful degradation
- [x] Full scoring suite (235 tests, 0 failures)
- [x] Race detector clean
- [x] Rule alignment tests confirm np.gitlab.2 and np.gitlab.4
- [x] gosec, go vet clean