### PR TITLE
feat(enum): add Confluence instance enumerator (LAB-1625)

### DIFF
--- a/cmd/titus/confluence.go
+++ b/cmd/titus/confluence.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"os"
@@ -20,6 +19,7 @@ var (
 	confluenceOutputPath   string
 	confluenceOutputFormat string
 	confluenceSpaces       string
+	confluenceRateLimit    float64
 )
 
 var confluenceCmd = &cobra.Command{
@@ -35,8 +35,8 @@ Authentication:
 
 Examples:
   titus confluence --base-url https://mysite.atlassian.net/wiki --username user@example.com --token ATATT...
-  CONFLUENCE_BASE_URL=https://mysite.atlassian.net/wiki CONFLUENCE_TOKEN=ATATT... titus confluence
-  titus confluence --base-url https://mysite.atlassian.net/wiki --token PAT_TOKEN --spaces DEV,OPS`,
+  CONFLUENCE_BASE_URL=https://mysite.atlassian.net/wiki CONFLUENCE_USERNAME=user@example.com CONFLUENCE_TOKEN=ATATT... titus confluence
+  titus confluence --base-url https://confluence.internal --token PAT_TOKEN --spaces DEV,OPS`,
 	RunE: runConfluenceScan,
 }
 
@@ -52,6 +52,7 @@ func init() {
 	confluenceCmd.Flags().StringVar(&scanRuleset, "ruleset", "default", "Ruleset to use: default, np.assets, np.hashes, all")
 	confluenceCmd.Flags().BoolVar(&scanIncludeNoisy, "include-noisy", false, "Include noisy rules that may produce more false positives")
 	confluenceCmd.Flags().StringVar(&confluenceSpaces, "spaces", "", "Comma-separated space keys to scan (empty = all)")
+	confluenceCmd.Flags().Float64Var(&confluenceRateLimit, "rate-limit", 5.0, "Requests per second")
 }
 
 func runConfluenceScan(cmd *cobra.Command, args []string) error {
@@ -82,11 +83,12 @@ func runConfluenceScan(cmd *cobra.Command, args []string) error {
 	}
 
 	enumerator, err := enum.NewConfluenceEnumerator(enum.ConfluenceConfig{
-		Token:    token,
-		Username: username,
-		BaseURL:  baseURL,
-		Spaces:   confluenceSpaces,
-		Verbose:  verboseWriter,
+		Token:     token,
+		Username:  username,
+		BaseURL:   baseURL,
+		RateLimit: confluenceRateLimit,
+		Spaces:    confluenceSpaces,
+		Verbose:   verboseWriter,
 	})
 	if err != nil {
 		return fmt.Errorf("creating Confluence enumerator: %w", err)
@@ -125,7 +127,7 @@ func runConfluenceScan(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	ctx := context.Background()
+	ctx := cmd.Context()
 	matchCount := 0
 	findingCount := 0
 

--- a/cmd/titus/confluence.go
+++ b/cmd/titus/confluence.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/praetorian-inc/titus/pkg/enum"
+	"github.com/praetorian-inc/titus/pkg/matcher"
+	"github.com/praetorian-inc/titus/pkg/store"
+	"github.com/praetorian-inc/titus/pkg/types"
+	"github.com/spf13/cobra"
+)
+
+var (
+	confluenceToken        string
+	confluenceUsername     string
+	confluenceBaseURL      string
+	confluenceOutputPath   string
+	confluenceOutputFormat string
+	confluenceSpaces       string
+)
+
+var confluenceCmd = &cobra.Command{
+	Use:   "confluence",
+	Short: "Scan a Confluence instance for secrets",
+	Long: `Scan an entire Confluence instance for secrets via the REST API.
+Enumerates pages, blog posts, and comments across all spaces.
+
+Authentication:
+  For Confluence Cloud: use --username and --token with an API token.
+  For Confluence Server/Data Center: use --token with a PAT (Personal Access Token).
+  Create a Cloud API token at: https://id.atlassian.com/manage-profile/security/api-tokens
+
+Examples:
+  titus confluence --base-url https://mysite.atlassian.net/wiki --username user@example.com --token ATATT...
+  CONFLUENCE_BASE_URL=https://mysite.atlassian.net/wiki CONFLUENCE_TOKEN=ATATT... titus confluence
+  titus confluence --base-url https://mysite.atlassian.net/wiki --token PAT_TOKEN --spaces DEV,OPS`,
+	RunE: runConfluenceScan,
+}
+
+func init() {
+	confluenceCmd.Flags().StringVar(&confluenceToken, "token", "", "Confluence API token or PAT (or CONFLUENCE_TOKEN env)")
+	confluenceCmd.Flags().StringVar(&confluenceUsername, "username", "", "Confluence username for Cloud basic auth (or CONFLUENCE_USERNAME env)")
+	confluenceCmd.Flags().StringVar(&confluenceBaseURL, "base-url", "", "Confluence base URL (or CONFLUENCE_BASE_URL env)")
+	confluenceCmd.Flags().StringVar(&confluenceOutputPath, "output", "titus.db", "Output database path")
+	confluenceCmd.Flags().StringVar(&confluenceOutputFormat, "format", "human", "Output format: json, human")
+	confluenceCmd.Flags().StringVar(&scanRulesPath, "rules", "", "Path to custom rules file or directory (merged with builtins)")
+	confluenceCmd.Flags().StringVar(&scanRulesInclude, "rules-include", "", "Include rules matching regex pattern (comma-separated)")
+	confluenceCmd.Flags().StringVar(&scanRulesExclude, "rules-exclude", "", "Exclude rules matching regex pattern (comma-separated)")
+	confluenceCmd.Flags().StringVar(&scanRuleset, "ruleset", "default", "Ruleset to use: default, np.assets, np.hashes, all")
+	confluenceCmd.Flags().BoolVar(&scanIncludeNoisy, "include-noisy", false, "Include noisy rules that may produce more false positives")
+	confluenceCmd.Flags().StringVar(&confluenceSpaces, "spaces", "", "Comma-separated space keys to scan (empty = all)")
+}
+
+func runConfluenceScan(cmd *cobra.Command, args []string) error {
+	token := confluenceToken
+	if token == "" {
+		token = os.Getenv("CONFLUENCE_TOKEN")
+	}
+	if token == "" {
+		return fmt.Errorf("confluence API token is required: use --token or CONFLUENCE_TOKEN env var")
+	}
+
+	username := confluenceUsername
+	if username == "" {
+		username = os.Getenv("CONFLUENCE_USERNAME")
+	}
+
+	baseURL := confluenceBaseURL
+	if baseURL == "" {
+		baseURL = os.Getenv("CONFLUENCE_BASE_URL")
+	}
+	if baseURL == "" {
+		return fmt.Errorf("confluence base URL is required: use --base-url or CONFLUENCE_BASE_URL env var")
+	}
+
+	var verboseWriter io.Writer
+	if verbose {
+		verboseWriter = cmd.ErrOrStderr()
+	}
+
+	enumerator, err := enum.NewConfluenceEnumerator(enum.ConfluenceConfig{
+		Token:    token,
+		Username: username,
+		BaseURL:  baseURL,
+		Spaces:   confluenceSpaces,
+		Verbose:  verboseWriter,
+	})
+	if err != nil {
+		return fmt.Errorf("creating Confluence enumerator: %w", err)
+	}
+
+	rules, err := loadRules(scanRulesPath, scanRulesInclude, scanRulesExclude, scanRuleset, scanIncludeNoisy)
+	if err != nil {
+		return fmt.Errorf("loading rules: %w", err)
+	}
+
+	ruleMap := make(map[string]*types.Rule)
+	for _, r := range rules {
+		ruleMap[r.ID] = r
+	}
+
+	m, err := matcher.New(matcher.Config{
+		Rules:        rules,
+		ContextLines: 3,
+	})
+	if err != nil {
+		return fmt.Errorf("creating matcher: %w", err)
+	}
+	defer m.Close()
+
+	s, err := store.New(store.Config{
+		Path: confluenceOutputPath,
+	})
+	if err != nil {
+		return fmt.Errorf("creating store: %w", err)
+	}
+	defer s.Close()
+
+	for _, r := range rules {
+		if err := s.AddRule(r); err != nil {
+			return fmt.Errorf("storing rule: %w", err)
+		}
+	}
+
+	ctx := context.Background()
+	matchCount := 0
+	findingCount := 0
+
+	err = enumerator.Enumerate(ctx, func(content []byte, blobID types.BlobID, prov types.Provenance) error {
+		if err := s.AddBlob(blobID, int64(len(content))); err != nil {
+			return fmt.Errorf("storing blob: %w", err)
+		}
+
+		if err := s.AddProvenance(blobID, prov); err != nil {
+			return fmt.Errorf("storing provenance: %w", err)
+		}
+
+		matches, err := m.MatchWithBlobID(content, blobID)
+		if err != nil {
+			return fmt.Errorf("matching content: %w", err)
+		}
+
+		for _, match := range matches {
+			startLine, startCol := types.ComputeLineColumn(content, int(match.Location.Offset.Start))
+			endLine, endCol := types.ComputeLineColumn(content, int(match.Location.Offset.End))
+			match.Location.Source.Start.Line = startLine
+			match.Location.Source.Start.Column = startCol
+			match.Location.Source.End.Line = endLine
+			match.Location.Source.End.Column = endCol
+		}
+
+		for _, match := range matches {
+			matchCount++
+
+			if err := s.AddMatch(match); err != nil {
+				return fmt.Errorf("storing match: %w", err)
+			}
+
+			rule, ok := ruleMap[match.RuleID]
+			if !ok {
+				return fmt.Errorf("rule not found: %s", match.RuleID)
+			}
+			findingID := types.ComputeFindingID(rule.StructuralID, match.Groups)
+			exists, err := s.FindingExists(findingID)
+			if err != nil {
+				return fmt.Errorf("checking finding: %w", err)
+			}
+
+			if !exists {
+				findingCount++
+				finding := &types.Finding{
+					ID:     findingID,
+					RuleID: match.RuleID,
+					Groups: match.Groups,
+				}
+				if err := s.AddFinding(finding); err != nil {
+					return fmt.Errorf("storing finding: %w", err)
+				}
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("scanning Confluence: %w", err)
+	}
+
+	if confluenceOutputFormat == "json" {
+		matches, err := s.GetAllMatches()
+		if err != nil {
+			return fmt.Errorf("retrieving matches: %w", err)
+		}
+		return outputMatches(cmd, matches)
+	}
+
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Confluence scan complete: %d matches, %d findings\n", matchCount, findingCount)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Results stored in: %s\n", confluenceOutputPath)
+
+	findings, err := s.GetFindings()
+	if err != nil {
+		return fmt.Errorf("retrieving findings: %w", err)
+	}
+	return outputFindings(cmd, findings)
+}

--- a/cmd/titus/root.go
+++ b/cmd/titus/root.go
@@ -35,6 +35,7 @@ func init() {
 	rootCmd.AddCommand(exploreCmd)
 	rootCmd.AddCommand(linearCmd)
 	rootCmd.AddCommand(notionCmd)
+	rootCmd.AddCommand(confluenceCmd)
 }
 
 // Execute runs the root command.

--- a/pkg/enum/confluence.go
+++ b/pkg/enum/confluence.go
@@ -20,12 +20,13 @@ import (
 
 // ConfluenceConfig configures the Confluence instance enumerator.
 type ConfluenceConfig struct {
-	BaseURL   string    // Confluence base URL (e.g., https://mysite.atlassian.net/wiki)
-	Token     string    // API token or PAT
-	Username  string    // Username for Cloud basic auth (empty = PAT/Bearer)
-	RateLimit float64   // requests per second (default 5)
-	Spaces    string    // comma-separated space key filter (empty = all)
-	Verbose   io.Writer // progress output (nil = silent)
+	BaseURL          string    // Confluence base URL (e.g., https://mysite.atlassian.net/wiki)
+	Token            string    // API token or PAT
+	Username         string    // Username for Cloud basic auth (empty = PAT/Bearer)
+	RateLimit        float64   // requests per second (default 5)
+	Spaces           string    // comma-separated space key filter (empty = all)
+	AllowInsecureHTTP bool     // allow plaintext HTTP base URLs
+	Verbose          io.Writer // progress output (nil = silent)
 }
 
 // ConfluenceEnumerator enumerates blobs from a Confluence instance via the REST API.
@@ -48,8 +49,8 @@ func NewConfluenceEnumerator(cfg ConfluenceConfig) (*ConfluenceEnumerator, error
 	if err != nil {
 		return nil, fmt.Errorf("confluence base URL: %w", err)
 	}
-	if insecure && cfg.Verbose != nil {
-		_, _ = fmt.Fprintf(cfg.Verbose, "WARNING: using plaintext HTTP; token may be exposed\n")
+	if insecure && !cfg.AllowInsecureHTTP {
+		return nil, fmt.Errorf("confluence base URL uses plaintext HTTP, which exposes credentials; use HTTPS or set AllowInsecureHTTP")
 	}
 	if cfg.RateLimit <= 0 {
 		cfg.RateLimit = 5.0
@@ -94,10 +95,15 @@ func (e *ConfluenceEnumerator) progressf(format string, args ...interface{}) {
 	}
 }
 
-var cfHTMLTagRe = regexp.MustCompile(`<[^>]*>`)
+var (
+	cfCDATARe  = regexp.MustCompile(`(?s)<!\[CDATA\[(.*?)\]\]>`)
+	cfHTMLTagRe = regexp.MustCompile(`<[^>]*>`)
+)
 
-// cfStripHTML removes HTML tags and unescapes HTML entities.
+// cfStripHTML removes HTML tags and unescapes HTML entities, preserving CDATA content.
 func cfStripHTML(s string) string {
+	// Extract CDATA content before stripping HTML tags.
+	s = cfCDATARe.ReplaceAllString(s, "$1")
 	stripped := cfHTMLTagRe.ReplaceAllString(s, "")
 	return html.UnescapeString(stripped)
 }
@@ -262,10 +268,10 @@ func (e *ConfluenceEnumerator) cfFetchSpaces(ctx context.Context) ([]cfSpace, er
 			}
 		}
 
-		if page.Size < page.Limit || page.Links.Next == "" {
+		if page.Size == 0 || page.Links.Next == "" {
 			break
 		}
-		start += limit
+		start += page.Size
 	}
 	return allSpaces, nil
 }
@@ -294,10 +300,10 @@ func (e *ConfluenceEnumerator) cfFetchContent(ctx context.Context, spaceKey, con
 		}
 		allContent = append(allContent, items...)
 
-		if page.Size < page.Limit || page.Links.Next == "" {
+		if page.Size == 0 || page.Links.Next == "" {
 			break
 		}
-		start += limit
+		start += page.Size
 	}
 	return allContent, nil
 }
@@ -332,10 +338,10 @@ func (e *ConfluenceEnumerator) cfFetchComments(ctx context.Context, contentID st
 			})
 		}
 
-		if page.Size < page.Limit || page.Links.Next == "" {
+		if page.Size == 0 || page.Links.Next == "" {
 			break
 		}
-		start += limit
+		start += page.Size
 	}
 	return allComments, nil
 }
@@ -353,26 +359,27 @@ func (e *ConfluenceEnumerator) Enumerate(ctx context.Context, callback func(cont
 
 	for _, space := range spaces {
 		// Fetch pages
+		var allContent []cfContent
 		pages, err := e.cfFetchContent(ctx, space.Key, "page")
 		if err != nil {
 			errs = append(errs, fmt.Sprintf("space %s pages: %v", space.Key, err))
-			continue
+		} else {
+			allContent = append(allContent, pages...)
 		}
 
 		// Fetch blog posts
 		blogs, err := e.cfFetchContent(ctx, space.Key, "blogpost")
 		if err != nil {
 			errs = append(errs, fmt.Sprintf("space %s blogposts: %v", space.Key, err))
-			continue
+		} else {
+			allContent = append(allContent, blogs...)
 		}
-
-		allContent := append(pages, blogs...)
 
 		for _, item := range allContent {
 			comments, err := e.cfFetchComments(ctx, item.ID)
 			if err != nil {
 				errs = append(errs, fmt.Sprintf("comments for %s: %v", item.ID, err))
-				continue
+				// Continue to emit the page body even without comments.
 			}
 
 			strippedBody := cfStripHTML(item.Body.Storage.Value)

--- a/pkg/enum/confluence.go
+++ b/pkg/enum/confluence.go
@@ -1,0 +1,400 @@
+package enum
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"html"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"golang.org/x/time/rate"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+)
+
+// ConfluenceConfig configures the Confluence instance enumerator.
+type ConfluenceConfig struct {
+	BaseURL   string    // Confluence base URL (e.g., https://mysite.atlassian.net/wiki)
+	Token     string    // API token or PAT
+	Username  string    // Username for Cloud basic auth (empty = PAT/Bearer)
+	RateLimit float64   // requests per second (default 5)
+	Spaces    string    // comma-separated space key filter (empty = all)
+	Verbose   io.Writer // progress output (nil = silent)
+}
+
+// ConfluenceEnumerator enumerates blobs from a Confluence instance via the REST API.
+type ConfluenceEnumerator struct {
+	config  ConfluenceConfig
+	client  *http.Client
+	limiter *rate.Limiter
+	apiBase string
+}
+
+// NewConfluenceEnumerator creates a new Confluence enumerator.
+func NewConfluenceEnumerator(cfg ConfluenceConfig) (*ConfluenceEnumerator, error) {
+	if cfg.Token == "" {
+		return nil, fmt.Errorf("confluence API token is required")
+	}
+	if cfg.BaseURL == "" {
+		return nil, fmt.Errorf("confluence base URL is required")
+	}
+	insecure, err := ValidateBaseURL(cfg.BaseURL)
+	if err != nil {
+		return nil, fmt.Errorf("confluence base URL: %w", err)
+	}
+	if insecure && cfg.Verbose != nil {
+		_, _ = fmt.Fprintf(cfg.Verbose, "WARNING: using plaintext HTTP; token may be exposed\n")
+	}
+	if cfg.RateLimit <= 0 {
+		cfg.RateLimit = 5.0
+	}
+
+	apiBase := strings.TrimRight(cfg.BaseURL, "/") + "/rest/api"
+
+	return &ConfluenceEnumerator{
+		config:  cfg,
+		client:  &http.Client{Timeout: 30 * time.Second},
+		limiter: rate.NewLimiter(rate.Limit(cfg.RateLimit), 1),
+		apiBase: apiBase,
+	}, nil
+}
+
+// confluenceProvenance builds an ExtendedProvenance for a Confluence entity.
+func confluenceProvenance(entityType, id, title, url, space string) types.ExtendedProvenance {
+	return types.ExtendedProvenance{
+		Payload: map[string]interface{}{
+			"source":     "confluence",
+			"entityType": entityType,
+			"identifier": id,
+			"title":      title,
+			"url":        url,
+			"path":       url,
+			"space":      space,
+		},
+	}
+}
+
+// logf writes a progress message when verbose output is enabled.
+func (e *ConfluenceEnumerator) logf(format string, args ...interface{}) {
+	if e.config.Verbose != nil {
+		_, _ = fmt.Fprintf(e.config.Verbose, format+"\n", args...)
+	}
+}
+
+// progressf writes an in-place progress update using \r.
+func (e *ConfluenceEnumerator) progressf(format string, args ...interface{}) {
+	if e.config.Verbose != nil {
+		_, _ = fmt.Fprintf(e.config.Verbose, "\r%-80s", fmt.Sprintf(format, args...))
+	}
+}
+
+var cfHTMLTagRe = regexp.MustCompile(`<[^>]*>`)
+
+// cfStripHTML removes HTML tags and unescapes HTML entities.
+func cfStripHTML(s string) string {
+	stripped := cfHTMLTagRe.ReplaceAllString(s, "")
+	return html.UnescapeString(stripped)
+}
+
+// cfComment holds author and body of a Confluence comment.
+type cfComment struct {
+	Author string
+	Body   string
+}
+
+// cfBuildPageBlob assembles a Confluence page/blogpost into a single blob.
+func cfBuildPageBlob(title, url, space, contentType, body string, comments []cfComment) []byte {
+	var sb strings.Builder
+	sb.WriteString("Title: " + title + "\n")
+	sb.WriteString("URL: " + url + "\n")
+	sb.WriteString("Space: " + space + "\n")
+	sb.WriteString("Type: " + contentType + "\n")
+	sb.WriteString("---\n")
+	sb.WriteString(body + "\n")
+	if len(comments) > 0 {
+		sb.WriteString("\n--- Comments ---\n")
+		for _, c := range comments {
+			sb.WriteString("\n[" + c.Author + "]:\n")
+			sb.WriteString(c.Body + "\n")
+		}
+	}
+	return []byte(sb.String())
+}
+
+// cfPaginatedResponse holds common pagination fields from the Confluence REST API.
+type cfPaginatedResponse struct {
+	Results json.RawMessage `json:"results"`
+	Start   int             `json:"start"`
+	Limit   int             `json:"limit"`
+	Size    int             `json:"size"`
+	Links   struct {
+		Next string `json:"next"`
+	} `json:"_links"`
+}
+
+// cfSpace represents a Confluence space.
+type cfSpace struct {
+	Key  string `json:"key"`
+	Name string `json:"name"`
+}
+
+// cfContent represents a Confluence page or blogpost.
+type cfContent struct {
+	ID    string `json:"id"`
+	Title string `json:"title"`
+	Type  string `json:"type"`
+	Body  struct {
+		Storage struct {
+			Value string `json:"value"`
+		} `json:"storage"`
+	} `json:"body"`
+	Links struct {
+		WebUI string `json:"webui"`
+	} `json:"_links"`
+}
+
+// cfGet performs a rate-limited GET request with auth and retry logic.
+func (e *ConfluenceEnumerator) cfGet(ctx context.Context, url string) ([]byte, error) {
+	const maxAttempts = 3
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if err := e.limiter.Wait(ctx); err != nil {
+			return nil, fmt.Errorf("rate limiter: %w", err)
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return nil, fmt.Errorf("build request: %w", err)
+		}
+
+		// Auth: Basic (username:token) or Bearer (PAT)
+		if e.config.Username != "" {
+			encoded := base64.StdEncoding.EncodeToString([]byte(e.config.Username + ":" + e.config.Token))
+			req.Header.Set("Authorization", "Basic "+encoded)
+		} else {
+			req.Header.Set("Authorization", "Bearer "+e.config.Token)
+		}
+		req.Header.Set("Accept", "application/json")
+
+		resp, err := e.client.Do(req)
+		if err != nil {
+			if attempt < maxAttempts-1 {
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(2 * time.Second):
+				}
+				continue
+			}
+			return nil, fmt.Errorf("http request: %w", err)
+		}
+
+		// Retry on 429 (rate limit) or 5xx (server error)
+		if resp.StatusCode == 429 || resp.StatusCode >= 500 {
+			resp.Body.Close()
+			if attempt < maxAttempts-1 {
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(2 * time.Second):
+				}
+				continue
+			}
+			return nil, fmt.Errorf("confluence API returned %d after %d attempts", resp.StatusCode, maxAttempts)
+		}
+
+		if resp.StatusCode != 200 {
+			resp.Body.Close()
+			return nil, fmt.Errorf("confluence API returned unexpected status %d", resp.StatusCode)
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("read response body: %w", err)
+		}
+		return body, nil
+	}
+	return nil, fmt.Errorf("cfGet: exceeded max attempts")
+}
+
+// cfFetchSpaces retrieves all spaces, optionally filtered by the Spaces config.
+func (e *ConfluenceEnumerator) cfFetchSpaces(ctx context.Context) ([]cfSpace, error) {
+	var allowed map[string]bool
+	if e.config.Spaces != "" {
+		allowed = make(map[string]bool)
+		for _, k := range strings.Split(e.config.Spaces, ",") {
+			k = strings.TrimSpace(k)
+			if k != "" {
+				allowed[k] = true
+			}
+		}
+	}
+
+	var allSpaces []cfSpace
+	start := 0
+	limit := 25
+	for {
+		url := fmt.Sprintf("%s/space?limit=%d&start=%d", e.apiBase, limit, start)
+		body, err := e.cfGet(ctx, url)
+		if err != nil {
+			return nil, fmt.Errorf("fetch spaces: %w", err)
+		}
+
+		var page cfPaginatedResponse
+		if err := json.Unmarshal(body, &page); err != nil {
+			return nil, fmt.Errorf("decode spaces response: %w", err)
+		}
+
+		var spaces []cfSpace
+		if err := json.Unmarshal(page.Results, &spaces); err != nil {
+			return nil, fmt.Errorf("decode spaces results: %w", err)
+		}
+
+		for _, s := range spaces {
+			if allowed == nil || allowed[s.Key] {
+				allSpaces = append(allSpaces, s)
+			}
+		}
+
+		if page.Size < page.Limit || page.Links.Next == "" {
+			break
+		}
+		start += limit
+	}
+	return allSpaces, nil
+}
+
+// cfFetchContent retrieves all content of a given type (page or blogpost) in a space.
+func (e *ConfluenceEnumerator) cfFetchContent(ctx context.Context, spaceKey, contentType string) ([]cfContent, error) {
+	var allContent []cfContent
+	start := 0
+	limit := 25
+	for {
+		url := fmt.Sprintf("%s/content?spaceKey=%s&type=%s&limit=%d&start=%d&expand=body.storage,version",
+			e.apiBase, spaceKey, contentType, limit, start)
+		body, err := e.cfGet(ctx, url)
+		if err != nil {
+			return nil, fmt.Errorf("fetch %s content in space %s: %w", contentType, spaceKey, err)
+		}
+
+		var page cfPaginatedResponse
+		if err := json.Unmarshal(body, &page); err != nil {
+			return nil, fmt.Errorf("decode content response: %w", err)
+		}
+
+		var items []cfContent
+		if err := json.Unmarshal(page.Results, &items); err != nil {
+			return nil, fmt.Errorf("decode content results: %w", err)
+		}
+		allContent = append(allContent, items...)
+
+		if page.Size < page.Limit || page.Links.Next == "" {
+			break
+		}
+		start += limit
+	}
+	return allContent, nil
+}
+
+// cfFetchComments retrieves all comments on a page/blogpost.
+func (e *ConfluenceEnumerator) cfFetchComments(ctx context.Context, contentID string) ([]cfComment, error) {
+	var allComments []cfComment
+	start := 0
+	limit := 25
+	for {
+		url := fmt.Sprintf("%s/content/%s/child/comment?limit=%d&start=%d&expand=body.storage",
+			e.apiBase, contentID, limit, start)
+		body, err := e.cfGet(ctx, url)
+		if err != nil {
+			return nil, fmt.Errorf("fetch comments for content %s: %w", contentID, err)
+		}
+
+		var page cfPaginatedResponse
+		if err := json.Unmarshal(body, &page); err != nil {
+			return nil, fmt.Errorf("decode comments response: %w", err)
+		}
+
+		var items []cfContent
+		if err := json.Unmarshal(page.Results, &items); err != nil {
+			return nil, fmt.Errorf("decode comment results: %w", err)
+		}
+
+		for _, item := range items {
+			allComments = append(allComments, cfComment{
+				Author: item.Title,
+				Body:   cfStripHTML(item.Body.Storage.Value),
+			})
+		}
+
+		if page.Size < page.Limit || page.Links.Next == "" {
+			break
+		}
+		start += limit
+	}
+	return allComments, nil
+}
+
+// Enumerate discovers content from a Confluence instance and yields blobs.
+func (e *ConfluenceEnumerator) Enumerate(ctx context.Context, callback func(content []byte, blobID types.BlobID, prov types.Provenance) error) error {
+	spaces, err := e.cfFetchSpaces(ctx)
+	if err != nil {
+		return err
+	}
+	e.logf("Found %d spaces, scanning for secrets...", len(spaces))
+
+	var count atomic.Int64
+	var errs []string
+
+	for _, space := range spaces {
+		// Fetch pages
+		pages, err := e.cfFetchContent(ctx, space.Key, "page")
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("space %s pages: %v", space.Key, err))
+			continue
+		}
+
+		// Fetch blog posts
+		blogs, err := e.cfFetchContent(ctx, space.Key, "blogpost")
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("space %s blogposts: %v", space.Key, err))
+			continue
+		}
+
+		allContent := append(pages, blogs...)
+
+		for _, item := range allContent {
+			comments, err := e.cfFetchComments(ctx, item.ID)
+			if err != nil {
+				errs = append(errs, fmt.Sprintf("comments for %s: %v", item.ID, err))
+				continue
+			}
+
+			strippedBody := cfStripHTML(item.Body.Storage.Value)
+
+			pageURL := strings.TrimRight(e.config.BaseURL, "/") + item.Links.WebUI
+			blob := cfBuildPageBlob(item.Title, pageURL, space.Key, item.Type, strippedBody, comments)
+			blobID := types.ComputeBlobID(blob)
+			prov := confluenceProvenance(item.Type, item.ID, item.Title, pageURL, space.Key)
+
+			n := count.Add(1)
+			e.progressf("Scanning content: %d items", n)
+
+			if err := callback(blob, blobID, prov); err != nil {
+				return err
+			}
+		}
+	}
+
+	e.logf("Scanned %d content items across %d spaces", count.Load(), len(spaces))
+
+	if len(errs) > 0 {
+		return fmt.Errorf("enumeration errors: %s", strings.Join(errs, "; "))
+	}
+	return nil
+}

--- a/pkg/enum/confluence_test.go
+++ b/pkg/enum/confluence_test.go
@@ -105,6 +105,16 @@ func TestConfluenceStripHTML(t *testing.T) {
 			expected: "key=\"secret\"",
 		},
 		{
+			name:     "CDATA in code macro",
+			input:    `<ac:structured-macro ac:name="code"><ac:plain-text-body><![CDATA[API_KEY=secret123]]></ac:plain-text-body></ac:structured-macro>`,
+			expected: "API_KEY=secret123",
+		},
+		{
+			name:     "CDATA with HTML around it",
+			input:    `<p>Config:</p><ac:plain-text-body><![CDATA[DB_PASS=hunter2]]></ac:plain-text-body><p>End</p>`,
+			expected: "Config:DB_PASS=hunter2End",
+		},
+		{
 			name:     "empty",
 			input:    "",
 			expected: "",
@@ -158,6 +168,50 @@ func TestConfluenceAPI_Success(t *testing.T) {
 	assert.Len(t, spaces, 2)
 	assert.Equal(t, "DEV", spaces[0].Key)
 	assert.Equal(t, "OPS", spaces[1].Key)
+}
+
+func TestConfluenceEnumerator_RejectsInsecureHTTP(t *testing.T) {
+	_, err := NewConfluenceEnumerator(ConfluenceConfig{
+		Token:   "test-token",
+		BaseURL: "http://example.com/wiki",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "plaintext HTTP")
+}
+
+func TestConfluenceEnumerator_AllowsInsecureHTTP(t *testing.T) {
+	e, err := NewConfluenceEnumerator(ConfluenceConfig{
+		Token:             "test-token",
+		BaseURL:           "http://example.com/wiki",
+		AllowInsecureHTTP: true,
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, e)
+}
+
+func TestConfluenceAPI_BasicAuth(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, pass, ok := r.BasicAuth()
+		assert.True(t, ok, "expected Basic auth")
+		assert.Equal(t, "user@example.com", user)
+		assert.Equal(t, "test-token", pass)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"results": []map[string]interface{}{},
+			"start":   0,
+			"limit":   25,
+			"size":    0,
+			"_links":  map[string]interface{}{"next": ""},
+		})
+	}))
+	defer server.Close()
+
+	e := testConfluenceEnumerator(t, server.URL)
+	e.config.Username = "user@example.com"
+	spaces, err := e.cfFetchSpaces(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, spaces, 0)
 }
 
 func TestConfluenceAPI_RateLimitRetry(t *testing.T) {

--- a/pkg/enum/confluence_test.go
+++ b/pkg/enum/confluence_test.go
@@ -1,0 +1,314 @@
+package enum
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfluenceEnumerator_Construction(t *testing.T) {
+	e, err := NewConfluenceEnumerator(ConfluenceConfig{
+		Token:   "test-token",
+		BaseURL: "https://example.atlassian.net/wiki",
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, e)
+}
+
+func TestConfluenceEnumerator_RequiresToken(t *testing.T) {
+	_, err := NewConfluenceEnumerator(ConfluenceConfig{
+		BaseURL: "https://example.atlassian.net/wiki",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "token")
+}
+
+func TestConfluenceEnumerator_RequiresBaseURL(t *testing.T) {
+	_, err := NewConfluenceEnumerator(ConfluenceConfig{
+		Token: "test-token",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "base URL")
+}
+
+func TestConfluenceEnumerator_Interface(t *testing.T) {
+	e, err := NewConfluenceEnumerator(ConfluenceConfig{
+		Token:   "test-token",
+		BaseURL: "https://example.atlassian.net/wiki",
+	})
+	require.NoError(t, err)
+	var _ Enumerator = e
+}
+
+// Compile-time assertion that *ConfluenceEnumerator satisfies Enumerator.
+var _ Enumerator = (*ConfluenceEnumerator)(nil)
+
+// Ensure types package is referenced so imports stay tidy.
+var _ types.Provenance = types.ExtendedProvenance{}
+
+func TestConfluenceProvenance(t *testing.T) {
+	prov := confluenceProvenance("page", "12345", "My Page", "https://example.atlassian.net/wiki/display/DEV/My+Page", "DEV")
+	assert.Equal(t, "extended", prov.Kind())
+	assert.Equal(t, "confluence", prov.Payload["source"])
+	assert.Equal(t, "page", prov.Payload["entityType"])
+	assert.Equal(t, "12345", prov.Payload["identifier"])
+	assert.Equal(t, "My Page", prov.Payload["title"])
+	assert.Equal(t, "https://example.atlassian.net/wiki/display/DEV/My+Page", prov.Payload["url"])
+	assert.Equal(t, "DEV", prov.Payload["space"])
+}
+
+func TestConfluenceBuildPageBlob(t *testing.T) {
+	comments := []cfComment{
+		{Author: "alice", Body: "First comment"},
+		{Author: "bob", Body: "Second comment"},
+	}
+	blob := cfBuildPageBlob("Test Page", "https://example.atlassian.net/wiki/display/DEV/Test+Page", "DEV", "page", "Page body content.", comments)
+
+	content := string(blob)
+	assert.Contains(t, content, "Title: Test Page")
+	assert.Contains(t, content, "URL: https://example.atlassian.net/wiki/display/DEV/Test+Page")
+	assert.Contains(t, content, "Space: DEV")
+	assert.Contains(t, content, "Type: page")
+	assert.Contains(t, content, "Page body content.")
+	assert.Contains(t, content, "[alice]:")
+	assert.Contains(t, content, "First comment")
+	assert.Contains(t, content, "[bob]:")
+	assert.Contains(t, content, "Second comment")
+}
+
+func TestConfluenceStripHTML(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "basic HTML",
+			input:    "<p>Hello <b>world</b></p>",
+			expected: "Hello world",
+		},
+		{
+			name:     "HTML entities",
+			input:    "foo &amp; bar &lt;baz&gt;",
+			expected: "foo & bar <baz>",
+		},
+		{
+			name:     "mixed",
+			input:    "<div class=\"x\">key=&quot;secret&quot;</div>",
+			expected: "key=\"secret\"",
+		},
+		{
+			name:     "empty",
+			input:    "",
+			expected: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, cfStripHTML(tt.input))
+		})
+	}
+}
+
+// testConfluenceEnumerator creates a ConfluenceEnumerator pointing at a test server.
+func testConfluenceEnumerator(t *testing.T, url string) *ConfluenceEnumerator {
+	t.Helper()
+	e, err := NewConfluenceEnumerator(ConfluenceConfig{
+		Token:     "test-token",
+		BaseURL:   "https://example.atlassian.net/wiki",
+		RateLimit: 1000, // no throttling in tests
+	})
+	require.NoError(t, err)
+	e.apiBase = url
+	return e
+}
+
+func TestConfluenceAPI_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Contains(t, r.Header.Get("Authorization"), "Bearer")
+		assert.Contains(t, r.URL.Path, "/space")
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"results": []map[string]interface{}{
+				{"key": "DEV", "name": "Development"},
+				{"key": "OPS", "name": "Operations"},
+			},
+			"start": 0,
+			"limit": 25,
+			"size":  2,
+			"_links": map[string]interface{}{
+				"next": "",
+			},
+		})
+	}))
+	defer server.Close()
+
+	e := testConfluenceEnumerator(t, server.URL)
+	spaces, err := e.cfFetchSpaces(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, spaces, 2)
+	assert.Equal(t, "DEV", spaces[0].Key)
+	assert.Equal(t, "OPS", spaces[1].Key)
+}
+
+func TestConfluenceAPI_RateLimitRetry(t *testing.T) {
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts == 1 {
+			w.WriteHeader(429)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"results": []map[string]interface{}{
+				{"key": "DEV", "name": "Development"},
+			},
+			"start":  0,
+			"limit":  25,
+			"size":   1,
+			"_links": map[string]interface{}{"next": ""},
+		})
+	}))
+	defer server.Close()
+
+	e := testConfluenceEnumerator(t, server.URL)
+	spaces, err := e.cfFetchSpaces(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 2, attempts)
+	assert.Len(t, spaces, 1)
+}
+
+func TestConfluenceEnumerate_FullIntegration(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		path := r.URL.Path
+		query := r.URL.Query()
+
+		switch {
+		case strings.HasSuffix(path, "/space"):
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"results": []map[string]interface{}{
+					{"key": "DEV", "name": "Development"},
+				},
+				"start":  0,
+				"limit":  25,
+				"size":   1,
+				"_links": map[string]interface{}{"next": ""},
+			})
+
+		case strings.HasSuffix(path, "/content") && query.Get("type") == "page":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"results": []map[string]interface{}{
+					{
+						"id":    "101",
+						"title": "Setup Guide",
+						"type":  "page",
+						"body": map[string]interface{}{
+							"storage": map[string]interface{}{
+								"value": "<p>API_KEY=sk_live_abc123</p>",
+							},
+						},
+						"_links": map[string]interface{}{
+							"webui": "/display/DEV/Setup+Guide",
+						},
+					},
+				},
+				"start":  0,
+				"limit":  25,
+				"size":   1,
+				"_links": map[string]interface{}{"next": ""},
+			})
+
+		case strings.HasSuffix(path, "/content") && query.Get("type") == "blogpost":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"results": []map[string]interface{}{
+					{
+						"id":    "201",
+						"title": "Launch Day",
+						"type":  "blogpost",
+						"body": map[string]interface{}{
+							"storage": map[string]interface{}{
+								"value": "<p>Blog content here</p>",
+							},
+						},
+						"_links": map[string]interface{}{
+							"webui": "/display/DEV/Launch+Day",
+						},
+					},
+				},
+				"start":  0,
+				"limit":  25,
+				"size":   1,
+				"_links": map[string]interface{}{"next": ""},
+			})
+
+		case strings.Contains(path, "/child/comment"):
+			if strings.Contains(path, "/101/") {
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"results": []map[string]interface{}{
+						{
+							"id":    "c1",
+							"title": "admin",
+							"type":  "comment",
+							"body": map[string]interface{}{
+								"storage": map[string]interface{}{
+									"value": "<p>Updated the key</p>",
+								},
+							},
+							"_links": map[string]interface{}{"webui": ""},
+						},
+					},
+					"start":  0,
+					"limit":  25,
+					"size":   1,
+					"_links": map[string]interface{}{"next": ""},
+				})
+			} else {
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"results": []interface{}{},
+					"start":   0,
+					"limit":   25,
+					"size":    0,
+					"_links":  map[string]interface{}{"next": ""},
+				})
+			}
+
+		default:
+			http.Error(w, "unexpected request: "+path, http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	e := testConfluenceEnumerator(t, server.URL)
+
+	var blobs []string
+	err := e.Enumerate(context.Background(), func(content []byte, blobID types.BlobID, prov types.Provenance) error {
+		blobs = append(blobs, string(content))
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Len(t, blobs, 2, "expected 1 page + 1 blogpost")
+
+	// Verify page blob content
+	assert.Contains(t, blobs[0], "Title: Setup Guide")
+	assert.Contains(t, blobs[0], "Space: DEV")
+	assert.Contains(t, blobs[0], "Type: page")
+	assert.Contains(t, blobs[0], "API_KEY=sk_live_abc123")
+	assert.Contains(t, blobs[0], "[admin]:")
+	assert.Contains(t, blobs[0], "Updated the key")
+
+	// Verify blogpost blob content
+	assert.Contains(t, blobs[1], "Title: Launch Day")
+	assert.Contains(t, blobs[1], "Type: blogpost")
+	assert.Contains(t, blobs[1], "Blog content here")
+}


### PR DESCRIPTION
## Summary
- Add Confluence connector that scans pages, blog posts, and comments for secrets via the REST API v1
- Supports Confluence Cloud (basic auth with email:api-token) and Server/Data Center (PAT Bearer auth)
- Includes `--spaces` flag for filtering specific space keys, HTML tag stripping, offset-based pagination, and rate limiting (5 req/sec default)

## Linear
Closes [LAB-1625](https://linear.app/praetorianlabs/issue/LAB-1625/confluence-connector-for-titus-secret-scanning)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/enum/ -run Confluence` -- 11 tests pass (including HTML strip subtests)
- [ ] Manual test against Confluence Cloud: `titus confluence --base-url https://site.atlassian.net/wiki --username user@co.com --token ATATT...`
- [ ] Manual test against Confluence Server/DC: `titus confluence --base-url https://confluence.internal --token PAT_TOKEN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)