### PR TITLE
feat(scoring): GCP service account key IAM scope scorer (LAB-3358)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 )
 
 require (
+	cloud.google.com/go/compute/metadata v0.7.0 // indirect
 	dario.cat/mergo v1.0.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,12 @@ cloud.google.com/go v0.45.1/go.mod h1:RpBamKRgapWJb87xiFSdk4g1CME7QZg3uwTez+TSTj
 cloud.google.com/go v0.46.3/go.mod h1:a6bKKbmY7er1mI7TEI4lsAkts/mkhTSZK8w33B4RAg0=
 cloud.google.com/go v0.50.0/go.mod h1:r9sluTvynVuxRIOHXQEHMFffphuXHOMZMycpNR5e6To=
 cloud.google.com/go v0.53.0/go.mod h1:fp/UouUEsRkN6ryDKNW/Upv/JBKnv6WDthjR6+vze6M=
+cloud.google.com/go v0.110.10 h1:LXy9GEO+timppncPIAZoOj3l58LIU9k+kn48AN7IO3Y=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/bigquery v1.3.0/go.mod h1:PjpwJnslEMmckchkHFfq+HTD2DmtT67aNFKH1/VBDHE=
+cloud.google.com/go/compute v1.23.3 h1:6sVlXXBmbd7jNX0Ipq0trII3e4n1/MsADLK6a+aiVlk=
+cloud.google.com/go/compute/metadata v0.7.0 h1:PBWF+iiAerVNe8UCHxdOt6eHLVc3ydFeOCw78U8ytSU=
+cloud.google.com/go/compute/metadata v0.7.0/go.mod h1:j5MvL9PprKL39t166CoB1uVHfQMs4tFQZZcKwksXUjo=
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/pubsub v1.1.0/go.mod h1:EwwdRX2sKPjnvnqCa270oGRyludottCI76h+R3AArQw=

--- a/pkg/scoring/gcp.go
+++ b/pkg/scoring/gcp.go
@@ -1,0 +1,289 @@
+package scoring
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+)
+
+// extractGCPCredentials extracts service account fields from the match.
+// Checks service_account group first, then service_account_nested.
+func extractGCPCredentials(m *types.Match) (*gcpServiceAccountKey, bool) {
+	if m == nil {
+		return nil, false
+	}
+	for _, group := range []string{"service_account", "service_account_nested"} {
+		raw, ok := m.NamedGroups[group]
+		if !ok || len(raw) == 0 {
+			continue
+		}
+		var key gcpServiceAccountKey
+		if err := json.Unmarshal(raw, &key); err == nil {
+			if key.ClientEmail != "" && key.PrivateKey != "" {
+				return &key, true
+			}
+		}
+		// Try recursive search for nested JSON objects
+		var obj map[string]interface{}
+		if err := json.Unmarshal(raw, &obj); err == nil {
+			if key := findGCPServiceAccountKey(obj); key != nil {
+				return key, true
+			}
+		}
+	}
+	return nil, false
+}
+
+// findGCPServiceAccountKey recursively searches a JSON object for a nested
+// object containing both client_email and private_key string fields.
+func findGCPServiceAccountKey(obj map[string]interface{}) *gcpServiceAccountKey {
+	email, _ := obj["client_email"].(string)
+	privKey, _ := obj["private_key"].(string)
+	if email != "" && privKey != "" {
+		projectID, _ := obj["project_id"].(string)
+		return &gcpServiceAccountKey{
+			ProjectID:   projectID,
+			ClientEmail: email,
+			PrivateKey:  privKey,
+		}
+	}
+	for _, v := range obj {
+		nested, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if key := findGCPServiceAccountKey(nested); key != nil {
+			return key
+		}
+	}
+	return nil
+}
+
+// gcpSADisabledCondition fires when the service account is disabled.
+// Detected by the factory's token exchange failing with a "disabled" error.
+type gcpSADisabledCondition struct {
+	clientFactory gcpClientFactory
+}
+
+func (c *gcpSADisabledCondition) markDynamic() {}
+
+func (c *gcpSADisabledCondition) Evaluate(ctx context.Context, m *types.Match) (bool, error) {
+	key, ok := extractGCPCredentials(m)
+	if !ok {
+		return false, nil
+	}
+	factory := c.clientFactory
+	if factory == nil {
+		factory = defaultGCPClientFactory
+	}
+	_, err := factory(ctx, key)
+	if err != nil && strings.Contains(strings.ToLower(err.Error()), "disabled") {
+		return true, nil
+	}
+	return false, nil
+}
+
+// gcpRoleBindingCondition fires when the SA's project IAM bindings match
+// specific roles. When onlyIfExclusive is true, ALL of the SA's roles must
+// be in matchRoles (used for read-only detection).
+type gcpRoleBindingCondition struct {
+	matchRoles      []string
+	onlyIfExclusive bool
+	clientFactory   gcpClientFactory
+}
+
+func (c *gcpRoleBindingCondition) markDynamic() {}
+
+func (c *gcpRoleBindingCondition) Evaluate(ctx context.Context, m *types.Match) (bool, error) {
+	key, ok := extractGCPCredentials(m)
+	if !ok {
+		return false, nil
+	}
+	factory := c.clientFactory
+	if factory == nil {
+		factory = defaultGCPClientFactory
+	}
+	api, err := factory(ctx, key)
+	if err != nil {
+		return false, nil
+	}
+
+	bindings, err := api.GetProjectIAMPolicy(ctx, key.ProjectID)
+	if err != nil {
+		return false, nil
+	}
+
+	member := "serviceAccount:" + key.ClientEmail
+	matchSet := make(map[string]bool, len(c.matchRoles))
+	for _, r := range c.matchRoles {
+		matchSet[r] = true
+	}
+
+	var saRoles []string
+	for _, b := range bindings {
+		for _, mem := range b.Members {
+			if mem == member {
+				saRoles = append(saRoles, b.Role)
+				break
+			}
+		}
+	}
+
+	if len(saRoles) == 0 {
+		return false, nil
+	}
+
+	if c.onlyIfExclusive {
+		for _, role := range saRoles {
+			if !matchSet[role] {
+				return false, nil
+			}
+		}
+		return true, nil
+	}
+
+	for _, role := range saRoles {
+		if matchSet[role] {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// gcpOrgLevelBindingCondition fires when the SA has any binding at the org level.
+type gcpOrgLevelBindingCondition struct {
+	clientFactory gcpClientFactory
+}
+
+func (c *gcpOrgLevelBindingCondition) markDynamic() {}
+
+func (c *gcpOrgLevelBindingCondition) Evaluate(ctx context.Context, m *types.Match) (bool, error) {
+	key, ok := extractGCPCredentials(m)
+	if !ok {
+		return false, nil
+	}
+	factory := c.clientFactory
+	if factory == nil {
+		factory = defaultGCPClientFactory
+	}
+	api, err := factory(ctx, key)
+	if err != nil {
+		return false, nil
+	}
+
+	bindings, err := api.GetOrgIAMPolicy(ctx, key.ProjectID)
+	if err != nil {
+		return false, nil
+	}
+
+	member := "serviceAccount:" + key.ClientEmail
+	for _, b := range bindings {
+		for _, mem := range b.Members {
+			if mem == member {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+// gcpMultiProjectCondition fires when the SA can access minProjects or more projects.
+type gcpMultiProjectCondition struct {
+	minProjects   int
+	clientFactory gcpClientFactory
+}
+
+func (c *gcpMultiProjectCondition) markDynamic() {}
+
+func (c *gcpMultiProjectCondition) Evaluate(ctx context.Context, m *types.Match) (bool, error) {
+	key, ok := extractGCPCredentials(m)
+	if !ok {
+		return false, nil
+	}
+	factory := c.clientFactory
+	if factory == nil {
+		factory = defaultGCPClientFactory
+	}
+	api, err := factory(ctx, key)
+	if err != nil {
+		return false, nil
+	}
+
+	count, err := api.CountAccessibleProjects(ctx)
+	if err != nil {
+		return false, nil
+	}
+	return count >= c.minProjects, nil
+}
+
+// gcpSingleNonProdCondition fires when the SA is scoped to exactly one project
+// and that project appears to be non-production.
+type gcpSingleNonProdCondition struct {
+	clientFactory gcpClientFactory
+}
+
+func (c *gcpSingleNonProdCondition) markDynamic() {}
+
+var nonProdPatterns = []string{
+	"dev", "test", "staging", "sandbox", "nonprod", "non-prod", "demo", "tmp", "temp",
+}
+
+func (c *gcpSingleNonProdCondition) Evaluate(ctx context.Context, m *types.Match) (bool, error) {
+	key, ok := extractGCPCredentials(m)
+	if !ok {
+		return false, nil
+	}
+	factory := c.clientFactory
+	if factory == nil {
+		factory = defaultGCPClientFactory
+	}
+	api, err := factory(ctx, key)
+	if err != nil {
+		return false, nil
+	}
+
+	count, err := api.CountAccessibleProjects(ctx)
+	if err != nil {
+		return false, nil
+	}
+	if count != 1 {
+		return false, nil
+	}
+
+	lower := strings.ToLower(key.ProjectID)
+	for _, pat := range nonProdPatterns {
+		if strings.Contains(lower, pat) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// GCPGoScorer returns a *Scorer targeting the GCP service account key rule.
+func GCPGoScorer() *Scorer {
+	return &Scorer{
+		Name:    "gcp-sa-iam-scope",
+		RuleIDs: []string{"kingfisher.gcp.1"},
+		Modifiers: []Modifier{
+			{Name: "sa-disabled", Priority: 100, Kind: ModifierKindSetScore, Value: 5, Condition: &gcpSADisabledCondition{}},
+			{Name: "owner-or-org-admin", Priority: 95, Kind: ModifierKindSetScore, Value: 99,
+				Condition: &gcpRoleBindingCondition{matchRoles: []string{"roles/owner", "roles/resourcemanager.organizationAdmin"}}},
+			{Name: "priv-escalation-path", Priority: 85, Kind: ModifierKindDelta, Value: 20,
+				Condition: &gcpRoleBindingCondition{matchRoles: []string{"roles/iam.serviceAccountAdmin", "roles/iam.securityAdmin"}}},
+			{Name: "secret-accessor", Priority: 80, Kind: ModifierKindDelta, Value: 15,
+				Condition: &gcpRoleBindingCondition{matchRoles: []string{"roles/secretmanager.secretAccessor"}}},
+			{Name: "storage-db-admin", Priority: 75, Kind: ModifierKindDelta, Value: 15,
+				Condition: &gcpRoleBindingCondition{matchRoles: []string{"roles/storage.admin", "roles/cloudsql.admin"}}},
+			{Name: "org-level-binding", Priority: 70, Kind: ModifierKindDelta, Value: 15, Condition: &gcpOrgLevelBindingCondition{}},
+			{Name: "multi-project-access", Priority: 65, Kind: ModifierKindDelta, Value: 10,
+				Condition: &gcpMultiProjectCondition{minProjects: 5}},
+			{Name: "viewer-only", Priority: 60, Kind: ModifierKindDelta, Value: -20,
+				Condition: &gcpRoleBindingCondition{matchRoles: []string{"roles/viewer", "roles/browser"}, onlyIfExclusive: true}},
+			{Name: "observability-only", Priority: 55, Kind: ModifierKindDelta, Value: -15,
+				Condition: &gcpRoleBindingCondition{matchRoles: []string{"roles/logging.viewer", "roles/monitoring.viewer"}, onlyIfExclusive: true}},
+			{Name: "single-non-prod-project", Priority: 50, Kind: ModifierKindDelta, Value: -10, Condition: &gcpSingleNonProdCondition{}},
+		},
+	}
+}

--- a/pkg/scoring/gcp.go
+++ b/pkg/scoring/gcp.go
@@ -50,12 +50,19 @@ func findGCPServiceAccountKey(obj map[string]interface{}) *gcpServiceAccountKey 
 		}
 	}
 	for _, v := range obj {
-		nested, ok := v.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		if key := findGCPServiceAccountKey(nested); key != nil {
-			return key
+		switch val := v.(type) {
+		case map[string]interface{}:
+			if key := findGCPServiceAccountKey(val); key != nil {
+				return key
+			}
+		case []interface{}:
+			for _, elem := range val {
+				if nested, ok := elem.(map[string]interface{}); ok {
+					if key := findGCPServiceAccountKey(nested); key != nil {
+						return key
+					}
+				}
+			}
 		}
 	}
 	return nil
@@ -79,19 +86,24 @@ func (c *gcpSADisabledCondition) Evaluate(ctx context.Context, m *types.Match) (
 		factory = defaultGCPClientFactory
 	}
 	_, err := factory(ctx, key)
-	if err != nil && strings.Contains(strings.ToLower(err.Error()), "disabled") {
-		return true, nil
+	if err != nil {
+		lower := strings.ToLower(err.Error())
+		if strings.Contains(lower, "disabled") || strings.Contains(lower, "deleted") {
+			return true, nil
+		}
 	}
 	return false, nil
 }
 
 // gcpRoleBindingCondition fires when the SA's project IAM bindings match
 // specific roles. When onlyIfExclusive is true, ALL of the SA's roles must
-// be in matchRoles (used for read-only detection).
+// be in matchRoles (used for read-only detection). When checkOrgBindings is
+// true, org-level bindings are also checked (used for org-admin detection).
 type gcpRoleBindingCondition struct {
-	matchRoles      []string
-	onlyIfExclusive bool
-	clientFactory   gcpClientFactory
+	matchRoles       []string
+	onlyIfExclusive  bool
+	checkOrgBindings bool
+	clientFactory    gcpClientFactory
 }
 
 func (c *gcpRoleBindingCondition) markDynamic() {}
@@ -127,6 +139,20 @@ func (c *gcpRoleBindingCondition) Evaluate(ctx context.Context, m *types.Match) 
 			if mem == member {
 				saRoles = append(saRoles, b.Role)
 				break
+			}
+		}
+	}
+
+	if c.checkOrgBindings {
+		orgBindings, err := api.GetOrgIAMPolicy(ctx, key.ProjectID)
+		if err == nil {
+			for _, b := range orgBindings {
+				for _, mem := range b.Members {
+					if mem == member {
+						saRoles = append(saRoles, b.Role)
+						break
+					}
+				}
 			}
 		}
 	}
@@ -269,7 +295,7 @@ func GCPGoScorer() *Scorer {
 		Modifiers: []Modifier{
 			{Name: "sa-disabled", Priority: 100, Kind: ModifierKindSetScore, Value: 5, Condition: &gcpSADisabledCondition{}},
 			{Name: "owner-or-org-admin", Priority: 95, Kind: ModifierKindSetScore, Value: 99,
-				Condition: &gcpRoleBindingCondition{matchRoles: []string{"roles/owner", "roles/resourcemanager.organizationAdmin"}}},
+				Condition: &gcpRoleBindingCondition{matchRoles: []string{"roles/owner", "roles/resourcemanager.organizationAdmin"}, checkOrgBindings: true}},
 			{Name: "priv-escalation-path", Priority: 85, Kind: ModifierKindDelta, Value: 20,
 				Condition: &gcpRoleBindingCondition{matchRoles: []string{"roles/iam.serviceAccountAdmin", "roles/iam.securityAdmin"}}},
 			{Name: "secret-accessor", Priority: 80, Kind: ModifierKindDelta, Value: 15,

--- a/pkg/scoring/gcp_client.go
+++ b/pkg/scoring/gcp_client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
@@ -18,7 +19,7 @@ type gcpServiceAccountKey struct {
 }
 
 // toJSON reconstructs a minimal service account JSON blob suitable for
-// google.CredentialsFromJSON. The type and token_uri fields are required by
+// google.CredentialsFromJSONWithType. The type and token_uri fields are required by
 // the Google auth library.
 func (k *gcpServiceAccountKey) toJSON() ([]byte, error) {
 	return json.Marshal(map[string]string{
@@ -55,7 +56,7 @@ func defaultGCPClientFactory(ctx context.Context, key *gcpServiceAccountKey) (gc
 	if err != nil {
 		return nil, err
 	}
-	creds, err := google.CredentialsFromJSON(ctx, saJSON,
+	creds, err := google.CredentialsFromJSONWithType(ctx, saJSON, google.ServiceAccount,
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	if err != nil {
@@ -79,7 +80,7 @@ type gcpHTTPAPI struct {
 
 func (a *gcpHTTPAPI) GetProjectIAMPolicy(ctx context.Context, project string) ([]gcpIAMBinding, error) {
 	url := "https://cloudresourcemanager.googleapis.com/v1/projects/" + project + ":getIamPolicy"
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, http.NoBody)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader("{}"))
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +111,7 @@ func (a *gcpHTTPAPI) GetProjectIAMPolicy(ctx context.Context, project string) ([
 
 func (a *gcpHTTPAPI) getOrgID(ctx context.Context, project string) (string, error) {
 	url := "https://cloudresourcemanager.googleapis.com/v1/projects/" + project + ":getAncestry"
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, http.NoBody)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader("{}"))
 	if err != nil {
 		return "", err
 	}
@@ -127,7 +128,7 @@ func (a *gcpHTTPAPI) getOrgID(ctx context.Context, project string) (string, erro
 		return "", err
 	}
 	if resp.StatusCode != http.StatusOK {
-		return "", nil
+		return "", fmt.Errorf("getAncestry: HTTP %d", resp.StatusCode)
 	}
 
 	var result struct {
@@ -154,7 +155,7 @@ func (a *gcpHTTPAPI) GetOrgIAMPolicy(ctx context.Context, project string) ([]gcp
 	}
 
 	url := "https://cloudresourcemanager.googleapis.com/v1/organizations/" + orgID + ":getIamPolicy"
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, http.NoBody)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader("{}"))
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +186,7 @@ func (a *gcpHTTPAPI) GetOrgIAMPolicy(ctx context.Context, project string) ([]gcp
 
 func (a *gcpHTTPAPI) CountAccessibleProjects(ctx context.Context) (int, error) {
 	// Single page of up to 100 projects — sufficient for the >= 5 threshold.
-	url := "https://cloudresourcemanager.googleapis.com/v3/projects?pageSize=100"
+	url := "https://cloudresourcemanager.googleapis.com/v1/projects?pageSize=100"
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return 0, err

--- a/pkg/scoring/gcp_client.go
+++ b/pkg/scoring/gcp_client.go
@@ -1,0 +1,215 @@
+package scoring
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+)
+
+type gcpServiceAccountKey struct {
+	ProjectID   string `json:"project_id"`
+	ClientEmail string `json:"client_email"`
+	PrivateKey  string `json:"private_key"`
+}
+
+// toJSON reconstructs a minimal service account JSON blob suitable for
+// google.CredentialsFromJSON. The type and token_uri fields are required by
+// the Google auth library.
+func (k *gcpServiceAccountKey) toJSON() ([]byte, error) {
+	return json.Marshal(map[string]string{
+		"type":         "service_account",
+		"project_id":   k.ProjectID,
+		"client_email": k.ClientEmail,
+		"private_key":  k.PrivateKey,
+		"token_uri":    "https://oauth2.googleapis.com/token",
+	})
+}
+
+type gcpIAMBinding struct {
+	Role    string   `json:"role"`
+	Members []string `json:"members"`
+}
+
+type gcpAncestor struct {
+	ResourceID struct {
+		Type string `json:"type"`
+		ID   string `json:"id"`
+	} `json:"resourceId"`
+}
+
+type gcpAPI interface {
+	GetProjectIAMPolicy(ctx context.Context, project string) ([]gcpIAMBinding, error)
+	GetOrgIAMPolicy(ctx context.Context, project string) ([]gcpIAMBinding, error)
+	CountAccessibleProjects(ctx context.Context) (int, error)
+}
+
+type gcpClientFactory func(ctx context.Context, key *gcpServiceAccountKey) (gcpAPI, error)
+
+func defaultGCPClientFactory(ctx context.Context, key *gcpServiceAccountKey) (gcpAPI, error) {
+	saJSON, err := key.toJSON()
+	if err != nil {
+		return nil, err
+	}
+	creds, err := google.CredentialsFromJSON(ctx, saJSON,
+		"https://www.googleapis.com/auth/cloud-platform",
+	)
+	if err != nil {
+		return nil, err
+	}
+	// Force a token exchange to validate the SA is active. A disabled SA
+	// returns an error here before any API calls are made.
+	tok, err := creds.TokenSource.Token()
+	if err != nil {
+		return nil, err
+	}
+	client := oauth2.NewClient(ctx, oauth2.StaticTokenSource(tok))
+	return &gcpHTTPAPI{client: client, projectID: key.ProjectID, clientEmail: key.ClientEmail}, nil
+}
+
+type gcpHTTPAPI struct {
+	client      *http.Client
+	projectID   string
+	clientEmail string
+}
+
+func (a *gcpHTTPAPI) GetProjectIAMPolicy(ctx context.Context, project string) ([]gcpIAMBinding, error) {
+	url := "https://cloudresourcemanager.googleapis.com/v1/projects/" + project + ":getIamPolicy"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, http.NoBody)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("getIamPolicy: HTTP %d", resp.StatusCode)
+	}
+
+	var result struct {
+		Bindings []gcpIAMBinding `json:"bindings"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, err
+	}
+	return result.Bindings, nil
+}
+
+func (a *gcpHTTPAPI) getOrgID(ctx context.Context, project string) (string, error) {
+	url := "https://cloudresourcemanager.googleapis.com/v1/projects/" + project + ":getAncestry"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, http.NoBody)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", nil
+	}
+
+	var result struct {
+		Ancestor []gcpAncestor `json:"ancestor"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", err
+	}
+	for _, a := range result.Ancestor {
+		if a.ResourceID.Type == "organization" {
+			return a.ResourceID.ID, nil
+		}
+	}
+	return "", nil
+}
+
+func (a *gcpHTTPAPI) GetOrgIAMPolicy(ctx context.Context, project string) ([]gcpIAMBinding, error) {
+	orgID, err := a.getOrgID(ctx, project)
+	if err != nil {
+		return nil, err
+	}
+	if orgID == "" {
+		return nil, nil
+	}
+
+	url := "https://cloudresourcemanager.googleapis.com/v1/organizations/" + orgID + ":getIamPolicy"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, http.NoBody)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("getIamPolicy: HTTP %d", resp.StatusCode)
+	}
+
+	var result struct {
+		Bindings []gcpIAMBinding `json:"bindings"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, err
+	}
+	return result.Bindings, nil
+}
+
+func (a *gcpHTTPAPI) CountAccessibleProjects(ctx context.Context) (int, error) {
+	// Single page of up to 100 projects — sufficient for the >= 5 threshold.
+	url := "https://cloudresourcemanager.googleapis.com/v3/projects?pageSize=100"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, err
+	}
+
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return 0, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("countProjects: HTTP %d", resp.StatusCode)
+	}
+
+	var result struct {
+		Projects []json.RawMessage `json:"projects"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return 0, err
+	}
+	return len(result.Projects), nil
+}

--- a/pkg/scoring/gcp_test.go
+++ b/pkg/scoring/gcp_test.go
@@ -401,6 +401,17 @@ func TestExtractGCPCredentials_DeeplyNestedJSON(t *testing.T) {
 	assert.Equal(t, "deep", key.ProjectID)
 }
 
+func TestExtractGCPCredentials_ArrayNestedJSON(t *testing.T) {
+	m := &types.Match{
+		NamedGroups: map[string][]byte{
+			"service_account_nested": []byte(`{"credentials":[{"project_id":"array-project","client_email":"sa@array-project.iam.gserviceaccount.com","private_key":"-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----\n"}]}`),
+		},
+	}
+	key, ok := extractGCPCredentials(m)
+	require.True(t, ok)
+	assert.Equal(t, "array-project", key.ProjectID)
+}
+
 // --- gcpSADisabledCondition edge cases ---
 
 func TestGCPSADisabledCondition_DoesNotFireOnNonDisabledError(t *testing.T) {
@@ -418,6 +429,15 @@ func TestGCPSADisabledCondition_ReturnsFalseOnBadCredentials(t *testing.T) {
 	fired, err := cond.Evaluate(context.Background(), m)
 	require.NoError(t, err)
 	assert.False(t, fired)
+}
+
+func TestGCPSADisabledCondition_FiresWhenDeleted(t *testing.T) {
+	cond := &gcpSADisabledCondition{
+		clientFactory: fakeGCPFactoryErr(errors.New("account has been deleted")),
+	}
+	fired, err := cond.Evaluate(context.Background(), gcpTestMatch())
+	require.NoError(t, err)
+	assert.True(t, fired)
 }
 
 // --- gcpRoleBindingCondition edge cases ---
@@ -454,6 +474,22 @@ func TestGCPRoleBindingCondition_MultipleMatchRoles(t *testing.T) {
 		matchRoles: []string{"roles/owner", "roles/resourcemanager.organizationAdmin"},
 		clientFactory: fakeGCPFactory(&mockGCPAPI{
 			projectBindings: []gcpIAMBinding{
+				{Role: "roles/resourcemanager.organizationAdmin", Members: []string{"serviceAccount:sa@test-project.iam.gserviceaccount.com"}},
+			},
+		}),
+	}
+	fired, err := cond.Evaluate(context.Background(), gcpTestMatch())
+	require.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestGCPRoleBindingCondition_CheckOrgBindingsFiresWhenOrgAdminAtOrgLevel(t *testing.T) {
+	cond := &gcpRoleBindingCondition{
+		matchRoles:       []string{"roles/owner", "roles/resourcemanager.organizationAdmin"},
+		checkOrgBindings: true,
+		clientFactory: fakeGCPFactory(&mockGCPAPI{
+			projectBindings: []gcpIAMBinding{},
+			orgBindings: []gcpIAMBinding{
 				{Role: "roles/resourcemanager.organizationAdmin", Members: []string{"serviceAccount:sa@test-project.iam.gserviceaccount.com"}},
 			},
 		}),

--- a/pkg/scoring/gcp_test.go
+++ b/pkg/scoring/gcp_test.go
@@ -1,0 +1,865 @@
+package scoring
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockGCPAPI struct {
+	projectBindings []gcpIAMBinding
+	orgBindings     []gcpIAMBinding
+	projectCount    int
+	projectErr      error
+	orgErr          error
+	countErr        error
+}
+
+func (m *mockGCPAPI) GetProjectIAMPolicy(_ context.Context, _ string) ([]gcpIAMBinding, error) {
+	return m.projectBindings, m.projectErr
+}
+
+func (m *mockGCPAPI) GetOrgIAMPolicy(_ context.Context, _ string) ([]gcpIAMBinding, error) {
+	return m.orgBindings, m.orgErr
+}
+
+func (m *mockGCPAPI) CountAccessibleProjects(_ context.Context) (int, error) {
+	return m.projectCount, m.countErr
+}
+
+func fakeGCPFactory(api gcpAPI) gcpClientFactory {
+	return func(_ context.Context, _ *gcpServiceAccountKey) (gcpAPI, error) {
+		return api, nil
+	}
+}
+
+func fakeGCPFactoryErr(err error) gcpClientFactory {
+	return func(_ context.Context, _ *gcpServiceAccountKey) (gcpAPI, error) {
+		return nil, err
+	}
+}
+
+func gcpTestMatch() *types.Match {
+	return &types.Match{
+		NamedGroups: map[string][]byte{
+			"service_account": []byte(`{"project_id":"test-project","client_email":"sa@test-project.iam.gserviceaccount.com","private_key":"-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----\n"}`),
+		},
+	}
+}
+
+func TestExtractGCPCredentials_SimpleJSON(t *testing.T) {
+	m := gcpTestMatch()
+	key, ok := extractGCPCredentials(m)
+	require.True(t, ok)
+	assert.Equal(t, "test-project", key.ProjectID)
+	assert.Equal(t, "sa@test-project.iam.gserviceaccount.com", key.ClientEmail)
+	assert.NotEmpty(t, key.PrivateKey)
+}
+
+func TestExtractGCPCredentials_NestedJSON(t *testing.T) {
+	m := &types.Match{
+		NamedGroups: map[string][]byte{
+			"service_account_nested": []byte(`{"wrapper":{"project_id":"nested-project","client_email":"sa@nested-project.iam.gserviceaccount.com","private_key":"-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----\n"}}`),
+		},
+	}
+	key, ok := extractGCPCredentials(m)
+	require.True(t, ok)
+	assert.Equal(t, "nested-project", key.ProjectID)
+	assert.Equal(t, "sa@nested-project.iam.gserviceaccount.com", key.ClientEmail)
+}
+
+func TestExtractGCPCredentials_NilMatch(t *testing.T) {
+	_, ok := extractGCPCredentials(nil)
+	assert.False(t, ok)
+}
+
+func TestExtractGCPCredentials_MissingPrivateKey(t *testing.T) {
+	m := &types.Match{
+		NamedGroups: map[string][]byte{
+			"service_account": []byte(`{"project_id":"test-project","client_email":"sa@test-project.iam.gserviceaccount.com"}`),
+		},
+	}
+	_, ok := extractGCPCredentials(m)
+	assert.False(t, ok)
+}
+
+func TestGCPSADisabledCondition_IsDynamic(t *testing.T) {
+	mod := Modifier{Condition: &gcpSADisabledCondition{}}
+	assert.True(t, mod.IsDynamic())
+}
+
+func TestGCPSADisabledCondition_FiresWhenDisabled(t *testing.T) {
+	cond := &gcpSADisabledCondition{
+		clientFactory: fakeGCPFactoryErr(errors.New("account is disabled")),
+	}
+	fired, err := cond.Evaluate(context.Background(), gcpTestMatch())
+	require.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestGCPSADisabledCondition_DoesNotFireWhenActive(t *testing.T) {
+	cond := &gcpSADisabledCondition{
+		clientFactory: fakeGCPFactory(&mockGCPAPI{}),
+	}
+	fired, err := cond.Evaluate(context.Background(), gcpTestMatch())
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestGCPRoleBindingCondition_IsDynamic(t *testing.T) {
+	mod := Modifier{Condition: &gcpRoleBindingCondition{matchRoles: []string{"roles/owner"}}}
+	assert.True(t, mod.IsDynamic())
+}
+
+func TestGCPRoleBindingCondition_FiresWhenOwnerRoleAttached(t *testing.T) {
+	cond := &gcpRoleBindingCondition{
+		matchRoles: []string{"roles/owner"},
+		clientFactory: fakeGCPFactory(&mockGCPAPI{
+			projectBindings: []gcpIAMBinding{
+				{Role: "roles/owner", Members: []string{"serviceAccount:sa@test-project.iam.gserviceaccount.com"}},
+			},
+		}),
+	}
+	fired, err := cond.Evaluate(context.Background(), gcpTestMatch())
+	require.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestGCPRoleBindingCondition_DoesNotFireWhenNoMatchingRoles(t *testing.T) {
+	cond := &gcpRoleBindingCondition{
+		matchRoles: []string{"roles/owner"},
+		clientFactory: fakeGCPFactory(&mockGCPAPI{
+			projectBindings: []gcpIAMBinding{
+				{Role: "roles/viewer", Members: []string{"serviceAccount:sa@test-project.iam.gserviceaccount.com"}},
+			},
+		}),
+	}
+	fired, err := cond.Evaluate(context.Background(), gcpTestMatch())
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestGCPRoleBindingCondition_ExclusiveFiresWhenOnlyMatchingRoles(t *testing.T) {
+	cond := &gcpRoleBindingCondition{
+		matchRoles:      []string{"roles/viewer", "roles/browser"},
+		onlyIfExclusive: true,
+		clientFactory: fakeGCPFactory(&mockGCPAPI{
+			projectBindings: []gcpIAMBinding{
+				{Role: "roles/viewer", Members: []string{"serviceAccount:sa@test-project.iam.gserviceaccount.com"}},
+			},
+		}),
+	}
+	fired, err := cond.Evaluate(context.Background(), gcpTestMatch())
+	require.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestGCPRoleBindingCondition_ExclusiveDoesNotFireWhenMixed(t *testing.T) {
+	cond := &gcpRoleBindingCondition{
+		matchRoles:      []string{"roles/viewer", "roles/browser"},
+		onlyIfExclusive: true,
+		clientFactory: fakeGCPFactory(&mockGCPAPI{
+			projectBindings: []gcpIAMBinding{
+				{Role: "roles/viewer", Members: []string{"serviceAccount:sa@test-project.iam.gserviceaccount.com"}},
+				{Role: "roles/editor", Members: []string{"serviceAccount:sa@test-project.iam.gserviceaccount.com"}},
+			},
+		}),
+	}
+	fired, err := cond.Evaluate(context.Background(), gcpTestMatch())
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestGCPOrgLevelBindingCondition_FiresWhenSABoundAtOrg(t *testing.T) {
+	cond := &gcpOrgLevelBindingCondition{
+		clientFactory: fakeGCPFactory(&mockGCPAPI{
+			orgBindings: []gcpIAMBinding{
+				{Role: "roles/viewer", Members: []string{"serviceAccount:sa@test-project.iam.gserviceaccount.com"}},
+			},
+		}),
+	}
+	fired, err := cond.Evaluate(context.Background(), gcpTestMatch())
+	require.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestGCPOrgLevelBindingCondition_DoesNotFireWhenNoOrgBindings(t *testing.T) {
+	cond := &gcpOrgLevelBindingCondition{
+		clientFactory: fakeGCPFactory(&mockGCPAPI{
+			orgBindings: []gcpIAMBinding{},
+		}),
+	}
+	fired, err := cond.Evaluate(context.Background(), gcpTestMatch())
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestGCPMultiProjectCondition_FiresWhenFiveOrMoreProjects(t *testing.T) {
+	cond := &gcpMultiProjectCondition{
+		minProjects:   5,
+		clientFactory: fakeGCPFactory(&mockGCPAPI{projectCount: 5}),
+	}
+	fired, err := cond.Evaluate(context.Background(), gcpTestMatch())
+	require.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestGCPMultiProjectCondition_DoesNotFireWhenFewer(t *testing.T) {
+	cond := &gcpMultiProjectCondition{
+		minProjects:   5,
+		clientFactory: fakeGCPFactory(&mockGCPAPI{projectCount: 3}),
+	}
+	fired, err := cond.Evaluate(context.Background(), gcpTestMatch())
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestGCPSingleNonProdCondition_FiresForDevProject(t *testing.T) {
+	m := &types.Match{
+		NamedGroups: map[string][]byte{
+			"service_account": []byte(`{"project_id":"my-dev-project","client_email":"sa@my-dev-project.iam.gserviceaccount.com","private_key":"-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----\n"}`),
+		},
+	}
+	cond := &gcpSingleNonProdCondition{
+		clientFactory: fakeGCPFactory(&mockGCPAPI{projectCount: 1}),
+	}
+	fired, err := cond.Evaluate(context.Background(), m)
+	require.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestGCPSingleNonProdCondition_DoesNotFireForMultipleProjects(t *testing.T) {
+	cond := &gcpSingleNonProdCondition{
+		clientFactory: fakeGCPFactory(&mockGCPAPI{projectCount: 3}),
+	}
+	fired, err := cond.Evaluate(context.Background(), gcpTestMatch())
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestGCPSingleNonProdCondition_DoesNotFireForProdProject(t *testing.T) {
+	m := &types.Match{
+		NamedGroups: map[string][]byte{
+			"service_account": []byte(`{"project_id":"production-app","client_email":"sa@production-app.iam.gserviceaccount.com","private_key":"-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----\n"}`),
+		},
+	}
+	cond := &gcpSingleNonProdCondition{
+		clientFactory: fakeGCPFactory(&mockGCPAPI{projectCount: 1}),
+	}
+	fired, err := cond.Evaluate(context.Background(), m)
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestGCPRoleBindingCondition_ReturnsFalseOnAPIError(t *testing.T) {
+	cond := &gcpRoleBindingCondition{
+		matchRoles:    []string{"roles/owner"},
+		clientFactory: fakeGCPFactory(&mockGCPAPI{projectErr: fmt.Errorf("permission denied")}),
+	}
+	fired, err := cond.Evaluate(context.Background(), gcpTestMatch())
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestGCPOrgLevelBindingCondition_ReturnsFalseOnAPIError(t *testing.T) {
+	cond := &gcpOrgLevelBindingCondition{
+		clientFactory: fakeGCPFactory(&mockGCPAPI{orgErr: fmt.Errorf("permission denied")}),
+	}
+	fired, err := cond.Evaluate(context.Background(), gcpTestMatch())
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestGCPMultiProjectCondition_ReturnsFalseOnAPIError(t *testing.T) {
+	cond := &gcpMultiProjectCondition{
+		minProjects:   5,
+		clientFactory: fakeGCPFactory(&mockGCPAPI{countErr: fmt.Errorf("permission denied")}),
+	}
+	fired, err := cond.Evaluate(context.Background(), gcpTestMatch())
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+// injectGCPFactory sets the clientFactory field on the underlying condition of a
+// Modifier, supporting all five GCP condition types used in engine scenario tests.
+func injectGCPFactory(m *Modifier, factory gcpClientFactory) {
+	switch c := m.Condition.(type) {
+	case *gcpSADisabledCondition:
+		c.clientFactory = factory
+	case *gcpRoleBindingCondition:
+		c.clientFactory = factory
+	case *gcpOrgLevelBindingCondition:
+		c.clientFactory = factory
+	case *gcpMultiProjectCondition:
+		c.clientFactory = factory
+	case *gcpSingleNonProdCondition:
+		c.clientFactory = factory
+	}
+}
+
+// --- Scorer structure tests ---
+
+func TestGCPGoScorer_Structure(t *testing.T) {
+	s := GCPGoScorer()
+	assert.Equal(t, "gcp-sa-iam-scope", s.Name)
+	assert.Equal(t, []string{"kingfisher.gcp.1"}, s.RuleIDs)
+	require.Len(t, s.Modifiers, 10)
+
+	names := make([]string, len(s.Modifiers))
+	for i, mod := range s.Modifiers {
+		names[i] = mod.Name
+	}
+	assert.Contains(t, names, "sa-disabled")
+	assert.Contains(t, names, "owner-or-org-admin")
+	assert.Contains(t, names, "priv-escalation-path")
+	assert.Contains(t, names, "secret-accessor")
+	assert.Contains(t, names, "storage-db-admin")
+	assert.Contains(t, names, "org-level-binding")
+	assert.Contains(t, names, "multi-project-access")
+	assert.Contains(t, names, "viewer-only")
+	assert.Contains(t, names, "observability-only")
+	assert.Contains(t, names, "single-non-prod-project")
+}
+
+func TestGCPGoScorer_AllModifiersAreDynamic(t *testing.T) {
+	s := GCPGoScorer()
+	for _, mod := range s.Modifiers {
+		assert.True(t, mod.IsDynamic(), "modifier %s must be dynamic", mod.Name)
+	}
+}
+
+func TestGCPGoScorer_MissingCredentials(t *testing.T) {
+	s := GCPGoScorer()
+	m := &types.Match{
+		NamedGroups: map[string][]byte{},
+	}
+	for _, mod := range s.Modifiers {
+		fired, err := mod.Condition.Evaluate(context.Background(), m)
+		assert.NoError(t, err, "modifier %s should not error", mod.Name)
+		assert.False(t, fired, "modifier %s should not fire without credentials", mod.Name)
+	}
+}
+
+// --- extractGCPCredentials edge cases ---
+
+func TestExtractGCPCredentials_MissingClientEmail(t *testing.T) {
+	m := &types.Match{
+		NamedGroups: map[string][]byte{
+			"service_account": []byte(`{"project_id":"p","private_key":"-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----\n"}`),
+		},
+	}
+	_, ok := extractGCPCredentials(m)
+	assert.False(t, ok)
+}
+
+func TestExtractGCPCredentials_InvalidJSON(t *testing.T) {
+	m := &types.Match{
+		NamedGroups: map[string][]byte{
+			"service_account": []byte(`{not-valid-json}`),
+		},
+	}
+	_, ok := extractGCPCredentials(m)
+	assert.False(t, ok)
+}
+
+func TestExtractGCPCredentials_EmptyNamedGroups(t *testing.T) {
+	m := &types.Match{
+		NamedGroups: map[string][]byte{
+			"other_group": []byte(`{"some":"data"}`),
+		},
+	}
+	_, ok := extractGCPCredentials(m)
+	assert.False(t, ok)
+}
+
+func TestExtractGCPCredentials_PrefersServiceAccountOverNested(t *testing.T) {
+	m := &types.Match{
+		NamedGroups: map[string][]byte{
+			"service_account":        []byte(`{"project_id":"primary","client_email":"sa@primary.iam.gserviceaccount.com","private_key":"-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----\n"}`),
+			"service_account_nested": []byte(`{"wrapper":{"project_id":"nested","client_email":"sa@nested.iam.gserviceaccount.com","private_key":"-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----\n"}}`),
+		},
+	}
+	key, ok := extractGCPCredentials(m)
+	require.True(t, ok)
+	assert.Equal(t, "primary", key.ProjectID)
+}
+
+func TestExtractGCPCredentials_DeeplyNestedJSON(t *testing.T) {
+	m := &types.Match{
+		NamedGroups: map[string][]byte{
+			"service_account_nested": []byte(`{"level1":{"level2":{"project_id":"deep","client_email":"sa@deep.iam.gserviceaccount.com","private_key":"-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----\n"}}}`),
+		},
+	}
+	key, ok := extractGCPCredentials(m)
+	require.True(t, ok)
+	assert.Equal(t, "deep", key.ProjectID)
+}
+
+// --- gcpSADisabledCondition edge cases ---
+
+func TestGCPSADisabledCondition_DoesNotFireOnNonDisabledError(t *testing.T) {
+	cond := &gcpSADisabledCondition{
+		clientFactory: fakeGCPFactoryErr(errors.New("connection refused")),
+	}
+	fired, err := cond.Evaluate(context.Background(), gcpTestMatch())
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestGCPSADisabledCondition_ReturnsFalseOnBadCredentials(t *testing.T) {
+	cond := &gcpSADisabledCondition{}
+	m := &types.Match{NamedGroups: map[string][]byte{}}
+	fired, err := cond.Evaluate(context.Background(), m)
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+// --- gcpRoleBindingCondition edge cases ---
+
+func TestGCPRoleBindingCondition_DoesNotFireWhenSANotInMembers(t *testing.T) {
+	cond := &gcpRoleBindingCondition{
+		matchRoles: []string{"roles/owner"},
+		clientFactory: fakeGCPFactory(&mockGCPAPI{
+			projectBindings: []gcpIAMBinding{
+				{Role: "roles/owner", Members: []string{"serviceAccount:other-sa@other-project.iam.gserviceaccount.com"}},
+			},
+		}),
+	}
+	fired, err := cond.Evaluate(context.Background(), gcpTestMatch())
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestGCPRoleBindingCondition_ExclusiveReturnsFalseWhenNoRoles(t *testing.T) {
+	cond := &gcpRoleBindingCondition{
+		matchRoles:      []string{"roles/viewer"},
+		onlyIfExclusive: true,
+		clientFactory: fakeGCPFactory(&mockGCPAPI{
+			projectBindings: []gcpIAMBinding{},
+		}),
+	}
+	fired, err := cond.Evaluate(context.Background(), gcpTestMatch())
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestGCPRoleBindingCondition_MultipleMatchRoles(t *testing.T) {
+	cond := &gcpRoleBindingCondition{
+		matchRoles: []string{"roles/owner", "roles/resourcemanager.organizationAdmin"},
+		clientFactory: fakeGCPFactory(&mockGCPAPI{
+			projectBindings: []gcpIAMBinding{
+				{Role: "roles/resourcemanager.organizationAdmin", Members: []string{"serviceAccount:sa@test-project.iam.gserviceaccount.com"}},
+			},
+		}),
+	}
+	fired, err := cond.Evaluate(context.Background(), gcpTestMatch())
+	require.NoError(t, err)
+	assert.True(t, fired)
+}
+
+// --- gcpOrgLevelBindingCondition edge cases ---
+
+func TestGCPOrgLevelBindingCondition_DoesNotFireWhenSANotInOrgBindingMembers(t *testing.T) {
+	cond := &gcpOrgLevelBindingCondition{
+		clientFactory: fakeGCPFactory(&mockGCPAPI{
+			orgBindings: []gcpIAMBinding{
+				{Role: "roles/viewer", Members: []string{"serviceAccount:other@other.iam.gserviceaccount.com"}},
+			},
+		}),
+	}
+	fired, err := cond.Evaluate(context.Background(), gcpTestMatch())
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+// --- gcpSingleNonProdCondition edge cases ---
+
+func TestGCPSingleNonProdCondition_AllNonProdPatterns(t *testing.T) {
+	patterns := []string{"dev", "test", "staging", "sandbox", "nonprod", "non-prod", "demo", "tmp", "temp"}
+	for _, pat := range patterns {
+		t.Run(pat, func(t *testing.T) {
+			m := &types.Match{
+				NamedGroups: map[string][]byte{
+					"service_account": []byte(fmt.Sprintf(`{"project_id":"my-%s-project","client_email":"sa@my-%s-project.iam.gserviceaccount.com","private_key":"-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----\n"}`, pat, pat)),
+				},
+			}
+			cond := &gcpSingleNonProdCondition{
+				clientFactory: fakeGCPFactory(&mockGCPAPI{projectCount: 1}),
+			}
+			fired, err := cond.Evaluate(context.Background(), m)
+			require.NoError(t, err)
+			assert.True(t, fired, "pattern %q should fire", pat)
+		})
+	}
+}
+
+func TestGCPSingleNonProdCondition_CaseInsensitive(t *testing.T) {
+	m := &types.Match{
+		NamedGroups: map[string][]byte{
+			"service_account": []byte(`{"project_id":"MY-STAGING-PROJECT","client_email":"sa@MY-STAGING-PROJECT.iam.gserviceaccount.com","private_key":"-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----\n"}`),
+		},
+	}
+	cond := &gcpSingleNonProdCondition{
+		clientFactory: fakeGCPFactory(&mockGCPAPI{projectCount: 1}),
+	}
+	fired, err := cond.Evaluate(context.Background(), m)
+	require.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestGCPSingleNonProdCondition_ReturnsFalseOnAPIError(t *testing.T) {
+	cond := &gcpSingleNonProdCondition{
+		clientFactory: fakeGCPFactory(&mockGCPAPI{countErr: fmt.Errorf("permission denied")}),
+	}
+	fired, err := cond.Evaluate(context.Background(), gcpTestMatch())
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestGCPSingleNonProdCondition_ReturnsFalseOnFactoryError(t *testing.T) {
+	cond := &gcpSingleNonProdCondition{
+		clientFactory: fakeGCPFactoryErr(fmt.Errorf("auth failed")),
+	}
+	fired, err := cond.Evaluate(context.Background(), gcpTestMatch())
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+// --- gcpMultiProjectCondition boundary ---
+
+func TestGCPMultiProjectCondition_ExactBoundary(t *testing.T) {
+	for _, tc := range []struct {
+		count int
+		want  bool
+	}{
+		{4, false},
+		{5, true},
+		{6, true},
+	} {
+		t.Run(fmt.Sprintf("count=%d", tc.count), func(t *testing.T) {
+			cond := &gcpMultiProjectCondition{
+				minProjects:   5,
+				clientFactory: fakeGCPFactory(&mockGCPAPI{projectCount: tc.count}),
+			}
+			fired, err := cond.Evaluate(context.Background(), gcpTestMatch())
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, fired)
+		})
+	}
+}
+
+// --- Engine scenario tests ---
+
+func TestGCPScorer_OwnerSetsScoreTo99(t *testing.T) {
+	s := GCPGoScorer()
+	// Use projectCount > 1 to prevent single-non-prod-project from firing
+	// (that modifier requires exactly 1 accessible project).
+	mockAPI := &mockGCPAPI{
+		projectBindings: []gcpIAMBinding{
+			{Role: "roles/owner", Members: []string{"serviceAccount:sa@prod-project.iam.gserviceaccount.com"}},
+		},
+		projectCount: 3,
+	}
+	factory := fakeGCPFactory(mockAPI)
+	for i := range s.Modifiers {
+		injectGCPFactory(&s.Modifiers[i], factory)
+	}
+
+	engine := NewEngine([]*Scorer{s}, EngineConfig{ScopeEnabled: true, Timeout: 5 * time.Second})
+	rule := &types.Rule{ID: "kingfisher.gcp.1", BaseScore: 92}
+	// Use a production-named project so non-prod patterns don't match.
+	match := &types.Match{
+		RuleID: "kingfisher.gcp.1",
+		NamedGroups: map[string][]byte{
+			"service_account": []byte(`{"project_id":"prod-project","client_email":"sa@prod-project.iam.gserviceaccount.com","private_key":"-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----\n"}`),
+		},
+	}
+
+	score := engine.Score(context.Background(), &types.Finding{RuleID: rule.ID}, []*types.Match{match}, rule)
+
+	assert.Equal(t, 99, score.Final)
+	require.NotEmpty(t, score.Applied)
+	assert.Equal(t, "owner-or-org-admin", score.Applied[0].Name)
+}
+
+func TestGCPScorer_DisabledSAOverridesEverything(t *testing.T) {
+	s := GCPGoScorer()
+	factory := fakeGCPFactoryErr(errors.New("account is disabled"))
+	for i := range s.Modifiers {
+		injectGCPFactory(&s.Modifiers[i], factory)
+	}
+
+	engine := NewEngine([]*Scorer{s}, EngineConfig{ScopeEnabled: true, Timeout: 5 * time.Second})
+	rule := &types.Rule{ID: "kingfisher.gcp.1", BaseScore: 92}
+	match := gcpTestMatch()
+	match.RuleID = "kingfisher.gcp.1"
+
+	score := engine.Score(context.Background(), &types.Finding{RuleID: rule.ID}, []*types.Match{match}, rule)
+
+	assert.Equal(t, 5, score.Final)
+	require.Len(t, score.Applied, 1)
+	assert.Equal(t, "sa-disabled", score.Applied[0].Name)
+}
+
+func TestGCPScorer_SeverityScenarios(t *testing.T) {
+	makeMatch := func(projectID, email string) *types.Match {
+		return &types.Match{
+			RuleID: "kingfisher.gcp.1",
+			NamedGroups: map[string][]byte{
+				"service_account": []byte(fmt.Sprintf(
+					`{"project_id":"%s","client_email":"%s","private_key":"-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----\n"}`,
+					projectID, email)),
+			},
+		}
+	}
+
+	prodMatch := makeMatch("prod-project", "sa@prod-project.iam.gserviceaccount.com")
+	devMatch := makeMatch("my-dev-project", "sa@my-dev-project.iam.gserviceaccount.com")
+
+	const prodEmail = "sa@prod-project.iam.gserviceaccount.com"
+	const devEmail = "sa@my-dev-project.iam.gserviceaccount.com"
+
+	tests := []struct {
+		name          string
+		match         *types.Match
+		mock          *mockGCPAPI
+		expectedScore int
+		appliedNames  []string
+	}{
+		// --- Score UP scenarios ---
+		{
+			name:  "priv-escalation-iam-admin",
+			match: prodMatch,
+			mock: &mockGCPAPI{
+				projectBindings: []gcpIAMBinding{
+					{Role: "roles/iam.serviceAccountAdmin", Members: []string{"serviceAccount:" + prodEmail}},
+				},
+				projectCount: 3,
+			},
+			expectedScore: 100, // 92 + 20 = 112, clamped
+			appliedNames:  []string{"priv-escalation-path"},
+		},
+		{
+			name:  "priv-escalation-security-admin",
+			match: prodMatch,
+			mock: &mockGCPAPI{
+				projectBindings: []gcpIAMBinding{
+					{Role: "roles/iam.securityAdmin", Members: []string{"serviceAccount:" + prodEmail}},
+				},
+				projectCount: 3,
+			},
+			expectedScore: 100, // 92 + 20 = 112, clamped
+			appliedNames:  []string{"priv-escalation-path"},
+		},
+		{
+			name:  "secret-accessor",
+			match: prodMatch,
+			mock: &mockGCPAPI{
+				projectBindings: []gcpIAMBinding{
+					{Role: "roles/secretmanager.secretAccessor", Members: []string{"serviceAccount:" + prodEmail}},
+				},
+				projectCount: 3,
+			},
+			expectedScore: 100, // 92 + 15 = 107, clamped
+			appliedNames:  []string{"secret-accessor"},
+		},
+		{
+			name:  "storage-admin",
+			match: prodMatch,
+			mock: &mockGCPAPI{
+				projectBindings: []gcpIAMBinding{
+					{Role: "roles/storage.admin", Members: []string{"serviceAccount:" + prodEmail}},
+				},
+				projectCount: 3,
+			},
+			expectedScore: 100, // 92 + 15 = 107, clamped
+			appliedNames:  []string{"storage-db-admin"},
+		},
+		{
+			name:  "cloudsql-admin",
+			match: prodMatch,
+			mock: &mockGCPAPI{
+				projectBindings: []gcpIAMBinding{
+					{Role: "roles/cloudsql.admin", Members: []string{"serviceAccount:" + prodEmail}},
+				},
+				projectCount: 3,
+			},
+			expectedScore: 100, // 92 + 15 = 107, clamped
+			appliedNames:  []string{"storage-db-admin"},
+		},
+		{
+			name:  "org-level-binding",
+			match: prodMatch,
+			mock: &mockGCPAPI{
+				projectBindings: []gcpIAMBinding{
+					{Role: "roles/editor", Members: []string{"serviceAccount:" + prodEmail}},
+				},
+				orgBindings: []gcpIAMBinding{
+					{Role: "roles/viewer", Members: []string{"serviceAccount:" + prodEmail}},
+				},
+				projectCount: 3,
+			},
+			expectedScore: 100, // 92 + 15 = 107, clamped
+			appliedNames:  []string{"org-level-binding"},
+		},
+		{
+			name:  "multi-project-access",
+			match: prodMatch,
+			mock: &mockGCPAPI{
+				projectBindings: []gcpIAMBinding{
+					{Role: "roles/editor", Members: []string{"serviceAccount:" + prodEmail}},
+				},
+				projectCount: 5,
+			},
+			expectedScore: 100, // 92 + 10 = 102, clamped
+			appliedNames:  []string{"multi-project-access"},
+		},
+		// --- Score DOWN scenarios ---
+		{
+			name:  "viewer-only",
+			match: prodMatch,
+			mock: &mockGCPAPI{
+				projectBindings: []gcpIAMBinding{
+					{Role: "roles/viewer", Members: []string{"serviceAccount:" + prodEmail}},
+				},
+				projectCount: 3,
+			},
+			expectedScore: 72, // 92 - 20
+			appliedNames:  []string{"viewer-only"},
+		},
+		{
+			name:  "browser-only",
+			match: prodMatch,
+			mock: &mockGCPAPI{
+				projectBindings: []gcpIAMBinding{
+					{Role: "roles/browser", Members: []string{"serviceAccount:" + prodEmail}},
+				},
+				projectCount: 3,
+			},
+			expectedScore: 72, // 92 - 20
+			appliedNames:  []string{"viewer-only"},
+		},
+		{
+			name:  "observability-only",
+			match: prodMatch,
+			mock: &mockGCPAPI{
+				projectBindings: []gcpIAMBinding{
+					{Role: "roles/logging.viewer", Members: []string{"serviceAccount:" + prodEmail}},
+				},
+				projectCount: 3,
+			},
+			expectedScore: 77, // 92 - 15
+			appliedNames:  []string{"observability-only"},
+		},
+		{
+			name:  "monitoring-viewer-only",
+			match: prodMatch,
+			mock: &mockGCPAPI{
+				projectBindings: []gcpIAMBinding{
+					{Role: "roles/monitoring.viewer", Members: []string{"serviceAccount:" + prodEmail}},
+				},
+				projectCount: 3,
+			},
+			expectedScore: 77, // 92 - 15
+			appliedNames:  []string{"observability-only"},
+		},
+		{
+			name:  "single-non-prod-project",
+			match: devMatch,
+			mock: &mockGCPAPI{
+				projectBindings: []gcpIAMBinding{
+					{Role: "roles/editor", Members: []string{"serviceAccount:" + devEmail}},
+				},
+				projectCount: 1,
+			},
+			expectedScore: 82, // 92 - 10
+			appliedNames:  []string{"single-non-prod-project"},
+		},
+		// --- Combination scenarios ---
+		{
+			name:  "viewer-only-single-non-prod",
+			match: devMatch,
+			mock: &mockGCPAPI{
+				projectBindings: []gcpIAMBinding{
+					{Role: "roles/viewer", Members: []string{"serviceAccount:" + devEmail}},
+				},
+				projectCount: 1,
+			},
+			expectedScore: 62, // 92 - 20 - 10
+			appliedNames:  []string{"viewer-only", "single-non-prod-project"},
+		},
+		{
+			name:  "owner-with-org-and-multi-project",
+			match: prodMatch,
+			mock: &mockGCPAPI{
+				projectBindings: []gcpIAMBinding{
+					{Role: "roles/owner", Members: []string{"serviceAccount:" + prodEmail}},
+				},
+				orgBindings: []gcpIAMBinding{
+					{Role: "roles/viewer", Members: []string{"serviceAccount:" + prodEmail}},
+				},
+				projectCount: 7,
+			},
+			expectedScore: 100, // set_score=99 + 15 + 10 = 124, clamped
+			appliedNames:  []string{"owner-or-org-admin", "org-level-binding", "multi-project-access"},
+		},
+		{
+			name:  "priv-escalation-with-secret-access",
+			match: prodMatch,
+			mock: &mockGCPAPI{
+				projectBindings: []gcpIAMBinding{
+					{Role: "roles/iam.serviceAccountAdmin", Members: []string{"serviceAccount:" + prodEmail}},
+					{Role: "roles/secretmanager.secretAccessor", Members: []string{"serviceAccount:" + prodEmail}},
+				},
+				projectCount: 3,
+			},
+			expectedScore: 100, // 92 + 20 + 15 = 127, clamped
+			appliedNames:  []string{"priv-escalation-path", "secret-accessor"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := GCPGoScorer()
+			factory := fakeGCPFactory(tc.mock)
+			for i := range s.Modifiers {
+				injectGCPFactory(&s.Modifiers[i], factory)
+			}
+
+			engine := NewEngine([]*Scorer{s}, EngineConfig{ScopeEnabled: true, Timeout: 5 * time.Second})
+			rule := &types.Rule{ID: "kingfisher.gcp.1", BaseScore: 92}
+
+			score := engine.Score(context.Background(), &types.Finding{RuleID: rule.ID}, []*types.Match{tc.match}, rule)
+
+			assert.Equal(t, tc.expectedScore, score.Final, "unexpected final score")
+
+			appliedNames := make([]string, len(score.Applied))
+			for i, a := range score.Applied {
+				appliedNames[i] = a.Name
+			}
+			for _, expected := range tc.appliedNames {
+				assert.Contains(t, appliedNames, expected, "expected modifier %s to be applied", expected)
+			}
+		})
+	}
+}
+
+func TestGCPScorer_ScopeDisabled_NoModifiersFire(t *testing.T) {
+	s := GCPGoScorer()
+
+	engine := NewEngine([]*Scorer{s}, EngineConfig{ScopeEnabled: false, Timeout: 5 * time.Second})
+	rule := &types.Rule{ID: "kingfisher.gcp.1", BaseScore: 92}
+	match := gcpTestMatch()
+	match.RuleID = "kingfisher.gcp.1"
+
+	score := engine.Score(context.Background(), &types.Finding{RuleID: rule.ID}, []*types.Match{match}, rule)
+
+	assert.Equal(t, 92, score.Final, "scope disabled: all dynamic modifiers must be skipped")
+	assert.Empty(t, score.Applied)
+}

--- a/pkg/scoring/go_scorers.go
+++ b/pkg/scoring/go_scorers.go
@@ -13,6 +13,7 @@ func BuiltinGoScorers() []*Scorer {
 		MongoDBGoScorer(),
 		MongoDBAtlasGoScorer(),
 		GitLabGoScorer(),
+		GCPGoScorer(),
 	}
 }
 

--- a/pkg/scoring/go_scorers_test.go
+++ b/pkg/scoring/go_scorers_test.go
@@ -73,3 +73,16 @@ func TestBuiltinGoScorers_IncludesGitLab(t *testing.T) {
 	}
 	assert.True(t, found, "BuiltinGoScorers must include gitlab-pat-scope scorer")
 }
+
+func TestBuiltinGoScorers_IncludesGCP(t *testing.T) {
+	scorers := BuiltinGoScorers()
+	var found bool
+	for _, s := range scorers {
+		if s.Name == "gcp-sa-iam-scope" {
+			found = true
+			assert.Contains(t, s.RuleIDs, "kingfisher.gcp.1")
+			assert.Equal(t, 10, len(s.Modifiers), "GCP scorer must have 10 modifiers")
+		}
+	}
+	assert.True(t, found, "BuiltinGoScorers must include gcp-sa-iam-scope scorer")
+}


### PR DESCRIPTION
## Summary

- Add live IAM enumeration scorer for GCP service account keys (`kingfisher.gcp.1`), gated by `--score-scope`
- Authenticates as the SA via `golang.org/x/oauth2/google`, queries project and org-level IAM policies plus accessible project count to adjust severity based on actual privilege
- 10 modifiers covering all ticket scenarios: owner/org-admin (set 99), priv-escalation (+20), secret-accessor (+15), storage/db-admin (+15), org-level binding (+15), multi-project (+10), viewer-only (-20), observability-only (-15), single-non-prod (-10), SA disabled (set 5)

## Test plan

- [x] 15 engine-level scoring scenario tests validating exact final scores through `Engine.Score()` for every severity scenario in the ticket
- [x] 11 condition unit tests for each condition type
- [x] 7 extraction tests including nested JSON and edge cases
- [x] 3 API error handling tests
- [x] 5 structural/sweep tests
- [x] Registration test confirming `GCPGoScorer()` in `BuiltinGoScorers()`
- [x] Full `go test ./pkg/scoring/` suite green (55+ GCP tests, no regressions)