### PR TITLE
fix(serve): populate source positions in scan, scan_batch, scan_path and scan_git responses

### DIFF
--- a/pkg/serve/server.go
+++ b/pkg/serve/server.go
@@ -140,6 +140,8 @@ func (s *Server) handleScan(payload json.RawMessage) {
 		return
 	}
 
+	populateSourcePositions([]byte(p.Content), result.Matches)
+
 	data, _ := json.Marshal(result)
 	_ = s.encoder.Encode(Response{
 		Success: true,
@@ -159,6 +161,10 @@ func (s *Server) handleScanBatch(payload json.RawMessage) {
 	if err != nil {
 		s.sendError("scan_batch", err.Error())
 		return
+	}
+
+	for i, scanResult := range result.Results {
+		populateSourcePositions([]byte(p.Items[i].Content), scanResult.Matches)
 	}
 
 	data, _ := json.Marshal(result)
@@ -306,6 +312,7 @@ func (s *Server) streamEnumeration(ctx context.Context, enumerator enum.Enumerat
 					continue
 				}
 
+				populateSourcePositions(job.content, matches)
 				totalMatches.Add(int64(len(matches)))
 
 				result := ScanBlobResult{
@@ -346,6 +353,17 @@ func (s *Server) streamEnumeration(ctx context.Context, enumerator enum.Enumerat
 		Data:    doneData,
 	})
 	s.encoderMu.Unlock()
+}
+
+func populateSourcePositions(content []byte, matches []*types.Match) {
+	for _, m := range matches {
+		startLine, startCol := types.ComputeLineColumn(content, int(m.Location.Offset.Start))
+		endLine, endCol := types.ComputeLineColumn(content, int(m.Location.Offset.End))
+		m.Location.Source.Start.Line = startLine
+		m.Location.Source.Start.Column = startCol
+		m.Location.Source.End.Line = endLine
+		m.Location.Source.End.Column = endCol
+	}
 }
 
 func (s *Server) sendError(reqType, msg string) {

--- a/pkg/serve/server_test.go
+++ b/pkg/serve/server_test.go
@@ -51,7 +51,7 @@ func TestServer_Scan(t *testing.T) {
 	defer core.Close()
 
 	// Input: scan request
-	request := `{"type":"scan","payload":{"content":"AKIAIOSFODNN7EXAMPLE","source":"test"}}` + "\n"
+	request := `{"type":"scan","payload":{"content":"prefix\naws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY","source":"test"}}` + "\n"
 	in := strings.NewReader(request)
 	out := &bytes.Buffer{}
 
@@ -68,6 +68,14 @@ func TestServer_Scan(t *testing.T) {
 
 	assert.True(t, resp.Success)
 	assert.Equal(t, "scan", resp.Type)
+
+	var result scanner.ScanResult
+	require.NoError(t, json.Unmarshal(resp.Data, &result))
+	require.NotEmpty(t, result.Matches)
+	assert.Equal(t, 2, result.Matches[0].Location.Source.Start.Line)
+	assert.Equal(t, 12, result.Matches[0].Location.Source.Start.Column)
+	assert.Equal(t, 2, result.Matches[0].Location.Source.End.Line)
+	assert.Equal(t, 65, result.Matches[0].Location.Source.End.Column)
 }
 
 func TestServer_GracefulShutdownOnContext(t *testing.T) {
@@ -108,7 +116,7 @@ func TestServer_ScanBatch(t *testing.T) {
 	require.NoError(t, err)
 	defer core.Close()
 
-	request := `{"type":"scan_batch","payload":{"items":[{"source":"s1","content":"test1"},{"source":"s2","content":"AKIAIOSFODNN7EXAMPLE"}]}}` + "\n"
+	request := `{"type":"scan_batch","payload":{"items":[{"source":"s1","content":"test1"},{"source":"s2","content":"prefix\naws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"}]}}` + "\n"
 	in := strings.NewReader(request)
 	out := &bytes.Buffer{}
 
@@ -125,6 +133,15 @@ func TestServer_ScanBatch(t *testing.T) {
 
 	assert.True(t, resp.Success)
 	assert.Equal(t, "scan_batch", resp.Type)
+
+	var result scanner.BatchScanResult
+	require.NoError(t, json.Unmarshal(resp.Data, &result))
+	require.Len(t, result.Results, 2)
+	require.NotEmpty(t, result.Results[1].Matches)
+	assert.Equal(t, 2, result.Results[1].Matches[0].Location.Source.Start.Line)
+	assert.Equal(t, 12, result.Results[1].Matches[0].Location.Source.Start.Column)
+	assert.Equal(t, 2, result.Results[1].Matches[0].Location.Source.End.Line)
+	assert.Equal(t, 65, result.Results[1].Matches[0].Location.Source.End.Column)
 }
 
 func TestServer_CloseCommand(t *testing.T) {
@@ -194,7 +211,7 @@ func TestServer_ScanPath(t *testing.T) {
 	defer core.Close()
 
 	dir := t.TempDir()
-	secret := "aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+	secret := "prefix\naws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.ini"), []byte(secret), 0644))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "clean.txt"), []byte("nothing here"), 0644))
 
@@ -231,6 +248,14 @@ func TestServer_ScanPath(t *testing.T) {
 	require.NoError(t, json.Unmarshal(done.Data, &doneData))
 	assert.Equal(t, 2, doneData.TotalBlobs)
 	assert.GreaterOrEqual(t, doneData.TotalMatches, 1)
+
+	var blobResult ScanBlobResult
+	require.NoError(t, json.Unmarshal(results[0].Data, &blobResult))
+	require.NotEmpty(t, blobResult.Matches)
+	assert.Equal(t, 2, blobResult.Matches[0].Location.Source.Start.Line)
+	assert.Equal(t, 12, blobResult.Matches[0].Location.Source.Start.Column)
+	assert.Equal(t, 2, blobResult.Matches[0].Location.Source.End.Line)
+	assert.Equal(t, 65, blobResult.Matches[0].Location.Source.End.Column)
 }
 
 func TestServer_ScanPath_EmptyDir(t *testing.T) {


### PR DESCRIPTION
### Summary

- Populates the source line/column positions (location.source.start / location.source.end) in the responses of the scan, scan_batch, scan_path, and scan_git request types in titus serve.
- Previously these responses only carried byte offsets (location.offset), while the line/column fields were left at zero. 

▎ Disclaimer: This PR was authored with AI