### PR TITLE
fix(scoring): add missing closing brace in go_scorers_test.go (unbreaks CI)

### DIFF
--- a/pkg/scoring/go_scorers_test.go
+++ b/pkg/scoring/go_scorers_test.go
@@ -59,7 +59,8 @@ func TestAllBuiltinScorers_IncludesGoAndYAML(t *testing.T) {
 	if goIdx != -1 && yamlIdx != -1 && goIdx > yamlIdx {
 		t.Errorf("Go scorers must precede YAML for first-match-wins: goIdx=%d yamlIdx=%d", goIdx, yamlIdx)
 	}
-  
+}
+
 func TestBuiltinGoScorers_IncludesGitLab(t *testing.T) {
 	scorers := BuiltinGoScorers()
 	var found bool


### PR DESCRIPTION
## Fix CI: missing closing brace in `go_scorers_test.go`

`main` builds are failing `ci / Lint`, `ci / Test`, and `Race Detector` with a Go parse error:

```
pkg/scoring/go_scorers_test.go:63:6: expected '(', found TestBuiltinGoScorers_IncludesGitLab
```

### Root cause
`TestAllBuiltinScorers_IncludesGoAndYAML` was missing its closing `}` — line 62 was a whitespace-only line where the function-closing brace should be, so the parser ran into the next `func` declaration while still inside the function body. Introduced by #272 (LAB-3379).

### Fix
Restore the single missing closing brace (whitespace-only line → `}`). gofmt-normalized the spacing. One-line change, no logic touched.

### Verification (local)
- `go build ./...` — exit 0
- `go vet ./pkg/scoring/` — clean (parse error gone)
- `go test ./pkg/scoring/ -count=1` — 316 pass (incl. `TestAllBuiltinScorers_IncludesGoAndYAML`, `TestBuiltinGoScorers_IncludesGitLab`)
- `go test ./pkg/... -count=1` — 1510 pass across 16 packages, no unrelated failures
- `gofmt -l` clean

PR CI (Lint/Test/Race) re-validates end-to-end.
