### PR TITLE
fix(matcher): prefer provider-specific rules over generic in pickWinner

### DIFF
--- a/pkg/matcher/crossrule.go
+++ b/pkg/matcher/crossrule.go
@@ -133,7 +133,7 @@ func minStartOffset(cluster []*types.Match) int64 {
 }
 
 // pickWinner selects the most informative match from a cluster.
-// Priority: has validator > group count > total captured length > pattern length.
+// Priority: has validator > non-generic rule > group count > total captured length > pattern length.
 func (d *CrossRuleDeduplicator) pickWinner(cluster []*types.Match) *types.Match {
 	best := 0
 	bestScore := d.score(cluster[0])
@@ -160,12 +160,15 @@ func (d *CrossRuleDeduplicator) score(m *types.Match) matchScore {
 	}
 
 	patternLen := 0
+	isGeneric := false
 	if r, ok := d.rules[m.RuleID]; ok {
 		patternLen = len(r.Pattern)
+		isGeneric = ruleHasCategory(r, "generic")
 	}
 
 	return matchScore{
 		hasValidator: hasValidator,
+		isGeneric:    isGeneric,
 		groupCount:   len(m.Groups),
 		groupsLen:    groupsLen,
 		patternLen:   patternLen,
@@ -173,9 +176,20 @@ func (d *CrossRuleDeduplicator) score(m *types.Match) matchScore {
 	}
 }
 
+// ruleHasCategory reports whether the rule is tagged with the given category.
+func ruleHasCategory(r *types.Rule, category string) bool {
+	for _, c := range r.Categories {
+		if c == category {
+			return true
+		}
+	}
+	return false
+}
+
 // matchScore captures the ranking criteria for comparing matches.
 type matchScore struct {
 	hasValidator bool
+	isGeneric    bool // rule carries the "generic" category (catch-all)
 	groupCount   int
 	groupsLen    int
 	patternLen   int
@@ -186,6 +200,13 @@ type matchScore struct {
 func (s matchScore) Better(other matchScore) bool {
 	if s.hasValidator != other.hasValidator {
 		return s.hasValidator
+	}
+	// A provider-specific rule beats a generic catch-all rule (e.g. np.aws.2
+	// over np.generic.2). Generic rules exist to catch credentials that no
+	// specific rule recognises, so whenever a specific rule also fires on the
+	// same secret it is the more informative match.
+	if s.isGeneric != other.isGeneric {
+		return !s.isGeneric
 	}
 	if s.groupCount != other.groupCount {
 		return s.groupCount > other.groupCount

--- a/pkg/matcher/crossrule_test.go
+++ b/pkg/matcher/crossrule_test.go
@@ -366,3 +366,66 @@ func TestCrossRuleDeduplicator_WinnerStableUnderInputReorder(t *testing.T) {
 	assert.Equal(t, "np.aws.1", expectedWinner,
 		"lexicographically smaller ruleID must win when all other score fields are equal")
 }
+
+func TestCrossRule_SpecificBeatsGeneric(t *testing.T) {
+	// np.aws.2 (provider-specific) and np.generic.2 (generic catch-all) capture
+	// the same secret, so they cluster. The generic rule has a longer pattern
+	// string, which would otherwise win the patternLen tiebreaker — but the
+	// "generic" category demotes it below the specific rule.
+	rules := map[string]*types.Rule{
+		"np.aws.2": {
+			ID:         "np.aws.2",
+			Pattern:    "short_specific_pattern",
+			Categories: []string{"api", "fuzzy", "secret"},
+		},
+		"np.generic.2": {
+			ID:         "np.generic.2",
+			Pattern:    "a_much_longer_generic_catch_all_pattern_string",
+			Categories: []string{"fuzzy", "generic", "secret"},
+		},
+	}
+
+	dedup := NewCrossRuleDeduplicator(rules, nil)
+
+	matches := []*types.Match{
+		makeMatch("np.generic.2", "FakeValues99cl9bqJFVA3iFUm+yqVe08HxhXFE/"),
+		makeMatch("np.aws.2", "FakeValues99cl9bqJFVA3iFUm+yqVe08HxhXFE/"),
+	}
+
+	result := dedup.Deduplicate(matches)
+
+	require.Len(t, result, 1)
+	assert.Equal(t, "np.aws.2", result[0].RuleID,
+		"provider-specific rule must beat the generic catch-all rule")
+}
+
+func TestCrossRule_ValidatorBeatsSpecificity(t *testing.T) {
+	// A generic rule with a validator still beats a specific rule without one:
+	// validator presence is a stronger signal than the generic/specific split.
+	rules := map[string]*types.Rule{
+		"np.specific.1": {
+			ID:         "np.specific.1",
+			Pattern:    "specific",
+			Categories: []string{"api", "secret"},
+		},
+		"np.generic.2": {
+			ID:         "np.generic.2",
+			Pattern:    "generic",
+			Categories: []string{"generic", "secret"},
+		},
+	}
+
+	canValidate := func(ruleID string) bool { return ruleID == "np.generic.2" }
+	dedup := NewCrossRuleDeduplicator(rules, canValidate)
+
+	matches := []*types.Match{
+		makeMatch("np.specific.1", "SHARED_SECRET_VALUE"),
+		makeMatch("np.generic.2", "SHARED_SECRET_VALUE"),
+	}
+
+	result := dedup.Deduplicate(matches)
+
+	require.Len(t, result, 1)
+	assert.Equal(t, "np.generic.2", result[0].RuleID,
+		"a validated generic match still beats an unvalidated specific match")
+}


### PR DESCRIPTION
### Problem

When several rules capture the same secret, `CrossRuleDeduplicator.pickWinner` keeps a single winner from the cluster. The winner is chosen by a scoring chain that ended with raw **pattern-string length** as the last meaningful tiebreak.

For some secrets this selected the generic catch-all rule over the provider-specific one. Example:

```
AWS_SECRET_ACCESS_KEY=<40-char secret>
```

Both `np.aws.2` (AWS Secret Access Key) and `np.generic.2` (Generic API Key) match and capture the same value, so they cluster. `np.generic.2`'s pattern is 167 chars vs `np.aws.2`'s 155, so the generic rule won and the specific AWS finding was suppressed. NoseyParker reports both because it does not pick a single winner across rules.

### Fix

Add a criterion to `pickWinner`'s scoring: a rule carrying the `generic` category loses to a non-generic rule on the same secret. New priority order:

1. has validator
2. **non-generic > generic** (new)
3. group count
4. captured length
5. pattern length
6. ruleID (deterministic tiebreak)

It sits right after the validator check (a validated match stays the strongest signal — covered by a test) and before the group-count / pattern-length tiebreaks.

Verified on several secrets where a specific and the generic rule collide — the specific rule now wins and the generic finding is suppressed:

| Input | Winner (after) | Generic also matched before |
|---|---|---|
| `AWS_SECRET_ACCESS_KEY=…` | `np.aws.2` | yes |
| `DD_API_KEY=…` | `kingfisher.datadog.2` | yes |
| `apikey: …` (Discord token format) | `kingfisher.discord.2` | yes |
| `flickr_api_key: …` | `kingfisher.flickr.1` | yes |


▎ Disclaimer: This PR was authored with AI