### PR TITLE
perf(matcher): strip lookarounds for the Hyperscan prefilter

### DIFF
--- a/pkg/matcher/vectorscan.go
+++ b/pkg/matcher/vectorscan.go
@@ -322,6 +322,15 @@ func preprocessPatternForHyperscan(pattern string) string {
 		pattern = stripExtendedMode(pattern)
 	}
 
+	// Strip lookaround assertions ((?=...) (?!...) (?<=...) (?<!...)).
+	// Hyperscan does not support lookaround. Since Hyperscan is only an
+	// over-approximating prefilter and regexp2 keeps the FULL pattern (lookarounds
+	// included) for precise match + capture extraction, removing a lookaround here
+	// only widens the prefilter — it can never introduce a false negative or change
+	// a reported match — and it lets otherwise-incompatible rules join the single
+	// combined Hyperscan pass instead of a separate per-blob regexp2 fallback scan.
+	pattern = stripLookarounds(pattern)
+
 	// Remove inline flag modifiers (we set them via Hyperscan flags instead)
 	pattern = strings.ReplaceAll(pattern, "(?i)", "")
 	pattern = strings.ReplaceAll(pattern, "(?s)", "")
@@ -334,6 +343,76 @@ func preprocessPatternForHyperscan(pattern string) string {
 	pattern = namedGroupRegex.ReplaceAllString(pattern, "(?:")
 
 	return pattern
+}
+
+// lookaroundEnd returns the index just past the balanced ')' that closes the
+// group starting at runes[start] (which must be '('). It honours backslash
+// escapes and [...] character classes.
+//
+// If the group is unbalanced or truncated (malformed pattern), it returns
+// len(runes). In that case stripLookarounds drops the remainder of the pattern
+// from the lookaround start onward. This is safe: a malformed pattern would
+// fail Hyperscan compilation anyway (→ regexp2 fallback), and regexp2 always
+// uses the unmodified rule.Pattern for precise extraction, so no reported match
+// can change.
+func lookaroundEnd(runes []rune, start int) int {
+	depth := 0
+	inClass := false
+	for j := start; j < len(runes); {
+		c := runes[j]
+		if c == '\\' { // skip escaped char
+			j += 2
+			continue
+		}
+		if inClass {
+			if c == ']' {
+				inClass = false
+			}
+			j++
+			continue
+		}
+		switch c {
+		case '[':
+			inClass = true
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return j + 1
+			}
+		}
+		j++
+	}
+	return len(runes)
+}
+
+// stripLookarounds removes lookaround assertions ((?=...) (?!...) (?<=...) (?<!...)) and
+// their balanced contents from a pattern. Hyperscan does not support lookaround;
+// since Hyperscan is only an over-approximating prefilter (regexp2 keeps the full
+// pattern for precise extraction), removing a lookaround only widens the prefilter
+// and can never change a reported match.
+//
+// Malformed or unclosed lookaround: if lookaroundEnd cannot find the closing ')',
+// it returns len(runes) and the remainder of the pattern is dropped from the
+// lookaround start onward. This is safe for the same reason — such a pattern
+// would fail Hyperscan compilation (→ regexp2 fallback) regardless.
+func stripLookarounds(pattern string) string {
+	runes := []rune(pattern)
+	var b strings.Builder
+	for i := 0; i < len(runes); {
+		if runes[i] == '(' && i+2 < len(runes) && runes[i+1] == '?' {
+			look := runes[i+2] == '=' || runes[i+2] == '!' ||
+				(runes[i+2] == '<' && i+3 < len(runes) && (runes[i+3] == '=' || runes[i+3] == '!'))
+			if look {
+				i = lookaroundEnd(runes, i) // drop the entire lookaround group
+				continue
+			}
+		}
+		b.WriteRune(runes[i])
+		i++
+	}
+	return b.String()
 }
 
 // hasExtendedMode checks if pattern uses extended mode.

--- a/pkg/matcher/vectorscan_lookaround_test.go
+++ b/pkg/matcher/vectorscan_lookaround_test.go
@@ -1,0 +1,157 @@
+//go:build !wasm && cgo && vectorscan
+
+package matcher
+
+import (
+	"testing"
+
+	"github.com/praetorian-inc/titus/pkg/rule"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStripLookarounds_NegativeLookaheadWithNestedGroups mirrors the np.generic.5
+// pattern (after extended-mode strip) and verifies the lookahead group is fully
+// removed while the surrounding pattern — including the capture group — is kept.
+func TestStripLookarounds_NegativeLookaheadWithNestedGroups(t *testing.T) {
+	// This is what np.generic.5 looks like after stripExtendedMode processes it.
+	input := `password"(?!(?-i)[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+")([^"]{4,})"`
+	want := `password"([^"]{4,})"`
+	got := stripLookarounds(input)
+	assert.Equal(t, want, got)
+}
+
+// TestStripLookarounds_CharClassSafety verifies that parentheses inside a character
+// class are NOT counted as group delimiters.
+func TestStripLookarounds_CharClassSafety(t *testing.T) {
+	// The (?!...) contains a character class with ) and ( inside it.
+	// The lookahead must still be fully consumed and the rest preserved.
+	input := `foo(?![()-])bar`
+	want := `foobar`
+	got := stripLookarounds(input)
+	assert.Equal(t, want, got)
+}
+
+// TestStripLookarounds_EscapedParenSafety verifies that \( and \) are preserved
+// verbatim and are not counted as group delimiters.
+func TestStripLookarounds_EscapedParenSafety(t *testing.T) {
+	// Pattern has escaped parens outside a lookaround — must be unchanged.
+	input := `\(hello\)(?=world)suffix`
+	want := `\(hello\)suffix`
+	got := stripLookarounds(input)
+	assert.Equal(t, want, got)
+}
+
+// TestStripLookarounds_NoLookaround verifies patterns without any lookaround are
+// returned unchanged.
+func TestStripLookarounds_NoLookaround(t *testing.T) {
+	cases := []string{
+		`foo(bar)baz`,
+		`[A-Z]+`,
+		`(?:abc)`,
+		`(?i)sensitive`,
+		`(?P<name>[a-z]+)`,
+		``,
+	}
+	for _, c := range cases {
+		assert.Equal(t, c, stripLookarounds(c), "pattern should be unchanged: %q", c)
+	}
+}
+
+// TestStripLookarounds_AllLookaroundTypes checks that all four lookaround forms
+// are recognised and removed.
+func TestStripLookarounds_AllLookaroundTypes(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"positive lookahead", `foo(?=bar)baz`, `foobaz`},
+		{"negative lookahead", `foo(?!bar)baz`, `foobaz`},
+		{"positive lookbehind", `foo(?<=bar)baz`, `foobaz`},
+		{"negative lookbehind", `foo(?<!bar)baz`, `foobaz`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, stripLookarounds(tc.input))
+		})
+	}
+}
+
+// TestStripLookarounds_MalformedUnclosed verifies that a lookaround group that
+// is never closed causes the remainder of the pattern (from the lookaround
+// start) to be dropped. This is safe: a malformed pattern would fail Hyperscan
+// compilation regardless, and regexp2 always uses the unmodified rule.Pattern.
+func TestStripLookarounds_MalformedUnclosed(t *testing.T) {
+	got := stripLookarounds("foo(?=bar")
+	assert.Equal(t, "foo", got)
+}
+
+// TestLookaroundEnd_Unbalanced verifies that lookaroundEnd returns len(runes)
+// when the group starting at start is never closed.
+func TestLookaroundEnd_Unbalanced(t *testing.T) {
+	runes := []rune("(?=bar") // no closing ')'
+	end := lookaroundEnd(runes, 0)
+	assert.Equal(t, len(runes), end)
+}
+
+// TestStripLookarounds_MultipleAdjacent verifies that multiple consecutive
+// lookarounds are all removed and the surrounding literal text is preserved.
+func TestStripLookarounds_MultipleAdjacent(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			"lookahead then lookbehind separated by literal",
+			`foo(?=bar)mid(?!baz)end`,
+			`foomidend`,
+		},
+		{
+			"two adjacent lookarounds with no literal between",
+			`pre(?=x)(?!y)post`,
+			`prepost`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, stripLookarounds(tc.input))
+		})
+	}
+}
+
+// TestStripLookarounds_LookbehindAdjacentToNamedGroup verifies that a lookbehind
+// immediately followed by a .NET-style named group does NOT clobber the named
+// group — only the lookbehind is stripped.
+func TestStripLookarounds_LookbehindAdjacentToNamedGroup(t *testing.T) {
+	input := `foo(?<=bar)(?<name>baz)`
+	want := `foo(?<name>baz)`
+	got := stripLookarounds(input)
+	assert.Equal(t, want, got)
+}
+
+// TestVectorscanMatcher_NoFallbackRulesAfterLookaroundStrip loads all built-in
+// rules, builds a VectorscanMatcher, and asserts that np.generic.5 and
+// np.generic.6 are NOT in the fallback set — i.e., they were successfully
+// compiled into Hyperscan after lookaround stripping.
+func TestVectorscanMatcher_NoFallbackRulesAfterLookaroundStrip(t *testing.T) {
+	rules, err := rule.NewLoader().LoadBuiltinRules()
+	require.NoError(t, err)
+	require.NotEmpty(t, rules)
+
+	m, err := NewVectorscan(rules, 0, nil)
+	require.NoError(t, err)
+	// Skip defer Close — pre-existing hyperscan cleanup issue can cause hangs.
+
+	// Build a set of fallback rule IDs for O(1) lookup.
+	fallbackIDs := make(map[string]bool, len(m.fallbackRules))
+	for _, r := range m.fallbackRules {
+		fallbackIDs[r.ID] = true
+	}
+
+	assert.False(t, fallbackIDs["np.generic.5"], "np.generic.5 should be compiled into Hyperscan, not fallback")
+	assert.False(t, fallbackIDs["np.generic.6"], "np.generic.6 should be compiled into Hyperscan, not fallback")
+	assert.Equal(t, 0, len(m.fallbackRules), "expected 0 fallback rules, got %d", len(m.fallbackRules))
+}
+


### PR DESCRIPTION
### Summary

`np.generic.5` and `np.generic.6` (the only builtin rules containing lookaround assertions) can't be compiled by Hyperscan, so today they fall back to a separate **per-blob regexp2 pass**. That pass is gated only by the `"password"` keyword prefilter, so the slow backtracking regexp2 fires on *every* blob containing the word "password" — the vast majority of which have no `password="value"` construct and produce no match.

This PR strips lookarounds from the **Hyperscan-prefilter copy of the pattern only**, letting both rules join the single combined Hyperscan pass and **eliminating the regexp2 fallback entirely** (501/501 rules now compile, 0 fallback).

### Why this is behavior-preserving

In `vectorscan.go`, Hyperscan is only an **over-approximating prefilter**: `db.Scan` records *which* rule IDs matched, then the full `regexp2` (compiled from the rule's **unmodified** `rule.Pattern`, lookarounds included) does the precise match + capture extraction. `preprocessPatternForHyperscan` only affects the bytes fed to Hyperscan compile — never the stored rule pattern.

Removing a lookaround from the prefilter copy can therefore only make the prefilter *more permissive*. It can never cause a false negative or change a reported match — the lookahead's false-positive guard still runs in regexp2 extraction. The `pkg/rule/generic_password_fp_test.go` contract (SCREAMING_SNAKE_CASE suppression, e.g. rejecting `password = "MY_CONSTANT"`) still passes.

### Measured impact (kubernetes, `--ruleset all --include-noisy`, vectorscan build)

| Scan | Before (2 fallback) | After (0 fallback) | Δ |
|---|---|---|---|
| working-tree path scan | 7.84s | 4.77s | **−39%** |
| full `--git` history scan | 90.0s | 76.7s | **−15% (−13.5s)** |
| findings (parity) | 470 (np.generic.5=21) | 470 (np.generic.5=21) | identical |

### Changes

- `pkg/matcher/vectorscan.go`: add `stripLookarounds` + `lookaroundEnd` helpers (escape- and char-class-aware balanced-paren removal of `(?=) (?!) (?<=) (?<!)`), called from `preprocessPatternForHyperscan`.
- `pkg/matcher/vectorscan_lookaround_test.go`: unit tests (all four lookaround forms, nested groups, char-class/escape safety, malformed/unclosed, adjacent lookarounds, lookbehind-vs-named-group, and a 0-fallback integration assertion).

### Verification

- `go test -tags vectorscan ./pkg/matcher/... ./pkg/rule/...` → all pass (incl. FP contract), `go vet` clean.
- Live scan: `[vectorscan] 501/501 rules compiled for Hyperscan, 0 rules use regexp2 fallback`.

▎ Disclaimer: This PR was authored with AI.