### PR TITLE
feat(serve): add scan_path and scan_git streaming request types

### DIFF
--- a/pkg/scanner/core.go
+++ b/pkg/scanner/core.go
@@ -132,6 +132,11 @@ func (c *Core) ScanBatch(items []ContentItem) (*BatchScanResult, error) {
 	}, nil
 }
 
+// ScanBlob scans raw content with a known BlobID.
+func (c *Core) ScanBlob(content []byte, blobID types.BlobID) ([]*types.Match, error) {
+	return c.matcher.MatchWithBlobID(content, blobID)
+}
+
 // Close releases scanner resources
 func (c *Core) Close() {
 	if c.matcher != nil {

--- a/pkg/serve/server.go
+++ b/pkg/serve/server.go
@@ -271,7 +271,7 @@ func (s *Server) streamEnumeration(ctx context.Context, enumerator enum.Enumerat
 
 		matches, err := s.core.ScanBlob(content, blobID)
 		if err != nil {
-			return err
+			return nil
 		}
 
 		if len(matches) == 0 {
@@ -288,12 +288,15 @@ func (s *Server) streamEnumeration(ctx context.Context, enumerator enum.Enumerat
 		data, _ := json.Marshal(result)
 
 		s.encoderMu.Lock()
-		_ = s.encoder.Encode(Response{
+		err = s.encoder.Encode(Response{
 			Success: true,
 			Type:    prefix + "_result",
 			Data:    data,
 		})
 		s.encoderMu.Unlock()
+		if err != nil {
+			return err
+		}
 
 		return nil
 	})

--- a/pkg/serve/server.go
+++ b/pkg/serve/server.go
@@ -5,8 +5,11 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"runtime"
 	"sync"
 	"sync/atomic"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/praetorian-inc/titus/pkg/enum"
 	"github.com/praetorian-inc/titus/pkg/scanner"
@@ -262,46 +265,72 @@ func (s *Server) handleScanGit(ctx context.Context, payload json.RawMessage) {
 	s.streamEnumeration(ctx, enumerator, "scan_git")
 }
 
+// streamBlobJob is a unit of work for streamEnumeration's worker pool.
+type streamBlobJob struct {
+	content []byte
+	blobID  types.BlobID
+	prov    types.Provenance
+}
+
 func (s *Server) streamEnumeration(ctx context.Context, enumerator enum.Enumerator, prefix string) {
 	var totalMatches atomic.Int64
 	var totalBlobs atomic.Int64
 
-	err := enumerator.Enumerate(ctx, func(content []byte, blobID types.BlobID, prov types.Provenance) error {
-		totalBlobs.Add(1)
+	numWorkers := runtime.NumCPU()
+	if numWorkers < 1 {
+		numWorkers = 1
+	}
+	jobs := make(chan streamBlobJob, 2*numWorkers)
+	g, gctx := errgroup.WithContext(ctx)
 
-		matches, err := s.core.ScanBlob(content, blobID)
-		if err != nil {
-			return nil
-		}
-
-		if len(matches) == 0 {
-			return nil
-		}
-
-		totalMatches.Add(int64(len(matches)))
-
-		result := ScanBlobResult{
-			Source:  prov.Path(),
-			Kind:    prov.Kind(),
-			Matches: matches,
-		}
-		data, _ := json.Marshal(result)
-
-		s.encoderMu.Lock()
-		err = s.encoder.Encode(Response{
-			Success: true,
-			Type:    prefix + "_result",
-			Data:    data,
+	// Producer: enumerate blobs and push them to the workers.
+	g.Go(func() error {
+		defer close(jobs)
+		return enumerator.Enumerate(gctx, func(content []byte, blobID types.BlobID, prov types.Provenance) error {
+			totalBlobs.Add(1)
+			select {
+			case jobs <- streamBlobJob{content: content, blobID: blobID, prov: prov}:
+				return nil
+			case <-gctx.Done():
+				return gctx.Err()
+			}
 		})
-		s.encoderMu.Unlock()
-		if err != nil {
-			return err
-		}
-
-		return nil
 	})
 
-	if err != nil {
+	// Consumers: scan each blob and stream matching results.
+	for range numWorkers {
+		g.Go(func() error {
+			for job := range jobs {
+				matches, err := s.core.ScanBlob(job.content, job.blobID)
+				if err != nil || len(matches) == 0 {
+					continue
+				}
+
+				totalMatches.Add(int64(len(matches)))
+
+				result := ScanBlobResult{
+					Source:  job.prov.Path(),
+					Kind:    job.prov.Kind(),
+					Matches: matches,
+				}
+				data, _ := json.Marshal(result)
+
+				s.encoderMu.Lock()
+				encErr := s.encoder.Encode(Response{
+					Success: true,
+					Type:    prefix + "_result",
+					Data:    data,
+				})
+				s.encoderMu.Unlock()
+				if encErr != nil {
+					return encErr
+				}
+			}
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
 		s.sendError(prefix, err.Error())
 		return
 	}
@@ -320,6 +349,8 @@ func (s *Server) streamEnumeration(ctx context.Context, enumerator enum.Enumerat
 }
 
 func (s *Server) sendError(reqType, msg string) {
+	s.encoderMu.Lock()
+	defer s.encoderMu.Unlock()
 	_ = s.encoder.Encode(Response{
 		Success: false,
 		Type:    reqType,

--- a/pkg/serve/server.go
+++ b/pkg/serve/server.go
@@ -5,7 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"sync"
+	"sync/atomic"
 
+	"github.com/praetorian-inc/titus/pkg/enum"
 	"github.com/praetorian-inc/titus/pkg/scanner"
 	"github.com/praetorian-inc/titus/pkg/types"
 	"github.com/praetorian-inc/titus/pkg/validator"
@@ -20,6 +23,7 @@ type Server struct {
 	validator *validator.Engine
 	encoder   *json.Encoder
 	decoder   *json.Decoder
+	encoderMu sync.Mutex
 }
 
 // NewServer creates a new streaming server
@@ -99,6 +103,10 @@ func (s *Server) processRequest(ctx context.Context, req Request) bool {
 		s.handleScanBatch(req.Payload)
 	case "validate":
 		s.handleValidate(ctx, req.Payload)
+	case "scan_path":
+		s.handleScanPath(ctx, req.Payload)
+	case "scan_git":
+		s.handleScanGit(ctx, req.Payload)
 	case "close":
 		return true
 	default:
@@ -208,6 +216,104 @@ func (s *Server) handleValidate(ctx context.Context, payload json.RawMessage) {
 		Type:    "validate",
 		Data:    data,
 	})
+}
+
+func (s *Server) handleScanPath(ctx context.Context, payload json.RawMessage) {
+	var p ScanPathPayload
+	if err := json.Unmarshal(payload, &p); err != nil {
+		s.sendError("scan_path", err.Error())
+		return
+	}
+
+	maxFileSize := int64(10 * 1024 * 1024)
+	if p.MaxFileSize > 0 {
+		maxFileSize = p.MaxFileSize
+	}
+
+	enumerator := enum.NewFilesystemEnumerator(enum.Config{
+		Root:            p.Path,
+		MaxFileSize:     maxFileSize,
+		ExtractArchives: p.ExtractArchives,
+		ExtractLimits:   enum.DefaultExtractionLimits(),
+		IgnoreFile:      p.IgnoreFile,
+	})
+
+	s.streamEnumeration(ctx, enumerator, "scan_path")
+}
+
+func (s *Server) handleScanGit(ctx context.Context, payload json.RawMessage) {
+	var p ScanGitPayload
+	if err := json.Unmarshal(payload, &p); err != nil {
+		s.sendError("scan_git", err.Error())
+		return
+	}
+
+	maxFileSize := int64(10 * 1024 * 1024)
+	if p.MaxFileSize > 0 {
+		maxFileSize = p.MaxFileSize
+	}
+
+	enumerator := enum.NewGitEnumerator(enum.Config{
+		Root:        p.Path,
+		MaxFileSize: maxFileSize,
+	})
+	enumerator.WalkAll = p.WalkAll
+
+	s.streamEnumeration(ctx, enumerator, "scan_git")
+}
+
+func (s *Server) streamEnumeration(ctx context.Context, enumerator enum.Enumerator, prefix string) {
+	var totalMatches atomic.Int64
+	var totalBlobs atomic.Int64
+
+	err := enumerator.Enumerate(ctx, func(content []byte, blobID types.BlobID, prov types.Provenance) error {
+		totalBlobs.Add(1)
+
+		matches, err := s.core.ScanBlob(content, blobID)
+		if err != nil {
+			return err
+		}
+
+		if len(matches) == 0 {
+			return nil
+		}
+
+		totalMatches.Add(int64(len(matches)))
+
+		result := ScanBlobResult{
+			Source:  prov.Path(),
+			Kind:    prov.Kind(),
+			Matches: matches,
+		}
+		data, _ := json.Marshal(result)
+
+		s.encoderMu.Lock()
+		_ = s.encoder.Encode(Response{
+			Success: true,
+			Type:    prefix + "_result",
+			Data:    data,
+		})
+		s.encoderMu.Unlock()
+
+		return nil
+	})
+
+	if err != nil {
+		s.sendError(prefix, err.Error())
+		return
+	}
+
+	doneData, _ := json.Marshal(ScanDoneData{
+		TotalMatches: int(totalMatches.Load()),
+		TotalBlobs:   int(totalBlobs.Load()),
+	})
+	s.encoderMu.Lock()
+	_ = s.encoder.Encode(Response{
+		Success: true,
+		Type:    prefix + "_done",
+		Data:    doneData,
+	})
+	s.encoderMu.Unlock()
 }
 
 func (s *Server) sendError(reqType, msg string) {

--- a/pkg/serve/server_test.go
+++ b/pkg/serve/server_test.go
@@ -215,9 +215,10 @@ func TestServer_ScanPath(t *testing.T) {
 	for _, line := range lines[1:] {
 		var resp Response
 		require.NoError(t, json.Unmarshal([]byte(line), &resp))
-		if resp.Type == "scan_path_result" {
+		switch resp.Type {
+		case "scan_path_result":
 			results = append(results, resp)
-		} else if resp.Type == "scan_path_done" {
+		case "scan_path_done":
 			done = resp
 		}
 	}
@@ -304,9 +305,10 @@ func TestServer_ScanGit(t *testing.T) {
 	for _, line := range lines[1:] {
 		var resp Response
 		require.NoError(t, json.Unmarshal([]byte(line), &resp))
-		if resp.Type == "scan_git_result" {
+		switch resp.Type {
+		case "scan_git_result":
 			results = append(results, resp)
-		} else if resp.Type == "scan_git_done" {
+		case "scan_git_done":
 			done = resp
 		}
 	}

--- a/pkg/serve/server_test.go
+++ b/pkg/serve/server_test.go
@@ -4,7 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -182,4 +186,158 @@ func TestServer_MalformedJSON(t *testing.T) {
 
 	assert.False(t, resp.Success)
 	assert.Equal(t, "decode", resp.Type)
+}
+
+func TestServer_ScanPath(t *testing.T) {
+	core, err := scanner.NewCore("builtin", nil)
+	require.NoError(t, err)
+	defer core.Close()
+
+	dir := t.TempDir()
+	secret := "aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.ini"), []byte(secret), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "clean.txt"), []byte("nothing here"), 0644))
+
+	request := fmt.Sprintf(`{"type":"scan_path","payload":{"path":%q}}`, dir) + "\n"
+	in := strings.NewReader(request)
+	out := &bytes.Buffer{}
+
+	srv := NewServer(core, in, out)
+	err = srv.Run(context.Background())
+	require.NoError(t, err)
+
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	// ready + at least one result + done
+	require.GreaterOrEqual(t, len(lines), 3)
+
+	var results []Response
+	var done Response
+	for _, line := range lines[1:] {
+		var resp Response
+		require.NoError(t, json.Unmarshal([]byte(line), &resp))
+		if resp.Type == "scan_path_result" {
+			results = append(results, resp)
+		} else if resp.Type == "scan_path_done" {
+			done = resp
+		}
+	}
+
+	require.NotEmpty(t, results, "expected at least one scan_path_result")
+	assert.True(t, done.Success)
+	assert.Equal(t, "scan_path_done", done.Type)
+
+	var doneData ScanDoneData
+	require.NoError(t, json.Unmarshal(done.Data, &doneData))
+	assert.Equal(t, 2, doneData.TotalBlobs)
+	assert.GreaterOrEqual(t, doneData.TotalMatches, 1)
+}
+
+func TestServer_ScanPath_EmptyDir(t *testing.T) {
+	core, err := scanner.NewCore("builtin", nil)
+	require.NoError(t, err)
+	defer core.Close()
+
+	dir := t.TempDir()
+
+	request := fmt.Sprintf(`{"type":"scan_path","payload":{"path":%q}}`, dir) + "\n"
+	in := strings.NewReader(request)
+	out := &bytes.Buffer{}
+
+	srv := NewServer(core, in, out)
+	err = srv.Run(context.Background())
+	require.NoError(t, err)
+
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	require.Len(t, lines, 2) // ready + done
+
+	var resp Response
+	require.NoError(t, json.Unmarshal([]byte(lines[1]), &resp))
+	assert.True(t, resp.Success)
+	assert.Equal(t, "scan_path_done", resp.Type)
+
+	var doneData ScanDoneData
+	require.NoError(t, json.Unmarshal(resp.Data, &doneData))
+	assert.Equal(t, 0, doneData.TotalBlobs)
+	assert.Equal(t, 0, doneData.TotalMatches)
+}
+
+func TestServer_ScanGit(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	core, err := scanner.NewCore("builtin", nil)
+	require.NoError(t, err)
+	defer core.Close()
+
+	dir := t.TempDir()
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "command %v failed: %s", args, string(out))
+	}
+
+	run("git", "init")
+	run("git", "config", "user.email", "test@test.com")
+	run("git", "config", "user.name", "Test")
+	secret := "aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.ini"), []byte(secret), 0644))
+	run("git", "add", ".")
+	run("git", "commit", "-m", "initial")
+
+	request := fmt.Sprintf(`{"type":"scan_git","payload":{"path":%q}}`, dir) + "\n"
+	in := strings.NewReader(request)
+	out := &bytes.Buffer{}
+
+	srv := NewServer(core, in, out)
+	err = srv.Run(context.Background())
+	require.NoError(t, err)
+
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	require.GreaterOrEqual(t, len(lines), 3)
+
+	var results []Response
+	var done Response
+	for _, line := range lines[1:] {
+		var resp Response
+		require.NoError(t, json.Unmarshal([]byte(line), &resp))
+		if resp.Type == "scan_git_result" {
+			results = append(results, resp)
+		} else if resp.Type == "scan_git_done" {
+			done = resp
+		}
+	}
+
+	require.NotEmpty(t, results, "expected at least one scan_git_result")
+	assert.True(t, done.Success)
+
+	var doneData ScanDoneData
+	require.NoError(t, json.Unmarshal(done.Data, &doneData))
+	assert.GreaterOrEqual(t, doneData.TotalMatches, 1)
+	assert.GreaterOrEqual(t, doneData.TotalBlobs, 1)
+}
+
+func TestServer_ScanGit_InvalidPath(t *testing.T) {
+	core, err := scanner.NewCore("builtin", nil)
+	require.NoError(t, err)
+	defer core.Close()
+
+	request := `{"type":"scan_git","payload":{"path":"/nonexistent/path"}}` + "\n"
+	in := strings.NewReader(request)
+	out := &bytes.Buffer{}
+
+	srv := NewServer(core, in, out)
+	err = srv.Run(context.Background())
+	require.NoError(t, err)
+
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	require.GreaterOrEqual(t, len(lines), 2)
+
+	var resp Response
+	require.NoError(t, json.Unmarshal([]byte(lines[1]), &resp))
+	assert.False(t, resp.Success)
+	assert.Equal(t, "scan_git", resp.Type)
 }

--- a/pkg/serve/types.go
+++ b/pkg/serve/types.go
@@ -4,11 +4,12 @@ import (
 	"encoding/json"
 
 	"github.com/praetorian-inc/titus/pkg/scanner"
+	"github.com/praetorian-inc/titus/pkg/types"
 )
 
 // Request represents an incoming NDJSON request
 type Request struct {
-	Type    string          `json:"type"`    // "scan" | "scan_batch" | "validate" | "close"
+	Type    string          `json:"type"` // "scan" | "scan_batch" | "validate" | "close"
 	Payload json.RawMessage `json:"payload"`
 }
 
@@ -26,7 +27,7 @@ type ScanBatchPayload struct {
 // Response represents an outgoing NDJSON response
 type Response struct {
 	Success bool            `json:"success"`
-	Type    string          `json:"type"`              // "ready" | "scan" | "scan_batch" | "validate" | "error"
+	Type    string          `json:"type"` // "ready" | "scan" | "scan_batch" | "validate" | "error"
 	Data    json.RawMessage `json:"data,omitempty"`
 	Error   string          `json:"error,omitempty"`
 }
@@ -49,4 +50,32 @@ type ValidateResult struct {
 	Confidence float64           `json:"confidence"`
 	Message    string            `json:"message"`
 	Details    map[string]string `json:"details,omitempty"`
+}
+
+// ScanPathPayload is the payload for "scan_path" requests
+type ScanPathPayload struct {
+	Path            string `json:"path"`
+	MaxFileSize     int64  `json:"max_file_size,omitempty"`
+	ExtractArchives string `json:"extract_archives,omitempty"`
+	IgnoreFile      string `json:"ignore_file,omitempty"`
+}
+
+// ScanGitPayload is the payload for "scan_git" requests
+type ScanGitPayload struct {
+	Path        string `json:"path"`
+	WalkAll     bool   `json:"walk_all,omitempty"`
+	MaxFileSize int64  `json:"max_file_size,omitempty"`
+}
+
+// ScanBlobResult is a streaming result for a single blob with matches
+type ScanBlobResult struct {
+	Source  string         `json:"source"`
+	Kind    string         `json:"kind"`
+	Matches []*types.Match `json:"matches"`
+}
+
+// ScanDoneData is the final message after a scan_path or scan_git completes
+type ScanDoneData struct {
+	TotalMatches int `json:"total_matches"`
+	TotalBlobs   int `json:"total_blobs"`
 }


### PR DESCRIPTION
### Summary

- Adds scan_path and scan_git streaming request types to titus serve, enabling filesystem and git repository scanning over the existing NDJSON protocol
- Useful for scanning a large number of repositories without reloading the ~487 detection rules on every invocation — a single long-lived titus serve process handles all requests
- Results are streamed as one NDJSON line per blob with matches, followed by a _done summary message with totals

### Protocol

→ {"type":"scan_path","payload":{"path":"/tmp/myproject"}}
← {"success":true,"type":"scan_path_result","data":{"source":"main.py","kind":"file","matches":[...]}}
← {"success":true,"type":"scan_path_done","data":{"total_matches":3,"total_blobs":15}}

→ {"type":"scan_git","payload":{"path":"/tmp/myrepo","walk_all":true}}
← {"success":true,"type":"scan_git_result","data":{"source":"secrets.py","kind":"git","matches":[...]}}
← {"success":true,"type":"scan_git_done","data":{"total_matches":1,"total_blobs":200}}

▎ Disclaimer: This PR was authored with AI