### PR TITLE
feat(caido): add Caido plugin for Titus secret scanning

### DIFF
--- a/caido/README.md
+++ b/caido/README.md
@@ -1,0 +1,124 @@
+# Titus Secret Scanner - Caido Plugin
+
+A [Caido](https://caido.io/) plugin that scans HTTP traffic for secrets and credentials using the [Titus](https://github.com/praetorian-inc/titus) detection engine (444+ rules).
+
+## Features
+
+- **Passive scanning** - Automatically scans HTTP responses flowing through the Caido proxy
+- **444+ detection rules** - AWS keys, Azure tokens, GitHub PATs, JWTs, database credentials, private keys, and more
+- **Smart filtering** - Skips binary content (images, fonts, PDFs) to minimize overhead
+- **Deduplication** - Same secret across multiple URLs is reported once
+- **Severity mapping** - Findings categorized as High/Medium/Low based on rule type
+- **Request scanning** - Optionally scan request bodies and headers
+- **Scope filtering** - Limit scanning to in-scope targets only
+
+## Prerequisites
+
+The Titus CLI binary must be installed on your system. The plugin communicates with Titus via its `titus serve` NDJSON protocol (same as the Burp extension).
+
+### Install Titus
+
+```bash
+# Download the latest release
+# https://github.com/praetorian-inc/titus/releases
+
+# Or build from source
+git clone https://github.com/praetorian-inc/titus.git
+cd titus
+make build
+
+# Install to ~/.titus/
+mkdir -p ~/.titus
+cp titus ~/.titus/titus
+```
+
+The plugin searches these paths (in order):
+1. `~/.titus/titus`
+2. `~/bin/titus`
+3. `/usr/local/bin/titus`
+4. `titus` (PATH lookup)
+
+## Installation
+
+### From source
+
+```bash
+cd caido/
+pnpm install
+pnpm build
+```
+
+This produces `plugin_package.zip` which can be installed in Caido via **Settings > Plugins > Install from file**.
+
+### Development
+
+```bash
+cd caido/
+pnpm install
+pnpm dev   # Watch mode - rebuilds on changes
+```
+
+## Architecture
+
+The plugin mirrors the architecture of the existing Burp Suite extension:
+
+```
+┌─────────────────────┐     NDJSON/stdin/stdout     ┌──────────────┐
+│   Caido Backend      │◄──────────────────────────►│ titus serve  │
+│                      │                             │              │
+│  - onInterceptResp() │  {"type":"scan",            │  444+ rules  │
+│  - FastPathFilter    │   "payload":{"content":...}}│  Hyperscan   │
+│  - DedupCache        │                             │  engine      │
+│  - FindingsReporter  │  {"success":true,           │              │
+│                      │   "data":{"matches":[...]}} │              │
+└─────────┬───────────┘                             └──────────────┘
+          │
+          │ sdk.api (RPC)
+          │
+┌─────────▼───────────┐
+│   Caido Frontend     │
+│                      │
+│  - Stats dashboard   │
+│  - Findings table    │
+│  - Settings toggles  │
+└─────────────────────┘
+```
+
+### Backend (`packages/backend/`)
+
+| File | Description |
+|------|-------------|
+| `index.ts` | Plugin entry point - registers HTTP handler and API |
+| `scanner.ts` | `TitusScanner` class - spawns and communicates with `titus serve` |
+| `filter.ts` | `FastPathFilter` - skips non-scannable content types and extensions |
+| `dedup.ts` | `DedupCache` - deduplicates findings by rule + secret content |
+| `types.ts` | TypeScript types for the NDJSON protocol |
+
+### Frontend (`packages/frontend/`)
+
+| File | Description |
+|------|-------------|
+| `index.ts` | UI page with stats, findings table, and settings |
+| `style.css` | Dark theme styles matching Caido's look |
+
+## Protocol
+
+The plugin uses the same NDJSON protocol as the Burp extension, documented in `pkg/serve/`:
+
+**Scan request:**
+```json
+{"type":"scan","payload":{"content":"response body...","source":"https://example.com/api"}}
+```
+
+**Scan response:**
+```json
+{"success":true,"type":"scan","data":{"matches":[{"RuleID":"np.aws.1","RuleName":"AWS API Key",...}]}}
+```
+
+## Settings
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| Passive Scan | On | Scan responses automatically |
+| Scan Requests | Off | Also scan request bodies |
+| Scope Only | Off | Only scan in-scope targets |

--- a/caido/manifest.json
+++ b/caido/manifest.json
@@ -1,0 +1,30 @@
+{
+  "id": "titus-secret-scanner",
+  "name": "Titus Secret Scanner",
+  "version": "1.0.0",
+  "description": "Scans HTTP traffic for secrets and credentials using the Titus detection engine (444+ rules).",
+  "author": {
+    "name": "Praetorian",
+    "email": "opensource@praetorian.com",
+    "url": "https://github.com/praetorian-inc/titus"
+  },
+  "plugins": [
+    {
+      "kind": "backend",
+      "id": "titus-backend",
+      "name": "Titus Backend",
+      "entrypoint": "packages/backend/dist/index.js",
+      "runtime": "javascript"
+    },
+    {
+      "kind": "frontend",
+      "id": "titus-frontend",
+      "name": "Titus Frontend",
+      "entrypoint": "packages/frontend/dist/index.js",
+      "style": "packages/frontend/dist/style.css",
+      "backend": {
+        "id": "titus-backend"
+      }
+    }
+  ]
+}

--- a/caido/package.json
+++ b/caido/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "titus-caido",
+  "version": "1.0.0",
+  "description": "Titus Secret Scanner plugin for Caido",
+  "author": "Praetorian <opensource@praetorian.com>",
+  "license": "Apache-2.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "node scripts/clean.js && pnpm -r build && node scripts/pack.js",
+    "dev": "pnpm -r dev",
+    "typecheck": "pnpm -r typecheck"
+  },
+  "devDependencies": {
+    "@caido/plugin-manifest": "^0.1.3",
+    "jszip": "^3.10.1",
+    "typescript": "^5.4.0",
+    "vite": "^5.2.0"
+  }
+}

--- a/caido/packages/backend/package.json
+++ b/caido/packages/backend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "titus-backend",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite build --watch",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@caido/sdk-backend": "^0.4.0",
+    "vite": "^5.2.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/caido/packages/backend/package.json
+++ b/caido/packages/backend/package.json
@@ -2,6 +2,8 @@
   "name": "titus-backend",
   "private": true,
   "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
   "scripts": {
     "build": "vite build",
     "dev": "vite build --watch",

--- a/caido/packages/backend/src/dedup.ts
+++ b/caido/packages/backend/src/dedup.ts
@@ -1,0 +1,129 @@
+/**
+ * Deduplication cache for secret findings.
+ *
+ * Deduplicates by rule ID + secret content (same secret at different URLs = one finding).
+ * Mirrors the Burp extension's DedupCache.java.
+ */
+
+import type { FindingRecord } from "./types.js";
+
+const MAX_CACHE_SIZE = 50_000;
+
+export class DedupCache {
+  private cache = new Map<string, FindingRecord>();
+
+  /**
+   * Record a finding. Returns true if this is a NEW finding (first occurrence).
+   */
+  recordIfNew(
+    url: string,
+    secretContent: string,
+    ruleId: string,
+    ruleName: string
+  ): boolean {
+    const key = this.computeKey(secretContent, ruleId);
+    const normalizedUrl = this.normalizeUrl(url);
+    const host = this.extractHost(url);
+
+    // Evict oldest entries if at capacity
+    if (!this.cache.has(key) && this.cache.size >= MAX_CACHE_SIZE) {
+      this.evictOldest();
+    }
+
+    const existing = this.cache.get(key);
+    if (existing) {
+      existing.urls.add(normalizedUrl);
+      existing.occurrenceCount++;
+      return false;
+    }
+
+    const record: FindingRecord = {
+      ruleId,
+      ruleName,
+      secretPreview: this.createPreview(secretContent),
+      secretContent,
+      url: normalizedUrl,
+      host,
+      urls: new Set([normalizedUrl]),
+      occurrenceCount: 1,
+      firstSeen: new Date().toISOString(),
+    };
+
+    this.cache.set(key, record);
+    return true;
+  }
+
+  /**
+   * Get all unique findings.
+   */
+  getAllFindings(): FindingRecord[] {
+    return Array.from(this.cache.values());
+  }
+
+  /**
+   * Get findings for a specific URL.
+   */
+  getFindingsForUrl(url: string): FindingRecord[] {
+    const normalized = this.normalizeUrl(url);
+    return this.getAllFindings().filter((f) => f.urls.has(normalized));
+  }
+
+  /**
+   * Get unique finding count.
+   */
+  uniqueCount(): number {
+    return this.cache.size;
+  }
+
+  /**
+   * Clear all findings.
+   */
+  clear(): void {
+    this.cache.clear();
+  }
+
+  private computeKey(secretContent: string, ruleId: string): string {
+    // Simple hash - in production you'd use SHA-256
+    let hash = 0;
+    const combined = `${ruleId}:${secretContent}`;
+    for (let i = 0; i < combined.length; i++) {
+      const chr = combined.charCodeAt(i);
+      hash = (hash << 5) - hash + chr;
+      hash |= 0;
+    }
+    return hash.toString(36);
+  }
+
+  private normalizeUrl(url: string): string {
+    if (!url) return "";
+    const queryIndex = url.indexOf("?");
+    return queryIndex > 0 ? url.substring(0, queryIndex) : url;
+  }
+
+  private extractHost(url: string): string {
+    try {
+      const u = new URL(url);
+      return u.host;
+    } catch {
+      return "unknown";
+    }
+  }
+
+  private createPreview(secret: string): string {
+    if (!secret) return "[empty]";
+    if (secret.length <= 20) return secret;
+    return secret.substring(0, 20) + "...";
+  }
+
+  private evictOldest(): void {
+    const toEvict = Math.max(1, Math.floor(MAX_CACHE_SIZE / 10));
+    const entries = Array.from(this.cache.entries()).sort(
+      (a, b) =>
+        new Date(a[1].firstSeen).getTime() -
+        new Date(b[1].firstSeen).getTime()
+    );
+    for (let i = 0; i < toEvict && i < entries.length; i++) {
+      this.cache.delete(entries[i]![0]);
+    }
+  }
+}

--- a/caido/packages/backend/src/dedup.ts
+++ b/caido/packages/backend/src/dedup.ts
@@ -32,7 +32,9 @@ export class DedupCache {
 
     const existing = this.cache.get(key);
     if (existing) {
-      existing.urls.add(normalizedUrl);
+      if (!existing.urls.includes(normalizedUrl)) {
+        existing.urls.push(normalizedUrl);
+      }
       existing.occurrenceCount++;
       return false;
     }
@@ -44,7 +46,7 @@ export class DedupCache {
       secretContent,
       url: normalizedUrl,
       host,
-      urls: new Set([normalizedUrl]),
+      urls: [normalizedUrl],
       occurrenceCount: 1,
       firstSeen: new Date().toISOString(),
     };
@@ -65,7 +67,7 @@ export class DedupCache {
    */
   getFindingsForUrl(url: string): FindingRecord[] {
     const normalized = this.normalizeUrl(url);
-    return this.getAllFindings().filter((f) => f.urls.has(normalized));
+    return this.getAllFindings().filter((f) => f.urls.includes(normalized));
   }
 
   /**
@@ -83,15 +85,7 @@ export class DedupCache {
   }
 
   private computeKey(secretContent: string, ruleId: string): string {
-    // Simple hash - in production you'd use SHA-256
-    let hash = 0;
-    const combined = `${ruleId}:${secretContent}`;
-    for (let i = 0; i < combined.length; i++) {
-      const chr = combined.charCodeAt(i);
-      hash = (hash << 5) - hash + chr;
-      hash |= 0;
-    }
-    return hash.toString(36);
+    return `${ruleId}:${secretContent}`;
   }
 
   private normalizeUrl(url: string): string {

--- a/caido/packages/backend/src/filter.ts
+++ b/caido/packages/backend/src/filter.ts
@@ -1,0 +1,64 @@
+/**
+ * Fast-path filter to skip non-scannable content.
+ *
+ * Mirrors the Burp extension's FastPathFilter.java.
+ * Eliminates ~60-70% of traffic before it reaches the scan queue.
+ */
+
+/** Content-Type prefixes that cannot contain text secrets. */
+const SKIP_CONTENT_TYPES = [
+  "image/",
+  "video/",
+  "audio/",
+  "font/",
+  "application/octet-stream",
+  "application/zip",
+  "application/gzip",
+  "application/x-gzip",
+  "application/pdf",
+  "application/x-shockwave-flash",
+];
+
+/** File extensions that cannot contain text secrets. */
+const SKIP_EXTENSIONS =
+  /\.(png|jpg|jpeg|gif|ico|svg|webp|bmp|tiff|woff|woff2|ttf|otf|eot|mp3|mp4|webm|ogg|wav|avi|mov|zip|gz|tar|rar|7z|pdf|swf)$/i;
+
+const MIN_RESPONSE_SIZE = 10;
+const DEFAULT_MAX_RESPONSE_SIZE = 10 * 1024 * 1024; // 10 MB
+
+export class FastPathFilter {
+  private maxResponseSize = DEFAULT_MAX_RESPONSE_SIZE;
+
+  setMaxResponseSize(bytes: number): void {
+    this.maxResponseSize = bytes;
+  }
+
+  /**
+   * Check if a response should be scanned based on content-type and size.
+   */
+  shouldScan(contentType: string | undefined, bodyLength: number): boolean {
+    if (bodyLength < MIN_RESPONSE_SIZE || bodyLength > this.maxResponseSize) {
+      return false;
+    }
+
+    if (contentType) {
+      const lower = contentType.toLowerCase();
+      for (const skip of SKIP_CONTENT_TYPES) {
+        if (lower.startsWith(skip)) {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Check if a URL should be scanned based on file extension.
+   */
+  shouldScanUrl(url: string): boolean {
+    if (!url) return true;
+    const path = url.split("?")[0] ?? url;
+    return !SKIP_EXTENSIONS.test(path);
+  }
+}

--- a/caido/packages/backend/src/index.ts
+++ b/caido/packages/backend/src/index.ts
@@ -45,7 +45,7 @@ let scopeOnly = false;
  */
 function decodeBase64(b64: string): string {
   try {
-    return atob(b64);
+    return Buffer.from(b64, "base64").toString("utf-8");
   } catch {
     return b64;
   }
@@ -56,7 +56,15 @@ function decodeBase64(b64: string): string {
  * Mirrors TitusProcessScanner.java's parseMatch logic.
  */
 function extractMatchContent(match: TitusMatch): string {
-  // Try Groups first (array of base64-encoded capture groups)
+  // Prefer NamedGroups (current Titus convention)
+  if (match.NamedGroups) {
+    const values = Object.values(match.NamedGroups);
+    if (values.length > 0 && values[0]) {
+      return decodeBase64(values[0]);
+    }
+  }
+
+  // Fall back to positional Groups
   if (match.Groups && match.Groups.length > 0) {
     return decodeBase64(match.Groups[0]!);
   }
@@ -250,7 +258,12 @@ export async function init(sdk: SDK<API>) {
             typeof requestBody === "string"
               ? requestBody
               : new TextDecoder().decode(requestBody as ArrayBuffer);
-          if (reqStr.length > 10) {
+          const reqContentType =
+            request.getHeader("content-type") ?? undefined;
+          if (
+            filter.shouldScan(reqContentType, reqStr.length) &&
+            reqStr.length > 10
+          ) {
             requestMatches = await scanner.scan(reqStr, `${url} [request]`);
           }
         }

--- a/caido/packages/backend/src/index.ts
+++ b/caido/packages/backend/src/index.ts
@@ -1,0 +1,314 @@
+/**
+ * Titus Secret Scanner - Caido Backend Plugin
+ *
+ * Scans HTTP response (and optionally request) content for secrets using
+ * the Titus detection engine via its `titus serve` NDJSON subprocess.
+ *
+ * Architecture mirrors the Burp Suite extension:
+ *   1. Spawns `titus serve` as a long-lived subprocess
+ *   2. Intercepts HTTP responses flowing through the Caido proxy
+ *   3. Filters out non-scannable content (images, fonts, etc.)
+ *   4. Sends scannable content to Titus via NDJSON over stdin/stdout
+ *   5. Reports findings via Caido's findings API
+ *   6. Deduplicates findings across URLs
+ */
+
+import type { SDK, DefineAPI } from "caido:plugin";
+import { TitusScanner } from "./scanner.js";
+import { FastPathFilter } from "./filter.js";
+import { DedupCache } from "./dedup.js";
+import type { TitusMatch, ScanStats, FindingRecord } from "./types.js";
+
+// --- State ---
+
+let scanner: TitusScanner | null = null;
+let filter: FastPathFilter;
+let dedupCache: DedupCache;
+let stats: ScanStats = {
+  totalScanned: 0,
+  totalFindings: 0,
+  uniqueFindings: 0,
+  isRunning: false,
+  titusVersion: "unknown",
+};
+
+// Settings
+let passiveScanEnabled = true;
+let scanRequests = false;
+let scopeOnly = false;
+
+// --- Helpers ---
+
+/**
+ * Decode a base64-encoded string, returning the UTF-8 text.
+ * Uses atob() which is available in most JS runtimes including QuickJS.
+ */
+function decodeBase64(b64: string): string {
+  try {
+    return atob(b64);
+  } catch {
+    return b64;
+  }
+}
+
+/**
+ * Extract the matched secret content from a Titus match.
+ * Mirrors TitusProcessScanner.java's parseMatch logic.
+ */
+function extractMatchContent(match: TitusMatch): string {
+  // Try Groups first (array of base64-encoded capture groups)
+  if (match.Groups && match.Groups.length > 0) {
+    return decodeBase64(match.Groups[0]!);
+  }
+
+  // Fall back to Snippet.Matching
+  if (match.Snippet?.Matching) {
+    return decodeBase64(match.Snippet.Matching);
+  }
+
+  return "[no content]";
+}
+
+/**
+ * Determine severity from rule ID category.
+ * Mirrors SeverityConfig.java's category-based severity mapping.
+ */
+function getSeverity(
+  ruleId: string
+): "info" | "low" | "medium" | "high" {
+  const lower = ruleId.toLowerCase();
+
+  // Extract category from "np.category.number" pattern
+  let category = "";
+  if (lower.startsWith("np.")) {
+    const parts = lower.split(".");
+    category = parts[1] ?? "";
+  }
+
+  // High severity: cloud, auth, database, private keys
+  const highCategories = [
+    "aws", "azure", "gcp", "cloud", "auth", "oauth", "jwt",
+    "database", "db", "postgres", "mysql", "mongodb",
+    "private", "ssh", "rsa",
+  ];
+  if (highCategories.some((c) => category === c || lower.includes(c))) {
+    return "high";
+  }
+
+  // Medium severity: third-party services
+  const mediumCategories = [
+    "slack", "github", "gitlab", "npm", "pypi",
+    "password", "secret", "api",
+  ];
+  if (mediumCategories.some((c) => category === c || lower.includes(c))) {
+    return "medium";
+  }
+
+  // Low severity: generic patterns
+  if (category === "generic" || lower.includes("generic")) {
+    return "low";
+  }
+
+  return "medium";
+}
+
+// --- API functions exposed to frontend ---
+
+async function getStats(_sdk: SDK<API>): Promise<ScanStats> {
+  return {
+    ...stats,
+    uniqueFindings: dedupCache.uniqueCount(),
+    isRunning: scanner?.isAlive() ?? false,
+    titusVersion: scanner?.getVersion() ?? "unknown",
+  };
+}
+
+function getFindings(_sdk: SDK<API>): FindingRecord[] {
+  return dedupCache.getAllFindings();
+}
+
+function clearFindings(_sdk: SDK<API>): void {
+  dedupCache.clear();
+  stats.totalFindings = 0;
+  stats.uniqueFindings = 0;
+}
+
+function setPassiveScan(_sdk: SDK<API>, enabled: boolean): void {
+  passiveScanEnabled = enabled;
+}
+
+function setScanRequests(_sdk: SDK<API>, enabled: boolean): void {
+  scanRequests = enabled;
+}
+
+function setScopeOnly(_sdk: SDK<API>, enabled: boolean): void {
+  scopeOnly = enabled;
+}
+
+function getSettings(
+  _sdk: SDK<API>
+): {
+  passiveScanEnabled: boolean;
+  scanRequests: boolean;
+  scopeOnly: boolean;
+} {
+  return { passiveScanEnabled, scanRequests, scopeOnly };
+}
+
+// --- API definition ---
+
+export type API = DefineAPI<{
+  getStats: typeof getStats;
+  getFindings: typeof getFindings;
+  clearFindings: typeof clearFindings;
+  setPassiveScan: typeof setPassiveScan;
+  setScanRequests: typeof setScanRequests;
+  setScopeOnly: typeof setScopeOnly;
+  getSettings: typeof getSettings;
+}>;
+
+// --- Init ---
+
+export async function init(sdk: SDK<API>) {
+  filter = new FastPathFilter();
+  dedupCache = new DedupCache();
+
+  // Register API handlers for frontend communication
+  sdk.api.register("getStats", getStats);
+  sdk.api.register("getFindings", getFindings);
+  sdk.api.register("clearFindings", clearFindings);
+  sdk.api.register("setPassiveScan", setPassiveScan);
+  sdk.api.register("setScanRequests", setScanRequests);
+  sdk.api.register("setScopeOnly", setScopeOnly);
+  sdk.api.register("getSettings", getSettings);
+
+  // Initialize scanner
+  scanner = new TitusScanner();
+  try {
+    await scanner.initialize();
+    stats.isRunning = true;
+    stats.titusVersion = scanner.getVersion();
+    sdk.console.log(
+      `Titus Secret Scanner initialized (v${scanner.getVersion()})`
+    );
+    sdk.console.log("  - Passive scanning: ENABLED");
+    sdk.console.log("  - 444+ detection rules loaded");
+  } catch (err) {
+    sdk.console.error(
+      `Failed to initialize Titus scanner: ${err instanceof Error ? err.message : String(err)}`
+    );
+    sdk.console.error(
+      "Install titus to ~/.titus/titus or ensure it is on PATH."
+    );
+    sdk.console.error(
+      "Download from: https://github.com/praetorian-inc/titus/releases"
+    );
+    return;
+  }
+
+  // Register passive scan handler on intercepted HTTP responses
+  sdk.events.onInterceptResponse(async (sdk, request, response) => {
+    if (!passiveScanEnabled || !scanner?.isAlive()) return;
+
+    try {
+      const url = request.getUrl();
+      const host = request.getHost();
+
+      // Scope filter: check if the request host is in scope
+      if (scopeOnly) {
+        const inScope = sdk.requests.inScope(url);
+        if (!inScope) return;
+      }
+
+      // Get response body as string
+      const responseBody = response.getBody();
+      if (!responseBody) return;
+
+      const bodyStr =
+        typeof responseBody === "string"
+          ? responseBody
+          : new TextDecoder().decode(responseBody as ArrayBuffer);
+
+      // Content-type filter
+      const contentType = response.getHeader("content-type") ?? undefined;
+      if (!filter.shouldScan(contentType, bodyStr.length)) return;
+
+      // URL extension filter
+      if (!filter.shouldScanUrl(url)) return;
+
+      stats.totalScanned++;
+
+      // Scan response body
+      const matches = await scanner.scan(bodyStr, url);
+
+      // Optionally scan request body
+      let requestMatches: TitusMatch[] = [];
+      if (scanRequests) {
+        const requestBody = request.getBody();
+        if (requestBody) {
+          const reqStr =
+            typeof requestBody === "string"
+              ? requestBody
+              : new TextDecoder().decode(requestBody as ArrayBuffer);
+          if (reqStr.length > 10) {
+            requestMatches = await scanner.scan(reqStr, `${url} [request]`);
+          }
+        }
+      }
+
+      const allMatches = [...matches, ...requestMatches];
+      if (allMatches.length === 0) return;
+
+      // Process matches
+      for (const match of allMatches) {
+        const secretContent = extractMatchContent(match);
+        const isNew = dedupCache.recordIfNew(
+          url,
+          secretContent,
+          match.RuleID,
+          match.RuleName
+        );
+
+        stats.totalFindings++;
+
+        if (isNew) {
+          stats.uniqueFindings++;
+          const severity = getSeverity(match.RuleID);
+
+          // Create a Caido finding
+          await sdk.findings.create({
+            title: `${match.RuleName} detected`,
+            description: [
+              `**Rule:** ${match.RuleName} (\`${match.RuleID}\`)`,
+              `**Secret:** \`${secretContent.substring(0, 40)}${secretContent.length > 40 ? "..." : ""}\``,
+              `**URL:** ${url}`,
+              `**Severity:** ${severity.toUpperCase()}`,
+            ].join("\n\n"),
+            reporter: "Titus Secret Scanner",
+            request,
+            dedupeKey: `titus-${match.RuleID}-${secretContent.substring(0, 64)}`,
+          });
+
+          // Notify frontend of new finding
+          sdk.api.send("newFinding" as any, {
+            ruleId: match.RuleID,
+            ruleName: match.RuleName,
+            secretPreview:
+              secretContent.substring(0, 20) +
+              (secretContent.length > 20 ? "..." : ""),
+            url,
+            host,
+            severity,
+          } as any);
+        }
+      }
+    } catch (err) {
+      // Log but don't crash on individual scan errors
+      sdk.console.error(
+        `Scan error: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  });
+
+  sdk.console.log("Titus passive scanning registered on HTTP responses");
+}

--- a/caido/packages/backend/src/scanner.ts
+++ b/caido/packages/backend/src/scanner.ts
@@ -1,0 +1,308 @@
+/**
+ * TitusScanner - spawns `titus serve` and communicates via NDJSON.
+ *
+ * Mirrors the architecture of the Burp extension's TitusProcessScanner.java.
+ * The titus binary must be installed on the system (e.g., ~/.titus/titus).
+ */
+
+import { spawn, type ChildProcess } from "child_process";
+import { homedir } from "os";
+import { join } from "path";
+import { existsSync } from "fs";
+import type {
+  TitusRequest,
+  TitusResponse,
+  TitusMatch,
+  ScanData,
+  ScanBatchData,
+  ValidateData,
+  ReadyData,
+  ContentItem,
+} from "./types.js";
+
+const READY_TIMEOUT_MS = 30_000;
+
+export class TitusScanner {
+  private process: ChildProcess | null = null;
+  private initialized = false;
+  private closed = false;
+  private version = "unknown";
+  private buffer = "";
+  private pendingResolve: ((resp: TitusResponse) => void) | null = null;
+  private pendingReject: ((err: Error) => void) | null = null;
+
+  /**
+   * Find the titus binary on the system.
+   * Searches common install locations, matching the Burp extension's logic.
+   */
+  static findBinary(): string | null {
+    const home = homedir();
+    const isWin = process.platform === "win32";
+    const exe = isWin ? ".exe" : "";
+
+    const paths = isWin
+      ? [
+          join(home, ".titus", `titus${exe}`),
+          join(home, "bin", `titus${exe}`),
+        ]
+      : [
+          join(home, ".titus", "titus"),
+          join(home, "bin", "titus"),
+          "/usr/local/bin/titus",
+        ];
+
+    for (const p of paths) {
+      if (existsSync(p)) {
+        return p;
+      }
+    }
+
+    // Fall back to PATH lookup (spawn will resolve it)
+    return "titus";
+  }
+
+  /**
+   * Initialize the scanner by spawning the titus serve process.
+   */
+  async initialize(binaryPath?: string): Promise<void> {
+    if (this.initialized) return;
+
+    const titusPath = binaryPath ?? TitusScanner.findBinary();
+    if (!titusPath) {
+      throw new Error(
+        "Titus binary not found. Install it to ~/.titus/titus or ensure it is on PATH."
+      );
+    }
+
+    return new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.close();
+        reject(new Error("Timeout waiting for titus serve ready signal"));
+      }, READY_TIMEOUT_MS);
+
+      try {
+        this.process = spawn(titusPath, ["serve"], {
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+      } catch (err) {
+        clearTimeout(timeout);
+        reject(
+          new Error(
+            `Failed to spawn titus: ${err instanceof Error ? err.message : String(err)}`
+          )
+        );
+        return;
+      }
+
+      this.process.on("error", (err) => {
+        clearTimeout(timeout);
+        reject(new Error(`Titus process error: ${err.message}`));
+      });
+
+      this.process.on("exit", (code) => {
+        if (!this.closed) {
+          this.initialized = false;
+        }
+      });
+
+      // Read the ready signal from stdout
+      const onData = (chunk: Buffer) => {
+        this.buffer += chunk.toString("utf-8");
+        const lines = this.buffer.split("\n");
+        this.buffer = lines.pop() ?? "";
+
+        for (const line of lines) {
+          if (!line.trim()) continue;
+          try {
+            const resp: TitusResponse = JSON.parse(line);
+            if (
+              resp.success &&
+              resp.type === "ready" &&
+              !this.initialized
+            ) {
+              const data = resp.data as ReadyData;
+              this.version = data?.version ?? "unknown";
+              this.initialized = true;
+              clearTimeout(timeout);
+
+              // Switch to normal response handling
+              this.process!.stdout!.removeListener("data", onData);
+              this.process!.stdout!.on("data", (chunk: Buffer) =>
+                this.handleData(chunk)
+              );
+
+              resolve();
+              return;
+            }
+          } catch {
+            // Ignore malformed lines during startup
+          }
+        }
+      };
+
+      this.process.stdout!.on("data", onData);
+    });
+  }
+
+  /**
+   * Handle incoming data from the titus process stdout.
+   */
+  private handleData(chunk: Buffer): void {
+    this.buffer += chunk.toString("utf-8");
+    const lines = this.buffer.split("\n");
+    this.buffer = lines.pop() ?? "";
+
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      try {
+        const resp: TitusResponse = JSON.parse(line);
+        if (this.pendingResolve) {
+          const resolve = this.pendingResolve;
+          this.pendingResolve = null;
+          this.pendingReject = null;
+          resolve(resp);
+        }
+      } catch {
+        if (this.pendingReject) {
+          const reject = this.pendingReject;
+          this.pendingResolve = null;
+          this.pendingReject = null;
+          reject(new Error(`Malformed response: ${line}`));
+        }
+      }
+    }
+  }
+
+  /**
+   * Send a request and wait for the response.
+   */
+  private async sendRequest(request: TitusRequest): Promise<TitusResponse> {
+    if (!this.initialized || !this.process?.stdin) {
+      throw new Error("Scanner not initialized");
+    }
+
+    return new Promise<TitusResponse>((resolve, reject) => {
+      this.pendingResolve = resolve;
+      this.pendingReject = reject;
+
+      const json = JSON.stringify(request) + "\n";
+      this.process!.stdin!.write(json, "utf-8", (err) => {
+        if (err) {
+          this.pendingResolve = null;
+          this.pendingReject = null;
+          reject(new Error(`Failed to write to titus: ${err.message}`));
+        }
+      });
+    });
+  }
+
+  /**
+   * Scan a single content string for secrets.
+   */
+  async scan(content: string, source: string): Promise<TitusMatch[]> {
+    const resp = await this.sendRequest({
+      type: "scan",
+      payload: { content, source },
+    });
+
+    if (!resp.success) {
+      throw new Error(`Scan failed: ${resp.error}`);
+    }
+
+    const data = resp.data as ScanData;
+    return data?.matches ?? [];
+  }
+
+  /**
+   * Batch scan multiple content items.
+   */
+  async scanBatch(
+    items: ContentItem[]
+  ): Promise<Map<string, TitusMatch[]>> {
+    const resp = await this.sendRequest({
+      type: "scan_batch",
+      payload: { items },
+    });
+
+    if (!resp.success) {
+      throw new Error(`Batch scan failed: ${resp.error}`);
+    }
+
+    const data = resp.data as ScanBatchData;
+    const results = new Map<string, TitusMatch[]>();
+    if (data?.results) {
+      for (const result of data.results) {
+        if (result.matches && result.matches.length > 0) {
+          results.set(result.source, result.matches);
+        }
+      }
+    }
+    return results;
+  }
+
+  /**
+   * Validate a detected secret against its source API.
+   */
+  async validate(
+    ruleId: string,
+    secret: string,
+    namedGroups: Record<string, string>
+  ): Promise<ValidateData> {
+    const resp = await this.sendRequest({
+      type: "validate",
+      payload: { rule_id: ruleId, secret, named_groups: namedGroups },
+    });
+
+    if (!resp.success) {
+      throw new Error(`Validation failed: ${resp.error}`);
+    }
+
+    return resp.data as ValidateData;
+  }
+
+  /**
+   * Get the titus version reported at startup.
+   */
+  getVersion(): string {
+    return this.version;
+  }
+
+  /**
+   * Check if the scanner process is alive.
+   */
+  isAlive(): boolean {
+    return (
+      this.initialized &&
+      !this.closed &&
+      this.process !== null &&
+      this.process.exitCode === null
+    );
+  }
+
+  /**
+   * Gracefully close the scanner process.
+   */
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.initialized = false;
+
+    if (this.process?.stdin) {
+      try {
+        const closeReq = JSON.stringify({ type: "close", payload: {} }) + "\n";
+        this.process.stdin.write(closeReq);
+        this.process.stdin.end();
+      } catch {
+        // Process may already be dead
+      }
+    }
+
+    if (this.process) {
+      setTimeout(() => {
+        if (this.process && this.process.exitCode === null) {
+          this.process.kill("SIGTERM");
+        }
+      }, 5000);
+    }
+  }
+}

--- a/caido/packages/backend/src/scanner.ts
+++ b/caido/packages/backend/src/scanner.ts
@@ -21,6 +21,13 @@ import type {
 } from "./types.js";
 
 const READY_TIMEOUT_MS = 30_000;
+const REQUEST_TIMEOUT_MS = 30_000;
+
+interface PendingRequest {
+  resolve: (resp: TitusResponse) => void;
+  reject: (err: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
 
 export class TitusScanner {
   private process: ChildProcess | null = null;
@@ -28,8 +35,12 @@ export class TitusScanner {
   private closed = false;
   private version = "unknown";
   private buffer = "";
-  private pendingResolve: ((resp: TitusResponse) => void) | null = null;
-  private pendingReject: ((err: Error) => void) | null = null;
+  private pending: PendingRequest | null = null;
+  private queue: Array<{
+    request: TitusRequest;
+    resolve: (resp: TitusResponse) => void;
+    reject: (err: Error) => void;
+  }> = [];
 
   /**
    * Find the titus binary on the system.
@@ -96,14 +107,21 @@ export class TitusScanner {
 
       this.process.on("error", (err) => {
         clearTimeout(timeout);
+        this.rejectPending(new Error(`Titus process error: ${err.message}`));
         reject(new Error(`Titus process error: ${err.message}`));
       });
 
       this.process.on("exit", (code) => {
         if (!this.closed) {
           this.initialized = false;
+          this.rejectPending(
+            new Error(`Titus process exited unexpectedly (code ${code})`)
+          );
         }
       });
+
+      // Drain stderr to prevent backpressure stalls
+      this.process.stderr?.on("data", () => {});
 
       // Read the ready signal from stdout
       const onData = (chunk: Buffer) => {
@@ -154,27 +172,56 @@ export class TitusScanner {
 
     for (const line of lines) {
       if (!line.trim()) continue;
+      if (!this.pending) continue;
+
+      const { resolve, reject, timer } = this.pending;
+      this.pending = null;
+      clearTimeout(timer);
+
       try {
         const resp: TitusResponse = JSON.parse(line);
-        if (this.pendingResolve) {
-          const resolve = this.pendingResolve;
-          this.pendingResolve = null;
-          this.pendingReject = null;
-          resolve(resp);
-        }
+        resolve(resp);
       } catch {
-        if (this.pendingReject) {
-          const reject = this.pendingReject;
-          this.pendingResolve = null;
-          this.pendingReject = null;
-          reject(new Error(`Malformed response: ${line}`));
-        }
+        reject(new Error(`Malformed response: ${line}`));
       }
+
+      // Process next queued request
+      this.processQueue();
     }
   }
 
   /**
+   * Reject the currently pending request (e.g., on process death).
+   */
+  private rejectPending(err: Error): void {
+    if (this.pending) {
+      clearTimeout(this.pending.timer);
+      this.pending.reject(err);
+      this.pending = null;
+    }
+    // Reject all queued requests too
+    for (const queued of this.queue) {
+      queued.reject(err);
+    }
+    this.queue = [];
+  }
+
+  /**
+   * Process the next request in the queue if no request is in flight.
+   */
+  private processQueue(): void {
+    if (this.pending || this.queue.length === 0) return;
+
+    const next = this.queue.shift()!;
+    this.dispatchRequest(next.request, next.resolve, next.reject);
+  }
+
+  /**
    * Send a request and wait for the response.
+   */
+  /**
+   * Send a request, queuing it if another request is already in flight.
+   * Enforces serial communication matching the Java synchronized behavior.
    */
   private async sendRequest(request: TitusRequest): Promise<TitusResponse> {
     if (!this.initialized || !this.process?.stdin) {
@@ -182,17 +229,43 @@ export class TitusScanner {
     }
 
     return new Promise<TitusResponse>((resolve, reject) => {
-      this.pendingResolve = resolve;
-      this.pendingReject = reject;
+      if (this.pending) {
+        // Queue behind the in-flight request
+        this.queue.push({ request, resolve, reject });
+      } else {
+        this.dispatchRequest(request, resolve, reject);
+      }
+    });
+  }
 
-      const json = JSON.stringify(request) + "\n";
-      this.process!.stdin!.write(json, "utf-8", (err) => {
-        if (err) {
-          this.pendingResolve = null;
-          this.pendingReject = null;
-          reject(new Error(`Failed to write to titus: ${err.message}`));
+  /**
+   * Actually write a request to stdin and set up the pending handler.
+   */
+  private dispatchRequest(
+    request: TitusRequest,
+    resolve: (resp: TitusResponse) => void,
+    reject: (err: Error) => void
+  ): void {
+    const timer = setTimeout(() => {
+      if (this.pending?.timer === timer) {
+        this.pending = null;
+        reject(new Error("Titus request timed out"));
+        this.processQueue();
+      }
+    }, REQUEST_TIMEOUT_MS);
+
+    this.pending = { resolve, reject, timer };
+
+    const json = JSON.stringify(request) + "\n";
+    this.process!.stdin!.write(json, "utf-8", (err) => {
+      if (err) {
+        if (this.pending?.timer === timer) {
+          clearTimeout(timer);
+          this.pending = null;
         }
-      });
+        reject(new Error(`Failed to write to titus: ${err.message}`));
+        this.processQueue();
+      }
     });
   }
 
@@ -286,6 +359,7 @@ export class TitusScanner {
     if (this.closed) return;
     this.closed = true;
     this.initialized = false;
+    this.rejectPending(new Error("Scanner closed"));
 
     if (this.process?.stdin) {
       try {

--- a/caido/packages/backend/src/types.ts
+++ b/caido/packages/backend/src/types.ts
@@ -1,0 +1,119 @@
+/**
+ * NDJSON protocol types for communicating with `titus serve`.
+ * Mirrors the Go types in pkg/serve/types.go.
+ */
+
+// --- Requests ---
+
+export interface ScanRequest {
+  type: "scan";
+  payload: {
+    content: string;
+    source: string;
+  };
+}
+
+export interface ScanBatchRequest {
+  type: "scan_batch";
+  payload: {
+    items: ContentItem[];
+  };
+}
+
+export interface ValidateRequest {
+  type: "validate";
+  payload: {
+    rule_id: string;
+    secret: string;
+    named_groups: Record<string, string>;
+  };
+}
+
+export interface CloseRequest {
+  type: "close";
+  payload: Record<string, never>;
+}
+
+export type TitusRequest =
+  | ScanRequest
+  | ScanBatchRequest
+  | ValidateRequest
+  | CloseRequest;
+
+export interface ContentItem {
+  source: string;
+  content: string;
+}
+
+// --- Responses ---
+
+export interface TitusResponse {
+  success: boolean;
+  type: "ready" | "scan" | "scan_batch" | "validate" | "error";
+  data?: unknown;
+  error?: string;
+}
+
+export interface ReadyData {
+  version: string;
+}
+
+export interface ScanData {
+  matches: TitusMatch[] | null;
+}
+
+export interface ScanBatchData {
+  results: Array<{
+    source: string;
+    matches: TitusMatch[] | null;
+  }>;
+}
+
+export interface ValidateData {
+  status: string;
+  confidence: number;
+  message: string;
+  details?: Record<string, string>;
+}
+
+export interface TitusMatch {
+  RuleID: string;
+  RuleName: string;
+  StructuralID: string;
+  Groups: string[] | null; // base64-encoded capture groups
+  NamedGroups: Record<string, string> | null; // base64-encoded named groups
+  Snippet: {
+    Before?: string;
+    Matching?: string;
+    After?: string;
+  } | null;
+  Location: {
+    Offset: { Start: number; End: number };
+    Source?: {
+      Start?: { Line: number; Column: number };
+      End?: { Line: number; Column: number };
+    };
+  } | null;
+}
+
+// --- Plugin state ---
+
+export interface FindingRecord {
+  ruleId: string;
+  ruleName: string;
+  secretPreview: string;
+  secretContent: string;
+  url: string;
+  host: string;
+  urls: Set<string>;
+  occurrenceCount: number;
+  firstSeen: string;
+}
+
+export interface ScanStats {
+  totalScanned: number;
+  totalFindings: number;
+  uniqueFindings: number;
+  isRunning: boolean;
+  titusVersion: string;
+}

--- a/caido/packages/backend/src/types.ts
+++ b/caido/packages/backend/src/types.ts
@@ -105,7 +105,7 @@ export interface FindingRecord {
   secretContent: string;
   url: string;
   host: string;
-  urls: Set<string>;
+  urls: string[];
   occurrenceCount: number;
   firstSeen: string;
 }

--- a/caido/packages/backend/tsconfig.json
+++ b/caido/packages/backend/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/caido/packages/backend/vite.config.ts
+++ b/caido/packages/backend/vite.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: "src/index.ts",
+      formats: ["es"],
+      fileName: "index",
+    },
+    outDir: "dist",
+    emptyOutDir: true,
+    rollupOptions: {
+      external: [
+        "caido:plugin",
+        "caido:utils",
+        "child_process",
+        "path",
+        "os",
+        "fs",
+      ],
+    },
+  },
+});

--- a/caido/packages/frontend/package.json
+++ b/caido/packages/frontend/package.json
@@ -7,6 +7,9 @@
     "dev": "vite build --watch",
     "typecheck": "tsc --noEmit"
   },
+  "dependencies": {
+    "titus-backend": "workspace:*"
+  },
   "devDependencies": {
     "@caido/sdk-frontend": "^0.14.0",
     "vite": "^5.2.0",

--- a/caido/packages/frontend/package.json
+++ b/caido/packages/frontend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "titus-frontend",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite build --watch",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@caido/sdk-frontend": "^0.14.0",
+    "vite": "^5.2.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/caido/packages/frontend/src/index.ts
+++ b/caido/packages/frontend/src/index.ts
@@ -96,6 +96,7 @@ function createPluginPage(sdk: SDK): HTMLElement {
   clearBtn.textContent = "Clear Findings";
   clearBtn.addEventListener("click", async () => {
     await sdk.backend.clearFindings();
+    refreshStats(sdk);
     refreshFindings(sdk);
   });
   controls.appendChild(clearBtn);
@@ -201,11 +202,13 @@ async function refreshFindings(sdk: SDK): Promise<void> {
       return;
     }
 
-    // Sort by first seen (newest first)
-    const sorted = [...findings].sort(
-      (a, b) =>
-        new Date(b.firstSeen).getTime() - new Date(a.firstSeen).getTime()
-    );
+    // Sort by first seen (newest first), limit to 100 rows for performance
+    const sorted = [...findings]
+      .sort(
+        (a, b) =>
+          new Date(b.firstSeen).getTime() - new Date(a.firstSeen).getTime()
+      )
+      .slice(0, 100);
 
     tbody.innerHTML = sorted
       .map((f) => {

--- a/caido/packages/frontend/src/index.ts
+++ b/caido/packages/frontend/src/index.ts
@@ -1,0 +1,309 @@
+/**
+ * Titus Secret Scanner - Caido Frontend Plugin
+ *
+ * Provides a "Titus" tab in the Caido UI showing:
+ *   - Scanner status and statistics
+ *   - Findings table with rule name, secret preview, URL, severity
+ *   - Settings toggles for passive scanning, request scanning, scope filtering
+ */
+
+import type { Caido } from "@caido/sdk-frontend";
+import type { API } from "titus-backend";
+
+type SDK = Caido<API>;
+
+// --- Severity badge colors ---
+const SEVERITY_COLORS: Record<string, string> = {
+  high: "#e74c3c",
+  medium: "#f39c12",
+  low: "#3498db",
+  info: "#95a5a6",
+};
+
+// --- Build the UI ---
+
+function createPluginPage(sdk: SDK): HTMLElement {
+  const container = document.createElement("div");
+  container.className = "titus-container";
+
+  // Header
+  const header = document.createElement("div");
+  header.className = "titus-header";
+  header.innerHTML = `
+    <h2>Titus Secret Scanner</h2>
+    <p class="titus-subtitle">Scanning HTTP traffic for secrets with 444+ detection rules</p>
+  `;
+  container.appendChild(header);
+
+  // Stats bar
+  const statsBar = document.createElement("div");
+  statsBar.className = "titus-stats";
+  statsBar.id = "titus-stats";
+  statsBar.innerHTML = `
+    <div class="titus-stat">
+      <span class="titus-stat-label">Status</span>
+      <span class="titus-stat-value" id="titus-status">Initializing...</span>
+    </div>
+    <div class="titus-stat">
+      <span class="titus-stat-label">Version</span>
+      <span class="titus-stat-value" id="titus-version">-</span>
+    </div>
+    <div class="titus-stat">
+      <span class="titus-stat-label">Responses Scanned</span>
+      <span class="titus-stat-value" id="titus-scanned">0</span>
+    </div>
+    <div class="titus-stat">
+      <span class="titus-stat-label">Total Hits</span>
+      <span class="titus-stat-value" id="titus-total">0</span>
+    </div>
+    <div class="titus-stat">
+      <span class="titus-stat-label">Unique Findings</span>
+      <span class="titus-stat-value" id="titus-unique">0</span>
+    </div>
+  `;
+  container.appendChild(statsBar);
+
+  // Controls
+  const controls = document.createElement("div");
+  controls.className = "titus-controls";
+
+  const passiveToggle = createToggle(
+    "Passive Scan",
+    "titus-passive",
+    true,
+    (enabled) => sdk.backend.setPassiveScan(enabled)
+  );
+  controls.appendChild(passiveToggle);
+
+  const requestToggle = createToggle(
+    "Scan Requests",
+    "titus-requests",
+    false,
+    (enabled) => sdk.backend.setScanRequests(enabled)
+  );
+  controls.appendChild(requestToggle);
+
+  const scopeToggle = createToggle(
+    "Scope Only",
+    "titus-scope",
+    false,
+    (enabled) => sdk.backend.setScopeOnly(enabled)
+  );
+  controls.appendChild(scopeToggle);
+
+  const clearBtn = document.createElement("button");
+  clearBtn.className = "titus-btn titus-btn-danger";
+  clearBtn.textContent = "Clear Findings";
+  clearBtn.addEventListener("click", async () => {
+    await sdk.backend.clearFindings();
+    refreshFindings(sdk);
+  });
+  controls.appendChild(clearBtn);
+
+  const refreshBtn = document.createElement("button");
+  refreshBtn.className = "titus-btn";
+  refreshBtn.textContent = "Refresh";
+  refreshBtn.addEventListener("click", () => {
+    refreshStats(sdk);
+    refreshFindings(sdk);
+  });
+  controls.appendChild(refreshBtn);
+
+  container.appendChild(controls);
+
+  // Findings table
+  const tableContainer = document.createElement("div");
+  tableContainer.className = "titus-table-container";
+  tableContainer.innerHTML = `
+    <table class="titus-table">
+      <thead>
+        <tr>
+          <th>Severity</th>
+          <th>Rule</th>
+          <th>Secret</th>
+          <th>Host</th>
+          <th>URL</th>
+          <th>Count</th>
+          <th>First Seen</th>
+        </tr>
+      </thead>
+      <tbody id="titus-findings-body">
+        <tr><td colspan="7" class="titus-empty">No findings yet. Secrets will appear here as HTTP traffic is scanned.</td></tr>
+      </tbody>
+    </table>
+  `;
+  container.appendChild(tableContainer);
+
+  return container;
+}
+
+function createToggle(
+  label: string,
+  id: string,
+  defaultChecked: boolean,
+  onChange: (enabled: boolean) => void
+): HTMLElement {
+  const wrapper = document.createElement("label");
+  wrapper.className = "titus-toggle";
+  wrapper.htmlFor = id;
+
+  const input = document.createElement("input");
+  input.type = "checkbox";
+  input.id = id;
+  input.checked = defaultChecked;
+  input.addEventListener("change", () => onChange(input.checked));
+
+  const span = document.createElement("span");
+  span.textContent = label;
+
+  wrapper.appendChild(input);
+  wrapper.appendChild(span);
+  return wrapper;
+}
+
+// --- Data refresh ---
+
+async function refreshStats(sdk: SDK): Promise<void> {
+  try {
+    const stats = await sdk.backend.getStats();
+
+    const statusEl = document.getElementById("titus-status");
+    if (statusEl) {
+      statusEl.textContent = stats.isRunning ? "Running" : "Stopped";
+      statusEl.style.color = stats.isRunning ? "#2ecc71" : "#e74c3c";
+    }
+
+    const versionEl = document.getElementById("titus-version");
+    if (versionEl) versionEl.textContent = stats.titusVersion;
+
+    const scannedEl = document.getElementById("titus-scanned");
+    if (scannedEl) scannedEl.textContent = String(stats.totalScanned);
+
+    const totalEl = document.getElementById("titus-total");
+    if (totalEl) totalEl.textContent = String(stats.totalFindings);
+
+    const uniqueEl = document.getElementById("titus-unique");
+    if (uniqueEl) uniqueEl.textContent = String(stats.uniqueFindings);
+  } catch {
+    // Backend may not be ready yet
+  }
+}
+
+async function refreshFindings(sdk: SDK): Promise<void> {
+  try {
+    const findings = await sdk.backend.getFindings();
+    const tbody = document.getElementById("titus-findings-body");
+    if (!tbody) return;
+
+    if (!findings || findings.length === 0) {
+      tbody.innerHTML =
+        '<tr><td colspan="7" class="titus-empty">No findings yet. Secrets will appear here as HTTP traffic is scanned.</td></tr>';
+      return;
+    }
+
+    // Sort by first seen (newest first)
+    const sorted = [...findings].sort(
+      (a, b) =>
+        new Date(b.firstSeen).getTime() - new Date(a.firstSeen).getTime()
+    );
+
+    tbody.innerHTML = sorted
+      .map((f) => {
+        const severity = getSeverityFromRuleId(f.ruleId);
+        const color = SEVERITY_COLORS[severity] ?? SEVERITY_COLORS.info;
+        const time = new Date(f.firstSeen).toLocaleTimeString();
+
+        return `
+        <tr>
+          <td><span class="titus-severity" style="background:${color}">${severity.toUpperCase()}</span></td>
+          <td class="titus-rule" title="${escapeHtml(f.ruleId)}">${escapeHtml(f.ruleName)}</td>
+          <td class="titus-secret"><code>${escapeHtml(f.secretPreview)}</code></td>
+          <td>${escapeHtml(f.host)}</td>
+          <td class="titus-url" title="${escapeHtml(f.url)}">${escapeHtml(truncate(f.url, 60))}</td>
+          <td>${f.occurrenceCount}</td>
+          <td>${time}</td>
+        </tr>
+      `;
+      })
+      .join("");
+  } catch {
+    // Backend may not be ready yet
+  }
+}
+
+function getSeverityFromRuleId(ruleId: string): string {
+  const lower = ruleId.toLowerCase();
+  const high = [
+    "aws",
+    "azure",
+    "gcp",
+    "auth",
+    "oauth",
+    "jwt",
+    "database",
+    "db",
+    "postgres",
+    "mysql",
+    "mongodb",
+    "private",
+    "ssh",
+    "rsa",
+  ];
+  if (high.some((c) => lower.includes(c))) return "high";
+
+  const medium = [
+    "slack",
+    "github",
+    "gitlab",
+    "npm",
+    "api",
+    "password",
+    "secret",
+  ];
+  if (medium.some((c) => lower.includes(c))) return "medium";
+
+  if (lower.includes("generic")) return "low";
+  return "medium";
+}
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function truncate(str: string, maxLen: number): string {
+  return str.length > maxLen ? str.substring(0, maxLen) + "..." : str;
+}
+
+// --- Plugin init ---
+
+export function init(sdk: SDK) {
+  // Register the Titus page
+  const page = createPluginPage(sdk);
+
+  sdk.navigation.addPage("/titus", {
+    body: page,
+  });
+
+  sdk.sidebar.registerItem("Titus", "/titus", {
+    icon: "fas fa-key",
+  });
+
+  // Listen for new findings from backend
+  sdk.backend.onEvent("newFinding" as any, () => {
+    refreshStats(sdk);
+    refreshFindings(sdk);
+  });
+
+  // Periodic stats refresh
+  setInterval(() => refreshStats(sdk), 5000);
+
+  // Initial data load
+  setTimeout(() => {
+    refreshStats(sdk);
+    refreshFindings(sdk);
+  }, 2000);
+}

--- a/caido/packages/frontend/src/style.css
+++ b/caido/packages/frontend/src/style.css
@@ -1,0 +1,182 @@
+/* Titus Secret Scanner - Caido Plugin Styles */
+
+.titus-container {
+  padding: 16px;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  color: var(--c-fg-default, #e1e4e8);
+  background: var(--c-bg-default, #0d1117);
+  height: 100%;
+  overflow-y: auto;
+}
+
+.titus-header {
+  margin-bottom: 16px;
+}
+
+.titus-header h2 {
+  margin: 0 0 4px 0;
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--c-fg-default, #f0f6fc);
+}
+
+.titus-subtitle {
+  margin: 0;
+  font-size: 13px;
+  color: var(--c-fg-subtle, #8b949e);
+}
+
+/* Stats bar */
+.titus-stats {
+  display: flex;
+  gap: 24px;
+  padding: 12px 16px;
+  margin-bottom: 12px;
+  background: var(--c-bg-subtle, #161b22);
+  border: 1px solid var(--c-border-default, #30363d);
+  border-radius: 6px;
+}
+
+.titus-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.titus-stat-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  color: var(--c-fg-subtle, #8b949e);
+  letter-spacing: 0.5px;
+}
+
+.titus-stat-value {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--c-fg-default, #f0f6fc);
+}
+
+/* Controls */
+.titus-controls {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 8px 0;
+  margin-bottom: 12px;
+}
+
+.titus-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  cursor: pointer;
+  color: var(--c-fg-default, #e1e4e8);
+}
+
+.titus-toggle input[type="checkbox"] {
+  cursor: pointer;
+}
+
+.titus-btn {
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  border: 1px solid var(--c-border-default, #30363d);
+  border-radius: 4px;
+  background: var(--c-bg-subtle, #21262d);
+  color: var(--c-fg-default, #e1e4e8);
+  cursor: pointer;
+}
+
+.titus-btn:hover {
+  background: var(--c-bg-emphasis, #30363d);
+}
+
+.titus-btn-danger {
+  color: #f85149;
+  border-color: rgba(248, 81, 73, 0.4);
+}
+
+.titus-btn-danger:hover {
+  background: rgba(248, 81, 73, 0.15);
+}
+
+/* Findings table */
+.titus-table-container {
+  border: 1px solid var(--c-border-default, #30363d);
+  border-radius: 6px;
+  overflow: auto;
+}
+
+.titus-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.titus-table thead {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.titus-table th {
+  padding: 8px 12px;
+  text-align: left;
+  font-weight: 600;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  background: var(--c-bg-subtle, #161b22);
+  border-bottom: 1px solid var(--c-border-default, #30363d);
+  color: var(--c-fg-subtle, #8b949e);
+}
+
+.titus-table td {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--c-border-muted, #21262d);
+  vertical-align: middle;
+}
+
+.titus-table tr:hover td {
+  background: var(--c-bg-subtle, #161b22);
+}
+
+.titus-severity {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 600;
+  color: #fff;
+}
+
+.titus-rule {
+  font-weight: 500;
+}
+
+.titus-secret code {
+  padding: 2px 6px;
+  background: var(--c-bg-subtle, #161b22);
+  border: 1px solid var(--c-border-default, #30363d);
+  border-radius: 3px;
+  font-size: 12px;
+  font-family: "SF Mono", SFMono-Regular, Consolas, monospace;
+  word-break: break-all;
+}
+
+.titus-url {
+  max-width: 300px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--c-fg-subtle, #8b949e);
+}
+
+.titus-empty {
+  text-align: center;
+  padding: 32px !important;
+  color: var(--c-fg-subtle, #8b949e);
+  font-style: italic;
+}

--- a/caido/packages/frontend/tsconfig.json
+++ b/caido/packages/frontend/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"]
+  },
+  "include": ["src"]
+}

--- a/caido/packages/frontend/vite.config.ts
+++ b/caido/packages/frontend/vite.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: "src/index.ts",
+      formats: ["es"],
+      fileName: "index",
+    },
+    outDir: "dist",
+    emptyOutDir: true,
+    rollupOptions: {
+      external: ["@caido/sdk-frontend", "caido:plugin", "caido:utils"],
+    },
+  },
+  css: {
+    // Extract CSS into a separate file
+  },
+});

--- a/caido/pnpm-workspace.yaml
+++ b/caido/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - "packages/*"

--- a/caido/scripts/clean.js
+++ b/caido/scripts/clean.js
@@ -1,0 +1,22 @@
+import { rmSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "..");
+
+const dirs = [
+  resolve(root, "dist"),
+  resolve(root, "packages/backend/dist"),
+  resolve(root, "packages/frontend/dist"),
+];
+
+for (const dir of dirs) {
+  try {
+    rmSync(dir, { recursive: true, force: true });
+  } catch {
+    // Directory may not exist
+  }
+}
+
+console.log("Cleaned dist directories");

--- a/caido/scripts/pack.js
+++ b/caido/scripts/pack.js
@@ -1,0 +1,59 @@
+import { readFileSync, writeFileSync, existsSync } from "fs";
+import { resolve, dirname, relative } from "path";
+import { fileURLToPath } from "url";
+import JSZip from "jszip";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "..");
+
+async function pack() {
+  const zip = new JSZip();
+
+  // Add manifest
+  const manifest = readFileSync(resolve(root, "manifest.json"), "utf-8");
+  zip.file("manifest.json", manifest);
+
+  // Add backend dist
+  const backendDist = resolve(root, "packages/backend/dist/index.js");
+  if (existsSync(backendDist)) {
+    zip.file(
+      "packages/backend/dist/index.js",
+      readFileSync(backendDist)
+    );
+  } else {
+    console.error("Backend dist not found:", backendDist);
+    process.exit(1);
+  }
+
+  // Add frontend dist
+  const frontendDist = resolve(root, "packages/frontend/dist/index.js");
+  if (existsSync(frontendDist)) {
+    zip.file(
+      "packages/frontend/dist/index.js",
+      readFileSync(frontendDist)
+    );
+  } else {
+    console.error("Frontend dist not found:", frontendDist);
+    process.exit(1);
+  }
+
+  // Add frontend styles
+  const frontendStyle = resolve(root, "packages/frontend/dist/style.css");
+  if (existsSync(frontendStyle)) {
+    zip.file(
+      "packages/frontend/dist/style.css",
+      readFileSync(frontendStyle)
+    );
+  }
+
+  // Write zip
+  const buffer = await zip.generateAsync({ type: "nodebuffer" });
+  const outputPath = resolve(root, "plugin_package.zip");
+  writeFileSync(outputPath, buffer);
+  console.log(`Plugin packaged: ${relative(root, outputPath)}`);
+}
+
+pack().catch((err) => {
+  console.error("Pack failed:", err);
+  process.exit(1);
+});

--- a/caido/tsconfig.json
+++ b/caido/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a Caido proxy plugin (`caido/`) that scans HTTP traffic for secrets using the Titus detection engine, mirroring the Burp Suite extension architecture
- Backend spawns `titus serve` subprocess and communicates via NDJSON, intercepts HTTP responses, filters non-scannable content, deduplicates findings, and reports via Caido's findings API
- Frontend provides a sidebar tab with stats dashboard, findings table, and settings toggles (passive scan, request scanning, scope filtering)

Closes LAB-1364

## Architecture

Same subprocess approach as the Burp extension -- spawns `titus serve` once, reuses for all scans. No rules ported to JS; full 444+ rule engine via the native binary.

```
Caido Backend ──NDJSON──► titus serve (444+ rules, Hyperscan)
     │
     │ sdk.api (RPC)
     ▼
Caido Frontend (stats, findings table, settings)
```

## Files

| Path | Description |
|------|-------------|
| `caido/packages/backend/src/index.ts` | Plugin entry: HTTP handler, findings API |
| `caido/packages/backend/src/scanner.ts` | `TitusScanner`: subprocess management |
| `caido/packages/backend/src/filter.ts` | `FastPathFilter`: content-type/extension filtering |
| `caido/packages/backend/src/dedup.ts` | `DedupCache`: finding deduplication |
| `caido/packages/backend/src/types.ts` | NDJSON protocol types |
| `caido/packages/frontend/src/index.ts` | UI: stats, findings table, settings |
| `caido/packages/frontend/src/style.css` | Dark theme CSS |

## Test plan

- [ ] Install `titus` binary, run `pnpm install && pnpm build` in `caido/`
- [ ] Load `plugin_package.zip` in Caido Settings > Plugins
- [ ] Verify Titus sidebar tab appears with "Running" status
- [ ] Browse a site with known exposed secrets and verify findings appear
- [ ] Toggle passive scan off/on and verify behavior
- [ ] Test scope-only filtering with Caido scope configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)