### PR TITLE
feat(explore): display Linear/Notion provenance in explore UI

### DIFF
--- a/pkg/enum/linear.go
+++ b/pkg/enum/linear.go
@@ -59,6 +59,7 @@ func linearProvenance(entityType, identifier, title, url, team, project string) 
 			"identifier": identifier,
 			"title":      title,
 			"url":        url,
+			"path":       url,
 			"team":       team,
 			"project":    project,
 		},

--- a/pkg/enum/notion.go
+++ b/pkg/enum/notion.go
@@ -46,6 +46,7 @@ func notionProvenance(pageID, title, pageURL, space string) types.ExtendedProven
 			"pageID": pageID,
 			"title":  title,
 			"url":    pageURL,
+			"path":   pageURL,
 			"space":  space,
 		},
 	}

--- a/pkg/explore/data.go
+++ b/pkg/explore/data.go
@@ -198,9 +198,7 @@ func buildFindingRow(f *types.Finding, matches []*types.Match, ruleMap map[strin
 				repoSet[gp.RepoPath] = struct{}{}
 			}
 			if ep, ok := prov.(types.ExtendedProvenance); ok {
-				if url, _ := ep.Payload["url"].(string); url != "" {
-					repoSet[url] = struct{}{}
-				} else if source, _ := ep.Payload["source"].(string); source != "" {
+				if source, _ := ep.Payload["source"].(string); source != "" {
 					repoSet[source] = struct{}{}
 				}
 			}

--- a/pkg/explore/data.go
+++ b/pkg/explore/data.go
@@ -197,6 +197,13 @@ func buildFindingRow(f *types.Finding, matches []*types.Match, ruleMap map[strin
 			if gp, ok := prov.(types.GitProvenance); ok && gp.RepoPath != "" {
 				repoSet[gp.RepoPath] = struct{}{}
 			}
+			if ep, ok := prov.(types.ExtendedProvenance); ok {
+				if url, _ := ep.Payload["url"].(string); url != "" {
+					repoSet[url] = struct{}{}
+				} else if source, _ := ep.Payload["source"].(string); source != "" {
+					repoSet[source] = struct{}{}
+				}
+			}
 		}
 	}
 	repos := make([]string, 0, len(repoSet))

--- a/pkg/explore/details.go
+++ b/pkg/explore/details.go
@@ -222,6 +222,42 @@ func renderMatchDetails(m *matchRow, maxWidth int) []string {
 							fieldValueStyle.Render(p.Commit.CommitterTimestamp.Format("2006-01-02 15:04:05"))))
 					}
 				}
+			case types.ExtendedProvenance:
+				if source, _ := p.Payload["source"].(string); source != "" {
+					lines = append(lines, fmt.Sprintf("  %s %s",
+						fieldLabelStyle.Render("Source:"),
+						fieldValueStyle.Render(source)))
+				}
+				if id, _ := p.Payload["identifier"].(string); id != "" {
+					lines = append(lines, fmt.Sprintf("  %s %s",
+						fieldLabelStyle.Render("Issue:"),
+						fieldValueStyle.Render(id)))
+				}
+				if title, _ := p.Payload["title"].(string); title != "" {
+					lines = append(lines, fmt.Sprintf("  %s %s",
+						fieldLabelStyle.Render("Title:"),
+						fieldValueStyle.Render(title)))
+				}
+				if url, _ := p.Payload["url"].(string); url != "" {
+					lines = append(lines, fmt.Sprintf("  %s %s",
+						fieldLabelStyle.Render("URL:"),
+						fieldValueStyle.Render(url)))
+				}
+				if team, _ := p.Payload["team"].(string); team != "" {
+					lines = append(lines, fmt.Sprintf("  %s %s",
+						fieldLabelStyle.Render("Team:"),
+						fieldValueStyle.Render(team)))
+				}
+				if project, _ := p.Payload["project"].(string); project != "" {
+					lines = append(lines, fmt.Sprintf("  %s %s",
+						fieldLabelStyle.Render("Project:"),
+						fieldValueStyle.Render(project)))
+				}
+				if space, _ := p.Payload["space"].(string); space != "" {
+					lines = append(lines, fmt.Sprintf("  %s %s",
+						fieldLabelStyle.Render("Space:"),
+						fieldValueStyle.Render(space)))
+				}
 			}
 		}
 	}

--- a/pkg/explore/details.go
+++ b/pkg/explore/details.go
@@ -228,9 +228,22 @@ func renderMatchDetails(m *matchRow, maxWidth int) []string {
 						fieldLabelStyle.Render("Source:"),
 						fieldValueStyle.Render(source)))
 				}
-				if id, _ := p.Payload["identifier"].(string); id != "" {
+				id, _ := p.Payload["identifier"].(string)
+				if id == "" {
+					id, _ = p.Payload["pageID"].(string)
+				}
+				if id != "" {
+					label := "ID:"
+					switch p.Payload["entityType"] {
+					case "issue":
+						label = "Issue:"
+					case "document":
+						label = "Document:"
+					case "projectUpdate":
+						label = "Update:"
+					}
 					lines = append(lines, fmt.Sprintf("  %s %s",
-						fieldLabelStyle.Render("Issue:"),
+						fieldLabelStyle.Render(label),
 						fieldValueStyle.Render(id)))
 				}
 				if title, _ := p.Payload["title"].(string); title != "" {


### PR DESCRIPTION
## Summary

- Add `ExtendedProvenance` handling to the explore TUI details pane — shows source, issue ID, title, URL, team, project, and space fields for Linear and Notion findings
- Include ExtendedProvenance URLs in the repository filter so Linear/Notion findings are filterable
- Set `path` key in Linear and Notion provenance so `ExtendedProvenance.Path()` returns the entity URL

Previously, findings from Linear and Notion scans showed blank provenance in `titus explore` because the details renderer only handled `FileProvenance` and `GitProvenance`.

## Test plan

- [x] `titus linear --verbose --output /tmp/test.db` produces findings
- [x] `titus explore /tmp/test.db` shows Source, Issue, Title, URL in details pane
- [x] `titus notion` findings also display provenance correctly
- [x] All existing tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)