### PR TITLE
feat(enum): add Asana workspace enumerator

### DIFF
--- a/cmd/titus/scan.go
+++ b/cmd/titus/scan.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -73,6 +74,12 @@ var (
 	scanScopeEnabled bool
 	scanScoreTimeout time.Duration
 	scanScoreBudget  time.Duration
+
+	// Asana scan flags.
+	scanAsanaIncludeAttachments bool
+	scanAsanaAttachmentMaxSize  int64
+	scanAsanaRateLimit          float64
+	scanAsanaConcurrency        int
 )
 
 var scanCmd = &cobra.Command{
@@ -116,6 +123,11 @@ func init() {
 		"per-modifier HTTP timeout for dynamic scoring (default 10s)")
 	scanCmd.Flags().DurationVar(&scanScoreBudget, "score-budget", 60*time.Second,
 		"per-finding overall scoring budget across all modifiers (default 60s; 0 = unlimited)")
+
+	scanCmd.Flags().BoolVar(&scanAsanaIncludeAttachments, "asana-include-attachments", false, "Download and scan Asana-hosted file attachments")
+	scanCmd.Flags().Int64Var(&scanAsanaAttachmentMaxSize, "asana-attachment-max-size", 50*1024*1024, "Maximum Asana attachment size in bytes to download")
+	scanCmd.Flags().Float64Var(&scanAsanaRateLimit, "asana-rate-limit", 10.0, "Asana API requests per second (free tier ≈ 2.5/sec; paid tier ≈ 25/sec)")
+	scanCmd.Flags().IntVar(&scanAsanaConcurrency, "asana-concurrency", 0, "Number of workers processing tasks within a project (0 = use default of 5)")
 }
 
 // blobJob represents a unit of work for the worker pool.
@@ -151,6 +163,11 @@ func runScan(cmd *cobra.Command, args []string) error {
 		// Check if target is an S3 URL
 		if bucket, prefix, ok := enum.ParseS3URL(target); ok {
 			return runS3Scan(cmd, bucket, prefix)
+		}
+
+		// Check if target is an Asana URL
+		if scope, gid, ok := enum.ParseAsanaURL(target); ok {
+			return runAsanaScan(cmd, scope, gid)
 		}
 
 		// Validate target exists (filesystem path)
@@ -1296,6 +1313,285 @@ func runS3Scan(cmd *cobra.Command, bucket, prefix string) error {
 
 	if verbose {
 		fmt.Fprintf(os.Stderr, "[scan] S3 scan complete: %d objects, %d matches, %d findings\n", blobCount.Load(), matchCount.Load(), findingCount.Load())
+	}
+
+	duration := time.Since(startTime)
+	printScanStats(cmd, scanOutputFormat, scanOutputPath,
+		totalBytes.Load(), blobCount.Load(), matchCount.Load(), skippedCount.Load(), duration)
+
+	return outputScanResults(cmd, s, rules, ruleMap)
+}
+
+// runAsanaScan handles scanning of Asana workspaces detected from asana:// URLs.
+func runAsanaScan(cmd *cobra.Command, scope enum.AsanaScope, gid string) error {
+	token := os.Getenv("ASANA_TOKEN")
+	if token == "" {
+		return fmt.Errorf("asana token is required: set ASANA_TOKEN")
+	}
+
+	rules, err := loadRules(scanRulesPath, scanRulesInclude, scanRulesExclude, scanRuleset, scanIncludeNoisy)
+	if err != nil {
+		return fmt.Errorf("loading rules: %w", err)
+	}
+
+	ruleMap := make(map[string]*types.Rule)
+	for _, r := range rules {
+		ruleMap[r.ID] = r
+	}
+
+	m, err := matcher.New(matcher.Config{
+		Rules:        rules,
+		ContextLines: scanContextLines,
+		WarnFunc: func(format string, args ...any) {
+			fmt.Fprintf(os.Stderr, format, args...)
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("creating matcher: %w", err)
+	}
+	defer m.Close()
+
+	s, ds, err := openScanStore(scanOutputPath, scanStoreBlobs)
+	if err != nil {
+		return err
+	}
+	if ds != nil {
+		defer ds.Close()
+	} else {
+		defer s.Close()
+	}
+
+	for _, r := range rules {
+		if err := s.AddRule(r); err != nil {
+			return fmt.Errorf("storing rule: %w", err)
+		}
+	}
+
+	validationEngine := initValidationEngine()
+	if validationEngine != nil {
+		matcher.SetCanValidate(m, validationEngine.CanValidate)
+	}
+
+	asanaEngine, err := buildScoringEngine()
+	if err != nil {
+		return fmt.Errorf("initializing scoring engine: %w", err)
+	}
+
+	// Asana content has no git remote; resolve accessibility from the flag only
+	// (auto falls back to private, which is the conservative default).
+	asanaAccessibility := ResolveAccessibility(scanAccessibility, "", "")
+
+	// Parse extraction limits
+	limits := enum.DefaultExtractionLimits()
+	if extractMaxSize != "" {
+		size, err := parseSize(extractMaxSize)
+		if err != nil {
+			return fmt.Errorf("parsing extract-max-size: %w", err)
+		}
+		limits.MaxSize = size
+	}
+	if extractMaxTotal != "" {
+		size, err := parseSize(extractMaxTotal)
+		if err != nil {
+			return fmt.Errorf("parsing extract-max-total: %w", err)
+		}
+		limits.MaxTotal = size
+	}
+	limits.MaxDepth = extractMaxDepth
+	limits.SQLiteRowLimit = scanSQLiteRowLimit
+
+	var verboseWriter io.Writer
+	if verbose {
+		verboseWriter = cmd.ErrOrStderr()
+	}
+
+	cfg := enum.AsanaConfig{
+		Token:              token,
+		IncludeAttachments: scanAsanaIncludeAttachments,
+		AttachmentMaxBytes: scanAsanaAttachmentMaxSize,
+		RatePerSec:         scanAsanaRateLimit,
+		Concurrency:        scanAsanaConcurrency,
+		Verbose:            verboseWriter,
+		Config: enum.Config{
+			MaxFileSize:     scanMaxFileSize,
+			ExtractArchives: string(scanExtractArchivesFlag),
+			ExtractLimits:   limits,
+		},
+	}
+	switch scope {
+	case enum.AsanaScopeWorkspace:
+		cfg.Workspace = gid
+	case enum.AsanaScopeTeam:
+		cfg.Team = gid
+	case enum.AsanaScopeProject:
+		cfg.Project = gid
+	}
+
+	asanaEnum, err := enum.NewAsanaEnumerator(cfg)
+	if err != nil {
+		return fmt.Errorf("creating Asana enumerator: %w", err)
+	}
+
+	ctx := context.Background()
+	var matchCount atomic.Int64
+	var findingCount atomic.Int64
+	var skippedCount atomic.Int64
+	var totalBytes atomic.Int64
+	var blobCount atomic.Int64
+	startTime := time.Now()
+
+	numWorkers := scanWorkers
+	if numWorkers < 1 {
+		numWorkers = 1
+	}
+
+	if verbose {
+		fmt.Fprintf(os.Stderr, "[scan] Starting Asana scan with %d workers and %d rules\n", numWorkers, len(rules))
+	}
+
+	jobs := make(chan blobJob, 2*numWorkers)
+
+	g, ctx := errgroup.WithContext(ctx)
+
+	// Producer
+	g.Go(func() error {
+		defer close(jobs)
+		return asanaEnum.Enumerate(ctx, func(content []byte, blobID types.BlobID, prov types.Provenance) error {
+			totalBytes.Add(int64(len(content)))
+			count := blobCount.Add(1)
+			if verbose && count%1000 == 0 {
+				fmt.Fprintf(os.Stderr, "[enumerate] %d blobs processed (%d bytes)\n", count, totalBytes.Load())
+			}
+
+			if scanIncremental {
+				exists, err := s.BlobExists(blobID)
+				if err != nil {
+					return fmt.Errorf("checking blob: %w", err)
+				}
+				if exists {
+					skippedCount.Add(1)
+					return nil
+				}
+			}
+
+			select {
+			case jobs <- blobJob{content: content, blobID: blobID, prov: prov}:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		})
+	})
+
+	// Consumer workers
+	const batchSize = 64
+	for i := 0; i < numWorkers; i++ {
+		g.Go(func() error {
+			type batchItem struct {
+				blobID  types.BlobID
+				prov    types.Provenance
+				size    int64
+				matches []*types.Match
+			}
+			var batch []batchItem
+
+			flush := func() error {
+				if len(batch) == 0 {
+					return nil
+				}
+				err := s.ExecBatch(func(tx store.Store) error {
+					for _, item := range batch {
+						if err := tx.AddBlob(item.blobID, item.size); err != nil {
+							return fmt.Errorf("storing blob: %w", err)
+						}
+						if err := tx.AddProvenance(item.blobID, item.prov); err != nil {
+							return fmt.Errorf("storing provenance: %w", err)
+						}
+						for _, match := range item.matches {
+							if err := tx.AddMatch(match); err != nil {
+								return fmt.Errorf("storing match: %w", err)
+							}
+							rule, ok := ruleMap[match.RuleID]
+							if !ok {
+								return fmt.Errorf("rule not found: %s", match.RuleID)
+							}
+							findingID := types.ComputeFindingID(rule.StructuralID, match.Groups)
+							exists, err := tx.FindingExists(findingID)
+							if err != nil {
+								return fmt.Errorf("checking finding: %w", err)
+							}
+							if !exists {
+								findingCount.Add(1)
+								f := &types.Finding{
+									ID:     findingID,
+									RuleID: match.RuleID,
+									Groups: match.Groups,
+								}
+								f.Score = asanaEngine.Score(ctx, f, []*types.Match{match}, rule)
+								if asanaAccessibility == AccessibilityPrivate {
+									ApplyAccessibilityModifier(f.Score)
+								}
+								if err := tx.AddFinding(f); err != nil {
+									return fmt.Errorf("storing finding: %w", err)
+								}
+							}
+						}
+					}
+					return nil
+				})
+				batch = batch[:0]
+				return err
+			}
+
+			for job := range jobs {
+				matches, err := m.MatchWithBlobID(job.content, job.blobID)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "[warn] match error (skipping blob %s): %v\n", job.blobID.Hex(), err)
+					continue
+				}
+
+				for _, match := range matches {
+					startLine, startCol := types.ComputeLineColumn(job.content, int(match.Location.Offset.Start))
+					endLine, endCol := types.ComputeLineColumn(job.content, int(match.Location.Offset.End))
+					match.Location.Source.Start.Line = startLine
+					match.Location.Source.Start.Column = startCol
+					match.Location.Source.End.Line = endLine
+					match.Location.Source.End.Column = endCol
+				}
+
+				validateMatches(ctx, validationEngine, matches, verbose)
+				matchCount.Add(int64(len(matches)))
+
+				batch = append(batch, batchItem{
+					blobID:  job.blobID,
+					prov:    job.prov,
+					size:    int64(len(job.content)),
+					matches: matches,
+				})
+				if len(batch) >= batchSize {
+					if err := flush(); err != nil {
+						return err
+					}
+				}
+			}
+			return flush()
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		if ctx.Err() != nil && errors.Is(err, context.Canceled) {
+			// Normal shutdown via Ctrl+C, not an error
+		} else {
+			return fmt.Errorf("scanning: %w", err)
+		}
+	}
+
+	if err := drainTimedOutMatches(ctx, m, s, ruleMap, asanaEngine, &findingCount, &matchCount, asanaAccessibility); err != nil {
+		return fmt.Errorf("retrying timed-out blobs: %w", err)
+	}
+
+	if verbose {
+		fmt.Fprintf(os.Stderr, "[scan] Asana scan complete: %d blobs, %d matches, %d findings\n", blobCount.Load(), matchCount.Load(), findingCount.Load())
 	}
 
 	duration := time.Since(startTime)

--- a/pkg/enum/asana.go
+++ b/pkg/enum/asana.go
@@ -1,0 +1,1041 @@
+package enum
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"golang.org/x/time/rate"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+)
+
+// Asana does not expose X-RateLimit-Remaining / X-RateLimit-Reset headers.
+// The only quota signal is 429 Too Many Requests with Retry-After. We retry
+// reactively rather than predictively. See https://developers.asana.com/docs/rate-limits.
+const (
+	asanaMaxRetries  = 5
+	asanaBaseBackoff = 500 * time.Millisecond
+	asanaMaxBackoff  = 60 * time.Second
+)
+
+// AsanaConfig configures the Asana enumerator.
+type AsanaConfig struct {
+	Token              string
+	BaseURL            string       // Optional; defaults to https://app.asana.com/api/1.0
+	Workspace          string       // Workspace GID
+	Team               string       // Team GID
+	Project            string       // Project GID
+	IncludeAttachments bool
+	AttachmentMaxBytes int64        // Default 50MB
+	RatePerSec         float64      // Default 10.0
+	SubtaskDepth       int          // Default 8
+	Concurrency        int          // Workers processing tasks within a project; default 5; clamped to [1, 100]
+	HTTPClient         *http.Client // Default 60s timeout
+	Verbose            io.Writer    // When non-nil, progress messages are written here
+	Config                          // Embedded base Config
+}
+
+// AsanaEnumerator enumerates content from Asana via the REST API.
+type AsanaEnumerator struct {
+	client *asanaClient
+	cfg    AsanaConfig
+	logMu  sync.Mutex
+	seenMu sync.Mutex
+	seen   map[string]struct{}
+}
+
+// NewAsanaEnumerator creates and validates an Asana enumerator.
+func NewAsanaEnumerator(cfg AsanaConfig) (*AsanaEnumerator, error) {
+	if cfg.Token == "" {
+		return nil, fmt.Errorf("asana token is required")
+	}
+
+	baseURL := "https://app.asana.com/api/1.0"
+	if cfg.BaseURL != "" {
+		if _, err := ValidateBaseURL(cfg.BaseURL); err != nil {
+			return nil, fmt.Errorf("asana base URL: %w", err)
+		}
+		baseURL = strings.TrimRight(cfg.BaseURL, "/")
+	}
+
+	if cfg.AttachmentMaxBytes <= 0 {
+		cfg.AttachmentMaxBytes = 50 * 1024 * 1024
+	}
+	if cfg.RatePerSec <= 0 {
+		cfg.RatePerSec = 10.0
+	}
+	if cfg.SubtaskDepth <= 0 {
+		cfg.SubtaskDepth = 8
+	}
+	if cfg.Concurrency <= 0 {
+		cfg.Concurrency = 5
+	}
+	if cfg.Concurrency > 100 {
+		cfg.Concurrency = 100
+	}
+	if cfg.HTTPClient == nil {
+		cfg.HTTPClient = &http.Client{Timeout: 60 * time.Second}
+	}
+
+	c := &asanaClient{
+		token:      cfg.Token,
+		baseURL:    baseURL,
+		httpClient: cfg.HTTPClient,
+		limiter:    rate.NewLimiter(rate.Limit(cfg.RatePerSec), 1),
+	}
+
+	return &AsanaEnumerator{client: c, cfg: cfg}, nil
+}
+
+// logf writes a progress message when verbose output is enabled.
+// It is safe to call concurrently.
+func (e *AsanaEnumerator) logf(format string, args ...interface{}) {
+	if e.cfg.Verbose != nil {
+		e.logMu.Lock()
+		_, _ = fmt.Fprintf(e.cfg.Verbose, format+"\n", args...)
+		e.logMu.Unlock()
+	}
+}
+
+// markSeen records a task GID as scanned this run. Returns true if the GID
+// is new (caller should proceed), false if it was already scanned (caller
+// should skip). Safe for concurrent use.
+func (e *AsanaEnumerator) markSeen(gid string) bool {
+	e.seenMu.Lock()
+	defer e.seenMu.Unlock()
+	if e.seen == nil {
+		e.seen = make(map[string]struct{})
+	}
+	if _, ok := e.seen[gid]; ok {
+		return false
+	}
+	e.seen[gid] = struct{}{}
+	return true
+}
+
+// Enumerate walks Asana resources and yields content blobs.
+// When no scope is configured (no workspace/team/project), every workspace
+// visible to the PAT is discovered and enumerated in turn.
+func (e *AsanaEnumerator) Enumerate(ctx context.Context, cb func(content []byte, blobID types.BlobID, prov types.Provenance) error) error {
+	e.seenMu.Lock()
+	e.seen = make(map[string]struct{})
+	e.seenMu.Unlock()
+
+	var cbMu sync.Mutex
+	safeCb := func(content []byte, id types.BlobID, prov types.Provenance) error {
+		cbMu.Lock()
+		defer cbMu.Unlock()
+		return cb(content, id, prov)
+	}
+
+	if e.cfg.Workspace == "" && e.cfg.Team == "" && e.cfg.Project == "" {
+		// Workspaces are bounded (a token typically sees < 10), so it's safe to
+		// collect them up-front. Tasks/subtasks/stories MUST stream — see paginate.
+		var workspaces []asanaWorkspace
+		if err := e.client.paginate(ctx, "/workspaces", url.Values{"opt_fields": []string{"name"}}, func(raw json.RawMessage) error {
+			var page []asanaWorkspace
+			if err := json.Unmarshal(raw, &page); err != nil {
+				return err
+			}
+			workspaces = append(workspaces, page...)
+			return nil
+		}); err != nil {
+			return fmt.Errorf("listing workspaces: %w", err)
+		}
+		e.logf("Discovered %d workspaces visible to token", len(workspaces))
+		for _, ws := range workspaces {
+			if err := e.enumerateWorkspace(ctx, ws.GID, safeCb); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	workspaceGID, err := e.resolveWorkspaceGID(ctx)
+	if err != nil {
+		return err
+	}
+	return e.enumerateWorkspace(ctx, workspaceGID, safeCb)
+}
+
+// enumerateWorkspace scans a single workspace by GID.
+func (e *AsanaEnumerator) enumerateWorkspace(ctx context.Context, workspaceGID string, cb func(content []byte, blobID types.BlobID, prov types.Provenance) error) error {
+	var ws asanaWorkspace
+	if err := e.client.get(ctx, "/workspaces/"+workspaceGID, nil, &ws); err != nil {
+		return fmt.Errorf("fetching workspace: %w", err)
+	}
+	e.logf("Entering workspace %q (gid=%s)", ws.Name, workspaceGID)
+
+	var teamCount int
+	// Teams and goals - skip when scoped to a single project
+	if e.cfg.Project == "" {
+		n, err := e.enumerateTeams(ctx, workspaceGID, cb)
+		if err != nil {
+			return err
+		}
+		teamCount = n
+		// Goals - soft-fail: some workspaces don't have goals enabled
+		if err := e.enumerateGoals(ctx, workspaceGID, cb); err != nil {
+			e.logf("Warning: goals: %v", err)
+		}
+	}
+
+	projectCount, err := e.enumerateProjects(ctx, workspaceGID, cb)
+	if err != nil {
+		return err
+	}
+
+	e.logf("Workspace %q: %d teams, %d projects", ws.Name, teamCount, projectCount)
+	return nil
+}
+
+// resolveWorkspaceGID derives the workspace GID from config.
+func (e *AsanaEnumerator) resolveWorkspaceGID(ctx context.Context) (string, error) {
+	if e.cfg.Workspace != "" {
+		return e.cfg.Workspace, nil
+	}
+
+	if e.cfg.Project != "" {
+		var proj struct {
+			GID       string `json:"gid"`
+			Workspace struct {
+				GID  string `json:"gid"`
+				Name string `json:"name"`
+			} `json:"workspace"`
+		}
+		params := url.Values{"opt_fields": []string{"workspace.name"}}
+		if err := e.client.get(ctx, "/projects/"+e.cfg.Project, params, &proj); err != nil {
+			return "", fmt.Errorf("fetching project to resolve workspace: %w", err)
+		}
+		return proj.Workspace.GID, nil
+	}
+
+	// Team path
+	var team struct {
+		GID          string `json:"gid"`
+		Organization struct {
+			GID  string `json:"gid"`
+			Name string `json:"name"`
+		} `json:"organization"`
+	}
+	params := url.Values{"opt_fields": []string{"organization.name"}}
+	if err := e.client.get(ctx, "/teams/"+e.cfg.Team, params, &team); err != nil {
+		return "", fmt.Errorf("fetching team to resolve workspace: %w", err)
+	}
+	return team.Organization.GID, nil
+}
+
+// asanaWorkspace holds the minimal workspace fields we need.
+type asanaWorkspace struct {
+	GID  string `json:"gid"`
+	Name string `json:"name"`
+}
+
+// asanaTeam holds the minimal team fields we scan.
+type asanaTeam struct {
+	GID         string `json:"gid"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+func (e *AsanaEnumerator) enumerateTeams(ctx context.Context, workspaceGID string, cb func([]byte, types.BlobID, types.Provenance) error) (int, error) {
+	params := url.Values{"opt_fields": []string{"name,description"}}
+
+	if e.cfg.Team != "" {
+		var t asanaTeam
+		if err := e.client.get(ctx, "/teams/"+e.cfg.Team, params, &t); err != nil {
+			return 0, fmt.Errorf("fetching team: %w", err)
+		}
+		if err := ctx.Err(); err != nil {
+			return 0, err
+		}
+		if err := e.emitText(t.Description, workspaceGID, "", "team", t.GID, "description", "", cb); err != nil {
+			return 0, err
+		}
+		return 1, nil
+	}
+
+	var count int
+	if err := e.client.paginate(ctx, "/workspaces/"+workspaceGID+"/teams", params, func(raw json.RawMessage) error {
+		var page []asanaTeam
+		if err := json.Unmarshal(raw, &page); err != nil {
+			return err
+		}
+		for _, t := range page {
+			count++
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if err := e.emitText(t.Description, workspaceGID, "", "team", t.GID, "description", "", cb); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		return 0, fmt.Errorf("listing teams: %w", err)
+	}
+	return count, nil
+}
+
+// asanaProject holds the minimal project fields we scan.
+type asanaProject struct {
+	GID          string `json:"gid"`
+	Name         string `json:"name"`
+	Notes        string `json:"notes"`
+	HTMLNotes    string `json:"html_notes"`
+	PermalinkURL string `json:"permalink_url"`
+	Brief        *struct {
+		GID string `json:"gid"`
+	} `json:"brief"`
+}
+
+// asanaProjectBrief holds the rich-text brief attached to a project.
+type asanaProjectBrief struct {
+	GID      string `json:"gid"`
+	Title    string `json:"title"`
+	Text     string `json:"text"`
+	HTMLText string `json:"html_text"`
+}
+
+// asanaCustomField is one custom field on a task.
+type asanaCustomField struct {
+	GID       string `json:"gid"`
+	Name      string `json:"name"`
+	Type      string `json:"type"`       // "text", "number", "enum", etc.
+	TextValue string `json:"text_value"` // populated only when Type=="text"
+}
+
+// asanaTask holds the minimal task fields we scan.
+type asanaTask struct {
+	GID          string             `json:"gid"`
+	Name         string             `json:"name"`
+	Notes        string             `json:"notes"`
+	HTMLNotes    string             `json:"html_notes"`
+	PermalinkURL string             `json:"permalink_url"`
+	CustomFields []asanaCustomField `json:"custom_fields"`
+	External     *struct {
+		Data string `json:"data"`
+	} `json:"external"`
+}
+
+func (e *AsanaEnumerator) enumerateProjects(ctx context.Context, workspaceGID string, cb func([]byte, types.BlobID, types.Provenance) error) (int, error) {
+	params := url.Values{"opt_fields": []string{"name,notes,html_notes,permalink_url,brief.gid"}}
+
+	switch {
+	case e.cfg.Project != "":
+		var p asanaProject
+		if err := e.client.get(ctx, "/projects/"+e.cfg.Project, params, &p); err != nil {
+			return 0, fmt.Errorf("fetching project: %w", err)
+		}
+		e.logf("Entering project %q (gid=%s)", p.Name, p.GID)
+		tasksScanned, err := e.enumerateProject(ctx, workspaceGID, p, cb)
+		if err != nil {
+			return 0, err
+		}
+		e.logf("Project %q: %d tasks", p.Name, tasksScanned)
+		return 1, nil
+
+	case e.cfg.Team != "":
+		var count int
+		if err := e.client.paginate(ctx, "/teams/"+e.cfg.Team+"/projects", params, func(raw json.RawMessage) error {
+			return e.processProjectsPage(ctx, workspaceGID, raw, &count, cb)
+		}); err != nil {
+			return 0, fmt.Errorf("listing team projects: %w", err)
+		}
+		return count, nil
+
+	default:
+		var count int
+		if err := e.client.paginate(ctx, "/workspaces/"+workspaceGID+"/projects", params, func(raw json.RawMessage) error {
+			return e.processProjectsPage(ctx, workspaceGID, raw, &count, cb)
+		}); err != nil {
+			return 0, fmt.Errorf("listing workspace projects: %w", err)
+		}
+		return count, nil
+	}
+}
+
+// processProjectsPage handles one page of project listings — counts, logs,
+// and recurses into each project. Used by both team-mode and workspace-mode
+// enumeration paths.
+func (e *AsanaEnumerator) processProjectsPage(ctx context.Context, workspaceGID string, raw json.RawMessage, count *int, cb func([]byte, types.BlobID, types.Provenance) error) error {
+	var page []asanaProject
+	if err := json.Unmarshal(raw, &page); err != nil {
+		return err
+	}
+	for _, p := range page {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		*count++
+		e.logf("Entering project %q (gid=%s)", p.Name, p.GID)
+		tasksScanned, err := e.enumerateProject(ctx, workspaceGID, p, cb)
+		if err != nil {
+			return err
+		}
+		e.logf("Project %q: %d tasks", p.Name, tasksScanned)
+	}
+	return nil
+}
+
+func (e *AsanaEnumerator) enumerateProject(ctx context.Context, workspaceGID string, p asanaProject, cb func([]byte, types.BlobID, types.Provenance) error) (int, error) {
+	if err := e.emitText(p.Notes, workspaceGID, p.PermalinkURL, "project", p.GID, "notes", "", cb); err != nil {
+		return 0, err
+	}
+	if err := e.emitText(p.HTMLNotes, workspaceGID, p.PermalinkURL, "project", p.GID, "html_notes", "", cb); err != nil {
+		return 0, err
+	}
+
+	// Project brief - soft-fail: some projects 403 if user can't see the brief
+	if p.Brief != nil && p.Brief.GID != "" {
+		if err := e.enumerateProjectBrief(ctx, workspaceGID, p.GID, p.Brief.GID, p.PermalinkURL, cb); err != nil {
+			e.logf("Warning: project %s brief %s: %v", p.GID, p.Brief.GID, err)
+		}
+	}
+
+	// Project statuses - soft-fail: some projects 404 this endpoint
+	if err := e.enumerateProjectStatuses(ctx, workspaceGID, p.GID, cb); err != nil {
+		e.logf("Warning: project %s statuses: %v", p.GID, err)
+	}
+
+	// Task templates - soft-fail: not available on all Asana tiers
+	if err := e.enumerateTaskTemplates(ctx, workspaceGID, p.GID, p.PermalinkURL, cb); err != nil {
+		e.logf("Warning: project %s task templates: %v", p.GID, err)
+	}
+
+	return e.enumerateTasks(ctx, workspaceGID, p.GID, cb)
+}
+
+func (e *AsanaEnumerator) enumerateProjectBrief(ctx context.Context, workspaceGID, projectGID, briefGID, projectPermalink string, cb func([]byte, types.BlobID, types.Provenance) error) error {
+	var brief asanaProjectBrief
+	params := url.Values{"opt_fields": []string{"text,html_text"}}
+	if err := e.client.get(ctx, "/project_briefs/"+briefGID, params, &brief); err != nil {
+		return err
+	}
+	if err := e.emitText(brief.Text, workspaceGID, projectPermalink, "project_brief", briefGID, "text", projectGID, cb); err != nil {
+		return err
+	}
+	return e.emitText(brief.HTMLText, workspaceGID, projectPermalink, "project_brief", briefGID, "html_text", projectGID, cb)
+}
+
+// asanaGoal holds the minimal goal fields we scan.
+type asanaGoal struct {
+	GID          string `json:"gid"`
+	Name         string `json:"name"`
+	Notes        string `json:"notes"`
+	HTMLNotes    string `json:"html_notes"`
+	PermalinkURL string `json:"permalink_url"`
+}
+
+func (e *AsanaEnumerator) enumerateGoals(ctx context.Context, workspaceGID string, cb func([]byte, types.BlobID, types.Provenance) error) error {
+	params := url.Values{"opt_fields": []string{"name,notes,html_notes,permalink_url"}}
+	if e.cfg.Team != "" {
+		params.Set("team", e.cfg.Team)
+	} else {
+		params.Set("workspace", workspaceGID)
+	}
+	return e.client.paginate(ctx, "/goals", params, func(raw json.RawMessage) error {
+		var page []asanaGoal
+		if err := json.Unmarshal(raw, &page); err != nil {
+			return err
+		}
+		for _, g := range page {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if err := e.emitText(g.Name, workspaceGID, g.PermalinkURL, "goal", g.GID, "name", "", cb); err != nil {
+				return err
+			}
+			if err := e.emitText(g.Notes, workspaceGID, g.PermalinkURL, "goal", g.GID, "notes", "", cb); err != nil {
+				return err
+			}
+			if err := e.emitText(g.HTMLNotes, workspaceGID, g.PermalinkURL, "goal", g.GID, "html_notes", "", cb); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// asanaTaskTemplate holds the minimal task template fields we scan.
+type asanaTaskTemplate struct {
+	GID  string `json:"gid"`
+	Name string `json:"name"`
+}
+
+func (e *AsanaEnumerator) enumerateTaskTemplates(ctx context.Context, workspaceGID, projectGID, projectPermalink string, cb func([]byte, types.BlobID, types.Provenance) error) error {
+	params := url.Values{
+		"project":    []string{projectGID},
+		"opt_fields": []string{"name"},
+	}
+	return e.client.paginate(ctx, "/task_templates", params, func(raw json.RawMessage) error {
+		var page []asanaTaskTemplate
+		if err := json.Unmarshal(raw, &page); err != nil {
+			return err
+		}
+		for _, tmpl := range page {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if err := e.emitText(tmpl.Name, workspaceGID, projectPermalink, "task_template", tmpl.GID, "name", projectGID, cb); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// asanaProjectStatus holds the minimal status fields we scan.
+type asanaProjectStatus struct {
+	GID      string `json:"gid"`
+	Title    string `json:"title"`
+	Text     string `json:"text"`
+	HTMLText string `json:"html_text"`
+}
+
+func (e *AsanaEnumerator) enumerateProjectStatuses(ctx context.Context, workspaceGID, projectGID string, cb func([]byte, types.BlobID, types.Provenance) error) error {
+	params := url.Values{"opt_fields": []string{"title,text,html_text"}}
+	return e.client.paginate(ctx, "/projects/"+projectGID+"/project_statuses", params, func(raw json.RawMessage) error {
+		var page []asanaProjectStatus
+		if err := json.Unmarshal(raw, &page); err != nil {
+			return err
+		}
+		for _, st := range page {
+			if err := e.emitText(st.Title, workspaceGID, "", "project_status", st.GID, "title", "", cb); err != nil {
+				return err
+			}
+			if err := e.emitText(st.Text, workspaceGID, "", "project_status", st.GID, "text", "", cb); err != nil {
+				return err
+			}
+			if err := e.emitText(st.HTMLText, workspaceGID, "", "project_status", st.GID, "html_text", "", cb); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func (e *AsanaEnumerator) enumerateTasks(ctx context.Context, workspaceGID, projectGID string, cb func([]byte, types.BlobID, types.Provenance) error) (int, error) {
+	params := url.Values{"opt_fields": []string{"name,notes,html_notes,permalink_url,custom_fields.name,custom_fields.text_value,custom_fields.type,custom_fields.gid,external.data"}}
+
+	concurrency := e.cfg.Concurrency
+	if concurrency <= 0 {
+		concurrency = 5
+	}
+
+	taskCh := make(chan asanaTask, 2*concurrency)
+
+	var firstErr error
+	var errOnce sync.Once
+	setErr := func(err error) { errOnce.Do(func() { firstErr = err }) }
+
+	// Producer: paginate tasks into taskCh.
+	var producerWg sync.WaitGroup
+	producerWg.Add(1)
+	go func() {
+		defer producerWg.Done()
+		defer close(taskCh)
+		if err := e.client.paginate(ctx, "/projects/"+projectGID+"/tasks", params, func(raw json.RawMessage) error {
+			if firstErr != nil {
+				return firstErr
+			}
+			var page []asanaTask
+			if err := json.Unmarshal(raw, &page); err != nil {
+				return err
+			}
+			for _, t := range page {
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+				if firstErr != nil {
+					return firstErr
+				}
+				taskCh <- t
+			}
+			return nil
+		}); err != nil {
+			setErr(fmt.Errorf("listing tasks for project %s: %w", projectGID, err))
+		}
+	}()
+
+	// Workers: consume tasks from taskCh.
+	var taskCount int64
+	var workerWg sync.WaitGroup
+	for i := 0; i < concurrency; i++ {
+		workerWg.Add(1)
+		go func() {
+			defer workerWg.Done()
+			for t := range taskCh {
+				if ctx.Err() != nil {
+					return
+				}
+				if firstErr != nil {
+					return
+				}
+				e.logf("Processing task %q (gid=%s)", truncateForLog(t.Name, 80), t.GID)
+				if err := e.enumerateTask(ctx, workspaceGID, t, 0, cb); err != nil {
+					setErr(err)
+					return
+				}
+				atomic.AddInt64(&taskCount, 1)
+			}
+		}()
+	}
+
+	producerWg.Wait()
+	workerWg.Wait()
+
+	return int(atomic.LoadInt64(&taskCount)), firstErr
+}
+
+func (e *AsanaEnumerator) enumerateTask(ctx context.Context, workspaceGID string, t asanaTask, depth int, cb func([]byte, types.BlobID, types.Provenance) error) error {
+	if !e.markSeen(t.GID) {
+		e.logf("Skipping task %q (gid=%s): already scanned this run", truncateForLog(t.Name, 80), t.GID)
+		return nil
+	}
+	if err := e.emitText(t.Name, workspaceGID, t.PermalinkURL, "task", t.GID, "name", "", cb); err != nil {
+		return err
+	}
+	if err := e.emitText(t.Notes, workspaceGID, t.PermalinkURL, "task", t.GID, "notes", "", cb); err != nil {
+		return err
+	}
+	if err := e.emitText(t.HTMLNotes, workspaceGID, t.PermalinkURL, "task", t.GID, "html_notes", "", cb); err != nil {
+		return err
+	}
+
+	// Emit external integration data
+	if t.External != nil && t.External.Data != "" {
+		if err := e.emitText(t.External.Data, workspaceGID, t.PermalinkURL, "task_external", t.GID, "data", "", cb); err != nil {
+			return err
+		}
+	}
+
+	// Emit text custom fields
+	for _, cf := range t.CustomFields {
+		if cf.Type != "text" || strings.TrimSpace(cf.TextValue) == "" {
+			continue
+		}
+		fieldName := strings.TrimSpace(cf.Name)
+		if fieldName == "" {
+			fieldName = cf.GID
+		}
+		if err := e.emitText(cf.TextValue, workspaceGID, t.PermalinkURL, "custom_field", cf.GID, fieldName, t.GID, cb); err != nil {
+			return err
+		}
+	}
+
+	if err := e.listAndEmitStories(ctx, workspaceGID, t, cb); err != nil {
+		return err
+	}
+
+	if depth < e.cfg.SubtaskDepth {
+		if err := e.enumerateSubtasks(ctx, workspaceGID, t.GID, depth, cb); err != nil {
+			e.logf("Warning: subtasks for task %s: %v", t.GID, err)
+		}
+	}
+
+	if e.cfg.IncludeAttachments {
+		if err := e.enumerateAttachments(ctx, workspaceGID, t.GID, cb); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// listAndEmitStories streams stories for a task and emits comment stories.
+func (e *AsanaEnumerator) listAndEmitStories(ctx context.Context, workspaceGID string, t asanaTask, cb func([]byte, types.BlobID, types.Provenance) error) error {
+	params := url.Values{"opt_fields": []string{"text,type"}}
+	if err := e.client.paginate(ctx, "/tasks/"+t.GID+"/stories", params, func(raw json.RawMessage) error {
+		var page []asanaStory
+		if err := json.Unmarshal(raw, &page); err != nil {
+			return err
+		}
+		for _, s := range page {
+			if s.Type != "comment" {
+				continue // skip system stories (noise)
+			}
+			storyPath := t.PermalinkURL
+			if storyPath == "" {
+				storyPath = fmt.Sprintf("asana://story/%s", s.GID)
+			}
+			prov := types.ExtendedProvenance{Payload: map[string]interface{}{
+				"source":     "asana",
+				"workspace":  workspaceGID,
+				"resource":   "story",
+				"gid":        s.GID,
+				"field":      "text",
+				"parent_gid": t.GID,
+				"permalink":  t.PermalinkURL,
+				"path":       storyPath,
+			}}
+			if err := emitWithProv(s.Text, prov, cb); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("listing stories for task %s: %w", t.GID, err)
+	}
+	return nil
+}
+
+func (e *AsanaEnumerator) enumerateSubtasks(ctx context.Context, workspaceGID, taskGID string, depth int, cb func([]byte, types.BlobID, types.Provenance) error) error {
+	params := url.Values{"opt_fields": []string{"name,notes,html_notes,permalink_url,custom_fields.name,custom_fields.text_value,custom_fields.type,custom_fields.gid,external.data"}}
+	return e.client.paginate(ctx, "/tasks/"+taskGID+"/subtasks", params, func(raw json.RawMessage) error {
+		var page []asanaTask
+		if err := json.Unmarshal(raw, &page); err != nil {
+			return err
+		}
+		for _, st := range page {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if err := e.enumerateTask(ctx, workspaceGID, st, depth+1, cb); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// asanaAttachment holds the minimal attachment fields we need.
+type asanaAttachment struct {
+	GID         string `json:"gid"`
+	Name        string `json:"name"`
+	Host        string `json:"host"`
+	DownloadURL string `json:"download_url"`
+}
+
+func (e *AsanaEnumerator) enumerateAttachments(ctx context.Context, workspaceGID, taskGID string, cb func([]byte, types.BlobID, types.Provenance) error) error {
+	params := url.Values{"opt_fields": []string{"name,host,download_url"}}
+	return e.client.paginate(ctx, "/tasks/"+taskGID+"/attachments", params, func(raw json.RawMessage) error {
+		var page []asanaAttachment
+		if err := json.Unmarshal(raw, &page); err != nil {
+			return err
+		}
+		for _, att := range page {
+			if att.Host != "asana" {
+				continue // external attachments (gdrive/box/dropbox) not proxied by Asana
+			}
+			if asanaSkipAttachmentExt(att.Name) {
+				continue
+			}
+			content, err := e.client.downloadRaw(ctx, att.DownloadURL, e.cfg.AttachmentMaxBytes)
+			if err != nil {
+				e.logf("Warning: download attachment %q: %v", att.Name, err)
+				continue // soft-fail individual download errors
+			}
+
+			if int64(len(content)) > e.cfg.AttachmentMaxBytes {
+				e.logf("Skipping attachment %q: exceeded max size (%d bytes)", att.Name, e.cfg.AttachmentMaxBytes)
+				continue
+			}
+
+			if isBinary(content) {
+				// Binary attachment: extract text from supported archive/document formats
+				// when the user has opted into extraction via --extract. Never emit raw
+				// binary to the matcher — regexp2 NFA blows up on rune-decoded binary
+				// content.
+				if e.cfg.ExtractArchives == "" {
+					continue
+				}
+				ext := getExtension(att.Name)
+				if !shouldExtract(e.cfg.Config, ext) {
+					continue
+				}
+				extractLimits := e.cfg.ExtractLimits
+				if extractLimits.MaxSize == 0 && extractLimits.MaxTotal == 0 {
+					extractLimits = DefaultExtractionLimits()
+				}
+				extracted, err := ExtractText(att.Name, content, extractLimits)
+				if err != nil {
+					continue
+				}
+				for _, ec := range extracted {
+					if len(ec.Content) == 0 {
+						continue
+					}
+					extProv := types.ExtendedProvenance{Payload: map[string]interface{}{
+						"source":          "asana",
+						"workspace":       workspaceGID,
+						"resource":        "attachment_extracted",
+						"gid":             att.GID,
+						"field":           "content",
+						"parent_gid":      taskGID,
+						"attachment":      att.Name,
+						"extracted_entry": ec.Name,
+						"path":            fmt.Sprintf("asana://attachment/%s/%s", taskGID, att.GID),
+					}}
+					if err := emitWithProv(string(ec.Content), extProv, cb); err != nil {
+						return err
+					}
+				}
+				continue
+			}
+
+			// Plain text attachment — emit raw bytes.
+			rawProv := types.ExtendedProvenance{Payload: map[string]interface{}{
+				"source":     "asana",
+				"workspace":  workspaceGID,
+				"resource":   "attachment",
+				"gid":        att.GID,
+				"field":      "content",
+				"parent_gid": taskGID,
+				"attachment": att.Name,
+				"path":       fmt.Sprintf("asana://attachment/%s/%s", taskGID, att.GID),
+			}}
+			if err := emitWithProv(string(content), rawProv, cb); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// emitText yields a non-empty text field as a blob with standard Asana provenance.
+func emitText(text, workspaceGID, permalink, resource, gid, field, parentGID string, cb func([]byte, types.BlobID, types.Provenance) error) error {
+	if strings.TrimSpace(text) == "" {
+		return nil
+	}
+	path := permalink
+	if path == "" {
+		path = fmt.Sprintf("asana://%s/%s", resource, gid)
+	}
+	payload := map[string]interface{}{
+		"source":    "asana",
+		"workspace": workspaceGID,
+		"resource":  resource,
+		"gid":       gid,
+		"field":     field,
+		"permalink": permalink,
+		"path":      path,
+	}
+	if parentGID != "" {
+		payload["parent_gid"] = parentGID
+	}
+	return emitWithProv(text, types.ExtendedProvenance{Payload: payload}, cb)
+}
+
+// emitText is the method form of the free function emitText. It enforces
+// MaxFileSize for task-content blobs (notes, comments, custom fields, etc.)
+// before delegating to the free function. MaxFileSize=0 means unlimited.
+func (e *AsanaEnumerator) emitText(text, workspaceGID, permalink, resource, gid, field, parentGID string, cb func([]byte, types.BlobID, types.Provenance) error) error {
+	if e.cfg.MaxFileSize > 0 && int64(len(text)) > e.cfg.MaxFileSize {
+		e.logf("Skipping %s field %q: exceeds max size (%d bytes)", resource, field, e.cfg.MaxFileSize)
+		return nil
+	}
+	return emitText(text, workspaceGID, permalink, resource, gid, field, parentGID, cb)
+}
+
+// emitWithProv yields non-empty text content with a pre-built provenance.
+func emitWithProv(text string, prov types.Provenance, cb func([]byte, types.BlobID, types.Provenance) error) error {
+	if strings.TrimSpace(text) == "" {
+		return nil
+	}
+	content := []byte(text)
+	return cb(content, types.ComputeBlobID(content), prov)
+}
+
+// ─── HTTP client ──────────────────────────────────────────────────────────────
+
+type asanaClient struct {
+	token      string
+	baseURL    string
+	httpClient *http.Client
+	limiter    *rate.Limiter
+}
+
+// asanaEnvelope is the outer JSON wrapper for all Asana API responses.
+type asanaEnvelope struct {
+	Data     json.RawMessage `json:"data"`
+	NextPage *struct {
+		Offset string `json:"offset"`
+	} `json:"next_page"`
+}
+
+// get fetches a single resource and decodes its "data" field into out.
+func (c *asanaClient) get(ctx context.Context, path string, params url.Values, out interface{}) error {
+	raw, err := c.doRequest(ctx, c.baseURL+path, params)
+	if err != nil {
+		return err
+	}
+
+	var env asanaEnvelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+	return json.Unmarshal(env.Data, out)
+}
+
+// paginate calls onPage for each page of results. Callers MUST process items
+// inside the callback — accumulating into a slice causes memory exhaustion on
+// large tenants (subtask recursion compounds).
+func (c *asanaClient) paginate(ctx context.Context, path string, params url.Values, onPage func(json.RawMessage) error) error {
+	p := make(url.Values)
+	for k, v := range params {
+		p[k] = v
+	}
+	p.Set("limit", "100")
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		raw, err := c.doRequest(ctx, c.baseURL+path, p)
+		if err != nil {
+			return err
+		}
+
+		var env asanaEnvelope
+		if err := json.Unmarshal(raw, &env); err != nil {
+			return fmt.Errorf("decoding page: %w", err)
+		}
+
+		if err := onPage(env.Data); err != nil {
+			return err
+		}
+
+		if env.NextPage == nil || env.NextPage.Offset == "" {
+			break
+		}
+		p.Set("offset", env.NextPage.Offset)
+	}
+	return nil
+}
+
+// downloadRaw fetches a presigned S3 URL without the Asana Bearer token.
+// The download_url is a temporary presigned S3 URL - sending the Bearer header
+// would leak the Asana token to AWS.
+func (c *asanaClient) downloadRaw(ctx context.Context, downloadURL string, maxBytes int64) ([]byte, error) {
+	if err := c.limiter.Wait(ctx); err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("attachment download: HTTP %d", resp.StatusCode)
+	}
+
+	return io.ReadAll(io.LimitReader(resp.Body, maxBytes+1))
+}
+
+// retryDelay returns the sleep duration before the next attempt.
+// If retryAfterHeader parses to a positive integer of seconds, that value
+// (capped at maxBackoff) is returned. Otherwise exponential backoff with
+// jitter is used: min(2^attempt * asanaBaseBackoff + jitter, maxBackoff).
+func retryDelay(attempt int, retryAfterHeader string, maxBackoff time.Duration) time.Duration {
+	if secs, err := strconv.Atoi(retryAfterHeader); err == nil && secs > 0 {
+		d := time.Duration(secs) * time.Second
+		if d > maxBackoff {
+			return maxBackoff
+		}
+		return d
+	}
+	// #nosec G115 -- attempt is bounded by asanaMaxRetries (5); shift is safe.
+	exp := time.Duration(1<<uint(attempt)) * asanaBaseBackoff
+	// #nosec G404 -- jitter for retry backoff; cryptographic randomness unnecessary.
+	jitter := time.Duration(rand.Int63n(int64(time.Second)))
+	d := exp + jitter
+	if d > maxBackoff {
+		return maxBackoff
+	}
+	return d
+}
+
+// doRequest executes an authenticated GET, retrying on 429 and transient 5xx
+// errors (500, 502, 503, 504) up to asanaMaxRetries times with exponential
+// backoff and jitter. Retry-After is honoured on both 429 and 5xx responses.
+func (c *asanaClient) doRequest(ctx context.Context, rawURL string, params url.Values) ([]byte, error) {
+	for attempt := 0; attempt < asanaMaxRetries; attempt++ {
+		if err := c.limiter.Wait(ctx); err != nil {
+			return nil, err
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Authorization", "Bearer "+c.token)
+		if len(params) > 0 {
+			req.URL.RawQuery = params.Encode()
+		}
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			return nil, err
+		}
+
+		body, readErr := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if readErr != nil {
+			return nil, fmt.Errorf("reading response: %w", readErr)
+		}
+
+		switch resp.StatusCode {
+		case http.StatusTooManyRequests,
+			http.StatusInternalServerError,
+			http.StatusBadGateway,
+			http.StatusServiceUnavailable,
+			http.StatusGatewayTimeout:
+			if attempt == asanaMaxRetries-1 {
+				return nil, fmt.Errorf("HTTP %d: request failed after %d attempts", resp.StatusCode, asanaMaxRetries)
+			}
+			wait := retryDelay(attempt, resp.Header.Get("Retry-After"), asanaMaxBackoff)
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(wait):
+			}
+			continue
+		}
+
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			trimmed := strings.TrimSpace(string(body))
+			if len(trimmed) > 200 {
+				trimmed = trimmed[:200]
+			}
+			return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, trimmed)
+		}
+
+		return body, nil
+	}
+
+	return nil, fmt.Errorf("request failed after %d attempts", asanaMaxRetries)
+}
+
+// asanaStory is a task comment or system event.
+type asanaStory struct {
+	GID  string `json:"gid"`
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// truncateForLog clips long strings (e.g. task names) for log readability.
+func truncateForLog(s string, max int) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	if len(s) <= max {
+		return s
+	}
+	return s[:max-1] + "…"
+}

--- a/pkg/enum/asana.go
+++ b/pkg/enum/asana.go
@@ -645,7 +645,7 @@ func (e *AsanaEnumerator) enumerateTask(ctx context.Context, workspaceGID string
 	}
 
 	if e.cfg.IncludeAttachments {
-		if err := e.enumerateAttachments(ctx, workspaceGID, t.GID, cb); err != nil {
+		if err := e.enumerateAttachments(ctx, workspaceGID, t.GID, t.PermalinkURL, cb); err != nil {
 			return err
 		}
 	}
@@ -717,7 +717,7 @@ type asanaAttachment struct {
 	DownloadURL string `json:"download_url"`
 }
 
-func (e *AsanaEnumerator) enumerateAttachments(ctx context.Context, workspaceGID, taskGID string, cb func([]byte, types.BlobID, types.Provenance) error) error {
+func (e *AsanaEnumerator) enumerateAttachments(ctx context.Context, workspaceGID, taskGID, taskPermalink string, cb func([]byte, types.BlobID, types.Provenance) error) error {
 	params := url.Values{"opt_fields": []string{"name,host,download_url"}}
 	return e.client.paginate(ctx, "/tasks/"+taskGID+"/attachments", params, func(raw json.RawMessage) error {
 		var page []asanaAttachment
@@ -775,6 +775,7 @@ func (e *AsanaEnumerator) enumerateAttachments(ctx context.Context, workspaceGID
 						"parent_gid":      taskGID,
 						"attachment":      att.Name,
 						"extracted_entry": ec.Name,
+						"permalink":       taskPermalink,
 						"path":            fmt.Sprintf("asana://attachment/%s/%s", taskGID, att.GID),
 					}}
 					if err := emitWithProv(string(ec.Content), extProv, cb); err != nil {
@@ -793,6 +794,7 @@ func (e *AsanaEnumerator) enumerateAttachments(ctx context.Context, workspaceGID
 				"field":      "content",
 				"parent_gid": taskGID,
 				"attachment": att.Name,
+				"permalink":  taskPermalink,
 				"path":       fmt.Sprintf("asana://attachment/%s/%s", taskGID, att.GID),
 			}}
 			if err := emitWithProv(string(content), rawProv, cb); err != nil {

--- a/pkg/enum/asana_attachment_filter.go
+++ b/pkg/enum/asana_attachment_filter.go
@@ -1,0 +1,36 @@
+package enum
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// asanaSkipAttachmentExt returns true if the file extension is in a hard-coded
+// skip list of media/binary types that essentially never contain secrets.
+// Used to avoid downloading large media attachments from Asana, since the
+// Asana API does not expose a mime_type field on the attachment resource.
+func asanaSkipAttachmentExt(name string) bool {
+	ext := strings.ToLower(strings.TrimPrefix(filepath.Ext(name), "."))
+	if ext == "" {
+		return false
+	}
+	_, skip := asanaSkipExtensions[ext]
+	return skip
+}
+
+var asanaSkipExtensions = map[string]struct{}{
+	// images
+	"png": {}, "jpg": {}, "jpeg": {}, "gif": {}, "bmp": {}, "webp": {},
+	"ico": {}, "tif": {}, "tiff": {}, "heic": {}, "heif": {},
+	"psd": {}, "ai": {}, "sketch": {}, "fig": {}, "xd": {},
+	// audio
+	"mp3": {}, "wav": {}, "flac": {}, "ogg": {}, "m4a": {}, "aac": {},
+	"wma": {}, "opus": {},
+	// video
+	"mp4": {}, "mov": {}, "avi": {}, "mkv": {}, "webm": {}, "m4v": {},
+	"wmv": {}, "flv": {}, "mpeg": {}, "mpg": {}, "3gp": {},
+	// fonts
+	"ttf": {}, "otf": {}, "woff": {}, "woff2": {}, "eot": {},
+	// disk images / installers (binary, very rarely text-bearing)
+	"dmg": {}, "iso": {}, "img": {},
+}

--- a/pkg/enum/asana_test.go
+++ b/pkg/enum/asana_test.go
@@ -229,9 +229,10 @@ func TestAsanaEnumerator_EndToEnd(t *testing.T) {
 	require.NoError(t, err)
 
 	type collected struct {
-		content string
-		kind    string
-		field   string
+		content   string
+		kind      string
+		field     string
+		permalink string
 	}
 	var blobs []collected
 
@@ -241,7 +242,8 @@ func TestAsanaEnumerator_EndToEnd(t *testing.T) {
 		require.True(t, ok, "expected ExtendedProvenance, got %T", prov)
 		kind, _ := ep.Payload["resource"].(string)
 		field, _ := ep.Payload["field"].(string)
-		blobs = append(blobs, collected{content: string(content), kind: kind, field: field})
+		permalink, _ := ep.Payload["permalink"].(string)
+		blobs = append(blobs, collected{content: string(content), kind: kind, field: field, permalink: permalink})
 		return nil
 	})
 	require.NoError(t, err)
@@ -262,6 +264,16 @@ func TestAsanaEnumerator_EndToEnd(t *testing.T) {
 	assert.Contains(t, seen[kindField{"task", "notes"}], "task notes here")
 	assert.Contains(t, seen[kindField{"story", "text"}], "secret-comment-text")
 	assert.Contains(t, seen[kindField{"attachment", "content"}], "secret-bytes")
+
+	// Find the attachment-content emit and verify its permalink is the parent task's URL.
+	var foundAttachmentPermalink string
+	for _, b := range blobs {
+		if b.kind == "attachment" && b.field == "content" && b.content == "secret-bytes" {
+			foundAttachmentPermalink = b.permalink
+			break
+		}
+	}
+	assert.Equal(t, "https://app.asana.com/T1", foundAttachmentPermalink, "attachment provenance must include parent task permalink for click-through")
 
 	// Project brief: only text emitted (title dropped)
 	assert.Contains(t, seen[kindField{"project_brief", "text"}], "Alpha brief rich text",

--- a/pkg/enum/asana_test.go
+++ b/pkg/enum/asana_test.go
@@ -1,0 +1,868 @@
+package enum
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAsanaEnumerator_RequiresToken(t *testing.T) {
+	_, err := NewAsanaEnumerator(AsanaConfig{
+		Workspace: "W1",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "token")
+}
+
+func TestAsanaEnumerator_NoScopeAllowed(t *testing.T) {
+	// Empty scope is now valid; no scope means "all workspaces visible to token".
+	e, err := NewAsanaEnumerator(AsanaConfig{
+		Token: "test-token",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, e)
+}
+
+func TestAsanaEnumerator_ValidConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  AsanaConfig
+	}{
+		{name: "workspace only", cfg: AsanaConfig{Token: "tok", Workspace: "W1"}},
+		{name: "team only", cfg: AsanaConfig{Token: "tok", Team: "T1"}},
+		{name: "project only", cfg: AsanaConfig{Token: "tok", Project: "P1"}},
+		{name: "with attachments", cfg: AsanaConfig{Token: "tok", Workspace: "W1", IncludeAttachments: true}},
+		{name: "custom rate", cfg: AsanaConfig{Token: "tok", Workspace: "W1", RatePerSec: 10}},
+		{name: "no scope", cfg: AsanaConfig{Token: "tok"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e, err := NewAsanaEnumerator(tt.cfg)
+			require.NoError(t, err)
+			require.NotNil(t, e)
+		})
+	}
+}
+
+func asanaResponse(data interface{}) []byte {
+	type env struct {
+		Data interface{} `json:"data"`
+	}
+	b, _ := json.Marshal(env{Data: data})
+	return b
+}
+
+func asanaListResponse(data interface{}, nextOffset string) []byte {
+	type nextPage struct {
+		Offset string `json:"offset"`
+	}
+	type env struct {
+		Data     interface{} `json:"data"`
+		NextPage *nextPage   `json:"next_page"`
+	}
+	e := env{Data: data}
+	if nextOffset != "" {
+		e.NextPage = &nextPage{Offset: nextOffset}
+	}
+	b, _ := json.Marshal(e)
+	return b
+}
+
+func TestAsanaEnumerator_EndToEnd(t *testing.T) {
+	storiesCallCount := 0
+	mp4DownloadCalled := false
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		offset := r.URL.Query().Get("offset")
+
+		switch {
+		case path == "/workspaces/W1":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(asanaResponse(map[string]string{"gid": "W1", "name": "Acme"}))
+
+		case path == "/workspaces/W1/teams":
+			w.Header().Set("Content-Type", "application/json")
+			teams := []map[string]string{{"gid": "TM1", "name": "Engineering", "description": "Engineers team"}}
+			_, _ = w.Write(asanaListResponse(teams, ""))
+
+		case r.URL.Path == "/goals" && r.URL.Query().Get("workspace") == "W1":
+			w.Header().Set("Content-Type", "application/json")
+			goals := []map[string]string{
+				{"gid": "G1", "name": "Grow Revenue", "notes": "goal notes here", "permalink_url": "https://app.asana.com/G1"},
+			}
+			_, _ = w.Write(asanaListResponse(goals, ""))
+
+		case path == "/workspaces/W1/projects" && offset == "":
+			w.Header().Set("Content-Type", "application/json")
+			projects := []map[string]interface{}{
+				{
+					"gid": "P1", "name": "Project Alpha", "notes": "Alpha notes",
+					"permalink_url": "https://app.asana.com/P1",
+					"brief":         map[string]string{"gid": "B1"},
+				},
+			}
+			_, _ = w.Write(asanaListResponse(projects, "page2"))
+
+		case path == "/workspaces/W1/projects" && offset == "page2":
+			w.Header().Set("Content-Type", "application/json")
+			projects := []map[string]string{{"gid": "P2", "name": "Project Beta", "notes": "", "permalink_url": "https://app.asana.com/P2"}}
+			_, _ = w.Write(asanaListResponse(projects, ""))
+
+		case path == "/project_briefs/B1":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(asanaResponse(map[string]string{
+				"gid":  "B1",
+				"text": "Alpha brief rich text",
+			}))
+
+		case path == "/projects/P1/project_statuses":
+			w.Header().Set("Content-Type", "application/json")
+			statuses := []map[string]string{{"gid": "PS1", "title": "On Track", "text": "Everything is going well"}}
+			_, _ = w.Write(asanaListResponse(statuses, ""))
+
+		case path == "/task_templates" && r.URL.Query().Get("project") == "P1":
+			w.Header().Set("Content-Type", "application/json")
+			templates := []map[string]string{
+				{"gid": "TT1", "name": "Bug Report Template"},
+			}
+			_, _ = w.Write(asanaListResponse(templates, ""))
+
+		case path == "/task_templates" && r.URL.Query().Get("project") == "P2":
+			// Free tier - no templates
+			http.NotFound(w, r)
+
+		case path == "/projects/P1/tasks":
+			w.Header().Set("Content-Type", "application/json")
+			tasks := []map[string]interface{}{
+				{
+					"gid": "T1", "name": "Task One", "notes": "task notes here",
+					"permalink_url": "https://app.asana.com/T1",
+					"custom_fields": []map[string]string{
+						{"gid": "CF1", "name": "Connection String", "type": "text", "text_value": "postgres://user:pass@host/db"},
+						{"gid": "CF2", "name": "Priority", "type": "enum", "text_value": ""},
+					},
+					"external": map[string]string{"data": "secret-external-blob"},
+				},
+			}
+			_, _ = w.Write(asanaListResponse(tasks, ""))
+
+		case path == "/projects/P2/project_statuses":
+			http.NotFound(w, r)
+
+		case path == "/projects/P2/tasks":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(asanaListResponse([]interface{}{}, ""))
+
+		case path == "/tasks/T1/stories":
+			storiesCallCount++
+			if storiesCallCount == 1 {
+				w.Header().Set("Retry-After", "0")
+				w.WriteHeader(http.StatusServiceUnavailable)
+				_, _ = w.Write([]byte(`{"errors":[{"message":"service unavailable"}]}`))
+				return
+			}
+			if storiesCallCount == 2 {
+				w.Header().Set("Retry-After", "0")
+				w.WriteHeader(http.StatusTooManyRequests)
+				_, _ = w.Write([]byte(`{"errors":[{"message":"rate limited"}]}`))
+				return
+			}
+			stories := []map[string]string{
+				{"gid": "S1", "type": "comment", "text": "secret-comment-text"},
+				{"gid": "S2", "type": "system", "text": "task assigned to user"},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(asanaListResponse(stories, ""))
+
+		case path == "/tasks/T1/subtasks":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(asanaListResponse([]interface{}{}, ""))
+
+		case path == "/tasks/T1/attachments":
+			w.Header().Set("Content-Type", "application/json")
+			attachments := []map[string]string{
+				{"gid": "A1", "name": "secret.txt", "host": "asana", "download_url": fmt.Sprintf("http://%s/download/A1", r.Host)},
+				{"gid": "A2", "name": "gdoc.pdf", "host": "gdrive", "download_url": "https://drive.google.com/file/d/xxx"},
+				{"gid": "A3", "name": "demo.mp4", "host": "asana", "download_url": fmt.Sprintf("http://%s/download/A3", r.Host)},
+			}
+			_, _ = w.Write(asanaListResponse(attachments, ""))
+
+		case path == "/download/A1":
+			w.Header().Set("Content-Type", "text/plain")
+			_, _ = w.Write([]byte("secret-bytes"))
+
+		case path == "/download/A3":
+			// This should never be called - mp4 is in the skip list.
+			mp4DownloadCalled = true
+			w.Header().Set("Content-Type", "video/mp4")
+			_, _ = w.Write([]byte("fake-video-bytes"))
+
+		default:
+			t.Logf("unexpected request: %s %s", r.Method, r.URL.String())
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	cfg := AsanaConfig{
+		Token:              "test-token",
+		BaseURL:            ts.URL,
+		Workspace:          "W1",
+		IncludeAttachments: true,
+		RatePerSec:         1000,
+		HTTPClient:         ts.Client(),
+	}
+
+	e, err := NewAsanaEnumerator(cfg)
+	require.NoError(t, err)
+
+	type collected struct {
+		content string
+		kind    string
+		field   string
+	}
+	var blobs []collected
+
+	ctx := context.Background()
+	err = e.Enumerate(ctx, func(content []byte, blobID types.BlobID, prov types.Provenance) error {
+		ep, ok := prov.(types.ExtendedProvenance)
+		require.True(t, ok, "expected ExtendedProvenance, got %T", prov)
+		kind, _ := ep.Payload["resource"].(string)
+		field, _ := ep.Payload["field"].(string)
+		blobs = append(blobs, collected{content: string(content), kind: kind, field: field})
+		return nil
+	})
+	require.NoError(t, err)
+
+	type kindField struct{ kind, field string }
+	seen := make(map[kindField][]string)
+	for _, b := range blobs {
+		kf := kindField{b.kind, b.field}
+		seen[kf] = append(seen[kf], b.content)
+	}
+
+	// Fields that are kept - sentence-like content
+	assert.Contains(t, seen[kindField{"team", "description"}], "Engineers team")
+	assert.Contains(t, seen[kindField{"project", "notes"}], "Alpha notes")
+	assert.Contains(t, seen[kindField{"project_status", "title"}], "On Track")
+	assert.Contains(t, seen[kindField{"project_status", "text"}], "Everything is going well")
+	assert.Contains(t, seen[kindField{"task", "name"}], "Task One")
+	assert.Contains(t, seen[kindField{"task", "notes"}], "task notes here")
+	assert.Contains(t, seen[kindField{"story", "text"}], "secret-comment-text")
+	assert.Contains(t, seen[kindField{"attachment", "content"}], "secret-bytes")
+
+	// Project brief: only text emitted (title dropped)
+	assert.Contains(t, seen[kindField{"project_brief", "text"}], "Alpha brief rich text",
+		"brief text must be emitted")
+
+	// Identifier-only fields must NOT be emitted
+	assert.Empty(t, seen[kindField{"workspace", "name"}], "workspace.name must not be emitted")
+	assert.Empty(t, seen[kindField{"team", "name"}], "team.name must not be emitted")
+	assert.Empty(t, seen[kindField{"project", "name"}], "project.name must not be emitted")
+	assert.Empty(t, seen[kindField{"project_brief", "title"}], "project_brief.title must not be emitted")
+
+	// Custom field: text type emitted
+	assert.Contains(t, seen[kindField{"custom_field", "Connection String"}], "postgres://user:pass@host/db",
+		"text custom field value must be emitted with field=name")
+
+	// Custom field: enum type NOT emitted
+	for _, b := range blobs {
+		if b.kind == "custom_field" && b.field == "Priority" {
+			t.Error("enum custom field must not be emitted")
+		}
+	}
+
+	// task_external: data field emitted
+	assert.Contains(t, seen[kindField{"task_external", "data"}], "secret-external-blob",
+		"task external data must be emitted")
+
+	// goals: name and notes emitted
+	assert.Contains(t, seen[kindField{"goal", "name"}], "Grow Revenue",
+		"goal name must be emitted")
+	assert.Contains(t, seen[kindField{"goal", "notes"}], "goal notes here",
+		"goal notes must be emitted")
+
+	// task templates: name emitted (P1 has one, P2 soft-fails)
+	assert.Contains(t, seen[kindField{"task_template", "name"}], "Bug Report Template",
+		"task template name must be emitted")
+
+	for _, txt := range seen[kindField{"story", "text"}] {
+		assert.NotEqual(t, "task assigned to user", txt, "system story must not be emitted")
+	}
+	for _, b := range blobs {
+		assert.NotContains(t, b.content, "drive.google.com", "gdrive must not be fetched")
+	}
+	assert.Equal(t, 3, storiesCallCount, "stories must be retried after 5xx and 429")
+
+	// mp4 attachment must be skipped without downloading
+	assert.False(t, mp4DownloadCalled, "mp4 download URL must never be hit")
+}
+
+func TestAsanaEnumerator_Interface(t *testing.T) {
+	var _ Enumerator = (*AsanaEnumerator)(nil)
+}
+
+func TestEmitText_SkipsEmpty(t *testing.T) {
+	called := false
+	cb := func(_ []byte, _ types.BlobID, _ types.Provenance) error {
+		called = true
+		return nil
+	}
+	require.NoError(t, emitText("", "W1", "", "task", "T1", "notes", "", cb))
+	assert.False(t, called)
+	require.NoError(t, emitText("   ", "W1", "", "task", "T1", "notes", "", cb))
+	assert.False(t, called)
+}
+
+func TestAsanaEnumerator_RateLimiterDoesNotDeadlock(t *testing.T) {
+	e, err := NewAsanaEnumerator(AsanaConfig{Token: "tok", RatePerSec: 1000})
+	require.NoError(t, err)
+	ctx := context.Background()
+	require.NoError(t, e.client.limiter.Wait(ctx))
+	require.NoError(t, e.client.limiter.Wait(ctx))
+}
+
+func TestAsanaEnumerator_ScopeProject_NoTeams(t *testing.T) {
+	teamsCalled := false
+	goalsCalled := false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasPrefix(r.URL.Path, "/workspaces/") && strings.HasSuffix(r.URL.Path, "/teams") {
+			teamsCalled = true
+			_, _ = w.Write(asanaListResponse([]interface{}{}, ""))
+			return
+		}
+		if r.URL.Path == "/goals" {
+			goalsCalled = true
+			_, _ = w.Write(asanaListResponse([]interface{}{}, ""))
+			return
+		}
+		switch r.URL.Path {
+		case "/projects/P1":
+			proj := map[string]interface{}{
+				"gid": "P1", "name": "Solo", "notes": "",
+				"workspace": map[string]string{"gid": "W1", "name": "Acme"},
+			}
+			_, _ = w.Write(asanaResponse(proj))
+		case "/workspaces/W1":
+			_, _ = w.Write(asanaResponse(map[string]string{"gid": "W1", "name": "Acme"}))
+		case "/projects/P1/project_statuses":
+			http.NotFound(w, r)
+		case "/task_templates":
+			http.NotFound(w, r)
+		case "/projects/P1/tasks":
+			_, _ = w.Write(asanaListResponse([]interface{}{}, ""))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	cfg := AsanaConfig{Token: "tok", BaseURL: ts.URL, Project: "P1", RatePerSec: 1000, HTTPClient: ts.Client()}
+	e, err := NewAsanaEnumerator(cfg)
+	require.NoError(t, err)
+	require.NoError(t, e.Enumerate(context.Background(), func(_ []byte, _ types.BlobID, _ types.Provenance) error { return nil }))
+	assert.False(t, teamsCalled, "teams must not be enumerated when --project is set")
+	assert.False(t, goalsCalled, "goals must not be enumerated when --project is set")
+}
+
+func TestAsanaEnumerator_ResourceKinds(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/workspaces/W1":
+			_, _ = w.Write(asanaResponse(map[string]string{"gid": "W1", "name": "WS"}))
+		case r.URL.Path == "/workspaces/W1/teams":
+			_, _ = w.Write(asanaListResponse([]map[string]string{{"gid": "TM1", "name": "TeamA", "description": "desc"}}, ""))
+		case r.URL.Path == "/goals" && r.URL.Query().Get("workspace") == "W1":
+			_, _ = w.Write(asanaListResponse([]map[string]string{{"gid": "G1", "name": "A goal", "notes": "goal notes"}}, ""))
+		case r.URL.Path == "/workspaces/W1/projects":
+			_, _ = w.Write(asanaListResponse([]map[string]string{{"gid": "P1", "name": "Proj", "notes": "notes", "permalink_url": ""}}, ""))
+		case r.URL.Path == "/projects/P1/project_statuses":
+			http.NotFound(w, r)
+		case r.URL.Path == "/task_templates":
+			http.NotFound(w, r)
+		case r.URL.Path == "/projects/P1/tasks":
+			_, _ = w.Write(asanaListResponse([]map[string]string{{"gid": "T1", "name": "Task", "notes": "tnotes", "permalink_url": ""}}, ""))
+		case r.URL.Path == "/tasks/T1/stories":
+			_, _ = w.Write(asanaListResponse([]map[string]string{{"gid": "S1", "type": "comment", "text": "comment"}}, ""))
+		case r.URL.Path == "/tasks/T1/subtasks":
+			_, _ = w.Write(asanaListResponse([]interface{}{}, ""))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	cfg := AsanaConfig{Token: "tok", BaseURL: ts.URL, Workspace: "W1", RatePerSec: 1000, HTTPClient: ts.Client()}
+	e, err := NewAsanaEnumerator(cfg)
+	require.NoError(t, err)
+
+	var kinds []string
+	require.NoError(t, e.Enumerate(context.Background(), func(_ []byte, _ types.BlobID, prov types.Provenance) error {
+		ep := prov.(types.ExtendedProvenance)
+		kinds = append(kinds, ep.Payload["resource"].(string))
+		return nil
+	}))
+
+	sort.Strings(kinds)
+	assert.Contains(t, kinds, "goal")
+	assert.Contains(t, kinds, "project")
+	assert.Contains(t, kinds, "task")
+	assert.Contains(t, kinds, "story")
+	// workspace and team no longer emit name; team emits description only if non-empty
+}
+
+func TestAsanaSkipAttachmentExt(t *testing.T) {
+	skip := []string{"foo.mp4", "song.mp3", "logo.PNG", "design.fig", "movie.MOV", "font.woff2"}
+	keep := []string{"creds.txt", "design.pdf", "config.yaml", "deck.pptx", "data.zip", "noext", "secrets.env"}
+	for _, n := range skip {
+		if !asanaSkipAttachmentExt(n) {
+			t.Errorf("expected skip: %s", n)
+		}
+	}
+	for _, n := range keep {
+		if asanaSkipAttachmentExt(n) {
+			t.Errorf("expected keep: %s", n)
+		}
+	}
+}
+
+func TestAsanaEnumerator_NoScope_AllWorkspaces(t *testing.T) {
+	visitedWorkspaces := make(map[string]bool)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/workspaces":
+			workspaces := []map[string]string{
+				{"gid": "W1", "name": "Workspace One"},
+				{"gid": "W2", "name": "Workspace Two"},
+			}
+			_, _ = w.Write(asanaListResponse(workspaces, ""))
+
+		case "/workspaces/W1":
+			visitedWorkspaces["W1"] = true
+			_, _ = w.Write(asanaResponse(map[string]string{"gid": "W1", "name": "Workspace One"}))
+		case "/workspaces/W1/teams":
+			_, _ = w.Write(asanaListResponse([]interface{}{}, ""))
+		case "/workspaces/W1/projects":
+			_, _ = w.Write(asanaListResponse([]interface{}{}, ""))
+
+		case "/goals":
+			_, _ = w.Write(asanaListResponse([]interface{}{}, ""))
+
+		case "/workspaces/W2":
+			visitedWorkspaces["W2"] = true
+			_, _ = w.Write(asanaResponse(map[string]string{"gid": "W2", "name": "Workspace Two"}))
+		case "/workspaces/W2/teams":
+			_, _ = w.Write(asanaListResponse([]interface{}{}, ""))
+		case "/workspaces/W2/projects":
+			_, _ = w.Write(asanaListResponse([]interface{}{}, ""))
+
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	cfg := AsanaConfig{
+		Token:      "tok",
+		BaseURL:    ts.URL,
+		RatePerSec: 1000,
+		HTTPClient: ts.Client(),
+	}
+	e, err := NewAsanaEnumerator(cfg)
+	require.NoError(t, err)
+	require.NoError(t, e.Enumerate(context.Background(), func(_ []byte, _ types.BlobID, _ types.Provenance) error {
+		return nil
+	}))
+
+	assert.True(t, visitedWorkspaces["W1"], "W1 must be visited in no-scope mode")
+	assert.True(t, visitedWorkspaces["W2"], "W2 must be visited in no-scope mode")
+}
+
+func TestAsanaEnumerator_DedupsTaskAcrossProjects(t *testing.T) {
+	sharedTask := map[string]string{
+		"gid":           "T1",
+		"name":          "Shared Task",
+		"notes":         "shared-task-notes",
+		"permalink_url": "https://app.asana.com/T1",
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/workspaces/W1":
+			_, _ = w.Write(asanaResponse(map[string]string{"gid": "W1", "name": "Acme"}))
+		case r.URL.Path == "/workspaces/W1/teams":
+			_, _ = w.Write(asanaListResponse([]interface{}{}, ""))
+		case r.URL.Path == "/goals" && r.URL.Query().Get("workspace") == "W1":
+			_, _ = w.Write(asanaListResponse([]interface{}{}, ""))
+		case r.URL.Path == "/workspaces/W1/projects":
+			projects := []map[string]string{
+				{"gid": "P1", "name": "Project One", "notes": "alpha notes", "permalink_url": ""},
+				{"gid": "P2", "name": "Project Two", "notes": "beta notes", "permalink_url": ""},
+			}
+			_, _ = w.Write(asanaListResponse(projects, ""))
+		case r.URL.Path == "/projects/P1/project_statuses":
+			http.NotFound(w, r)
+		case r.URL.Path == "/projects/P2/project_statuses":
+			http.NotFound(w, r)
+		case r.URL.Path == "/task_templates" && r.URL.Query().Get("project") == "P1":
+			http.NotFound(w, r)
+		case r.URL.Path == "/task_templates" && r.URL.Query().Get("project") == "P2":
+			http.NotFound(w, r)
+		case r.URL.Path == "/projects/P1/tasks":
+			_, _ = w.Write(asanaListResponse([]map[string]string{sharedTask}, ""))
+		case r.URL.Path == "/projects/P2/tasks":
+			_, _ = w.Write(asanaListResponse([]map[string]string{sharedTask}, ""))
+		case r.URL.Path == "/tasks/T1/stories":
+			_, _ = w.Write(asanaListResponse([]interface{}{}, ""))
+		case r.URL.Path == "/tasks/T1/subtasks":
+			_, _ = w.Write(asanaListResponse([]interface{}{}, ""))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	cfg := AsanaConfig{
+		Token:      "test-token",
+		BaseURL:    ts.URL,
+		Workspace:  "W1",
+		RatePerSec: 1000,
+		HTTPClient: ts.Client(),
+	}
+	e, err := NewAsanaEnumerator(cfg)
+	require.NoError(t, err)
+
+	type emit struct{ content, resource, field string }
+	var emits []emit
+	err = e.Enumerate(context.Background(), func(content []byte, _ types.BlobID, prov types.Provenance) error {
+		ep := prov.(types.ExtendedProvenance)
+		resource, _ := ep.Payload["resource"].(string)
+		field, _ := ep.Payload["field"].(string)
+		emits = append(emits, emit{string(content), resource, field})
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Count how many times the shared task notes were emitted.
+	var sharedCount int
+	for _, e := range emits {
+		if e.resource == "task" && e.field == "notes" && e.content == "shared-task-notes" {
+			sharedCount++
+		}
+	}
+	assert.Equal(t, 1, sharedCount, "shared task notes must appear exactly once (dedup)")
+
+	// Both projects' own notes must be present (proves both P1 and P2 were walked).
+	var projectNotes []string
+	for _, e := range emits {
+		if e.resource == "project" && e.field == "notes" {
+			projectNotes = append(projectNotes, e.content)
+		}
+	}
+	assert.Contains(t, projectNotes, "alpha notes", "P1 project notes must be emitted")
+	assert.Contains(t, projectNotes, "beta notes", "P2 project notes must be emitted")
+}
+
+func TestAsanaEnumerator_DedupsSubtaskAcrossProjects(t *testing.T) {
+	sharedSubtask := map[string]string{
+		"gid":           "TSHARED",
+		"name":          "Shared Subtask",
+		"notes":         "shared-subtask-notes",
+		"permalink_url": "https://app.asana.com/TSHARED",
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/workspaces/W1":
+			_, _ = w.Write(asanaResponse(map[string]string{"gid": "W1", "name": "Acme"}))
+		case r.URL.Path == "/workspaces/W1/teams":
+			_, _ = w.Write(asanaListResponse([]interface{}{}, ""))
+		case r.URL.Path == "/goals" && r.URL.Query().Get("workspace") == "W1":
+			_, _ = w.Write(asanaListResponse([]interface{}{}, ""))
+		case r.URL.Path == "/workspaces/W1/projects":
+			projects := []map[string]string{
+				{"gid": "P1", "name": "Project One", "notes": "", "permalink_url": ""},
+				{"gid": "P2", "name": "Project Two", "notes": "", "permalink_url": ""},
+			}
+			_, _ = w.Write(asanaListResponse(projects, ""))
+		case r.URL.Path == "/projects/P1/project_statuses":
+			http.NotFound(w, r)
+		case r.URL.Path == "/projects/P2/project_statuses":
+			http.NotFound(w, r)
+		case r.URL.Path == "/task_templates" && r.URL.Query().Get("project") == "P1":
+			http.NotFound(w, r)
+		case r.URL.Path == "/task_templates" && r.URL.Query().Get("project") == "P2":
+			http.NotFound(w, r)
+		case r.URL.Path == "/projects/P1/tasks":
+			tasks := []map[string]string{{"gid": "T1", "name": "Task One", "notes": "t1-notes", "permalink_url": ""}}
+			_, _ = w.Write(asanaListResponse(tasks, ""))
+		case r.URL.Path == "/projects/P2/tasks":
+			tasks := []map[string]string{{"gid": "T2", "name": "Task Two", "notes": "t2-notes", "permalink_url": ""}}
+			_, _ = w.Write(asanaListResponse(tasks, ""))
+		case r.URL.Path == "/tasks/T1/stories":
+			_, _ = w.Write(asanaListResponse([]interface{}{}, ""))
+		case r.URL.Path == "/tasks/T2/stories":
+			_, _ = w.Write(asanaListResponse([]interface{}{}, ""))
+		case r.URL.Path == "/tasks/T1/subtasks":
+			_, _ = w.Write(asanaListResponse([]map[string]string{sharedSubtask}, ""))
+		case r.URL.Path == "/tasks/T2/subtasks":
+			// TSHARED is also a subtask of T2 — Asana many-to-many
+			_, _ = w.Write(asanaListResponse([]map[string]string{sharedSubtask}, ""))
+		case r.URL.Path == "/tasks/TSHARED/stories":
+			_, _ = w.Write(asanaListResponse([]interface{}{}, ""))
+		case r.URL.Path == "/tasks/TSHARED/subtasks":
+			_, _ = w.Write(asanaListResponse([]interface{}{}, ""))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	cfg := AsanaConfig{
+		Token:      "test-token",
+		BaseURL:    ts.URL,
+		Workspace:  "W1",
+		RatePerSec: 1000,
+		HTTPClient: ts.Client(),
+	}
+	e, err := NewAsanaEnumerator(cfg)
+	require.NoError(t, err)
+
+	type emit struct{ content, resource, field string }
+	var emits []emit
+	err = e.Enumerate(context.Background(), func(content []byte, _ types.BlobID, prov types.Provenance) error {
+		ep := prov.(types.ExtendedProvenance)
+		resource, _ := ep.Payload["resource"].(string)
+		field, _ := ep.Payload["field"].(string)
+		emits = append(emits, emit{string(content), resource, field})
+		return nil
+	})
+	require.NoError(t, err)
+
+	countTaskNotes := func(notes string) int {
+		var n int
+		for _, em := range emits {
+			if em.resource == "task" && em.field == "notes" && em.content == notes {
+				n++
+			}
+		}
+		return n
+	}
+
+	assert.Equal(t, 1, countTaskNotes("shared-subtask-notes"), "shared subtask notes must appear exactly once (dedup catches recursive path)")
+	assert.Equal(t, 1, countTaskNotes("t1-notes"), "T1 notes must appear exactly once")
+	assert.Equal(t, 1, countTaskNotes("t2-notes"), "T2 notes must appear exactly once")
+}
+
+func TestAsanaEnumerator_SeenResetsBetweenRuns(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/workspaces/W1":
+			_, _ = w.Write(asanaResponse(map[string]string{"gid": "W1", "name": "Acme"}))
+		case r.URL.Path == "/workspaces/W1/teams":
+			_, _ = w.Write(asanaListResponse([]interface{}{}, ""))
+		case r.URL.Path == "/goals" && r.URL.Query().Get("workspace") == "W1":
+			_, _ = w.Write(asanaListResponse([]interface{}{}, ""))
+		case r.URL.Path == "/workspaces/W1/projects":
+			projects := []map[string]string{{"gid": "P1", "name": "Proj", "notes": "", "permalink_url": ""}}
+			_, _ = w.Write(asanaListResponse(projects, ""))
+		case r.URL.Path == "/projects/P1/project_statuses":
+			http.NotFound(w, r)
+		case r.URL.Path == "/task_templates" && r.URL.Query().Get("project") == "P1":
+			http.NotFound(w, r)
+		case r.URL.Path == "/projects/P1/tasks":
+			tasks := []map[string]string{{"gid": "T1", "name": "Task One", "notes": "single-task-notes", "permalink_url": ""}}
+			_, _ = w.Write(asanaListResponse(tasks, ""))
+		case r.URL.Path == "/tasks/T1/stories":
+			_, _ = w.Write(asanaListResponse([]interface{}{}, ""))
+		case r.URL.Path == "/tasks/T1/subtasks":
+			_, _ = w.Write(asanaListResponse([]interface{}{}, ""))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	cfg := AsanaConfig{
+		Token:      "test-token",
+		BaseURL:    ts.URL,
+		Workspace:  "W1",
+		RatePerSec: 1000,
+		HTTPClient: ts.Client(),
+	}
+	e, err := NewAsanaEnumerator(cfg)
+	require.NoError(t, err)
+
+	countEmits := func() int {
+		var n int
+		err := e.Enumerate(context.Background(), func(content []byte, _ types.BlobID, prov types.Provenance) error {
+			ep := prov.(types.ExtendedProvenance)
+			resource, _ := ep.Payload["resource"].(string)
+			field, _ := ep.Payload["field"].(string)
+			if resource == "task" && field == "notes" && string(content) == "single-task-notes" {
+				n++
+			}
+			return nil
+		})
+		require.NoError(t, err)
+		return n
+	}
+
+	firstRun := countEmits()
+	secondRun := countEmits()
+	assert.Equal(t, 1, firstRun, "task notes must appear once on first run")
+	assert.Equal(t, 1, secondRun, "task notes must appear once on second run (seen map must reset)")
+}
+
+// buildZipBytesWithMember returns the bytes of a zip archive containing one
+// member file with the given name and content.
+func buildZipBytesWithMember(t *testing.T, memberName, memberContent string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	w := zip.NewWriter(&buf)
+	entry, err := w.Create(memberName)
+	require.NoError(t, err)
+	_, err = entry.Write([]byte(memberContent))
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+	return buf.Bytes()
+}
+
+// asanaBinaryAttachmentServer builds a minimal httptest.Server that serves a
+// single workspace → project → task → attachment flow. The attachment download
+// response is provided by the caller so tests can inject different payloads.
+func asanaBinaryAttachmentServer(t *testing.T, attachmentContent []byte) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/workspaces/W1":
+			_, _ = w.Write(asanaResponse(map[string]string{"gid": "W1", "name": "Acme"}))
+		case "/workspaces/W1/teams":
+			_, _ = w.Write(asanaListResponse([]interface{}{}, ""))
+		case "/goals":
+			_, _ = w.Write(asanaListResponse([]interface{}{}, ""))
+		case "/workspaces/W1/projects":
+			projects := []map[string]string{{"gid": "P1", "name": "Proj", "notes": "", "permalink_url": ""}}
+			_, _ = w.Write(asanaListResponse(projects, ""))
+		case "/projects/P1/project_statuses":
+			http.NotFound(w, r)
+		case "/task_templates":
+			http.NotFound(w, r)
+		case "/projects/P1/tasks":
+			tasks := []map[string]string{{"gid": "T1", "name": "Task", "notes": "", "permalink_url": ""}}
+			_, _ = w.Write(asanaListResponse(tasks, ""))
+		case "/tasks/T1/stories":
+			_, _ = w.Write(asanaListResponse([]interface{}{}, ""))
+		case "/tasks/T1/subtasks":
+			_, _ = w.Write(asanaListResponse([]interface{}{}, ""))
+		case "/tasks/T1/attachments":
+			attachments := []map[string]string{
+				{"gid": "A1", "name": "data.zip", "host": "asana",
+					"download_url": fmt.Sprintf("http://%s/download/A1", r.Host)},
+			}
+			_, _ = w.Write(asanaListResponse(attachments, ""))
+		case "/download/A1":
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write(attachmentContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+// TestAsanaEnumerator_BinaryAttachment_SkippedWithoutExtract verifies that a
+// binary attachment is silently skipped (no blob emitted) when ExtractArchives
+// is empty, locking in the first gate in the attachment loop.
+func TestAsanaEnumerator_BinaryAttachment_SkippedWithoutExtract(t *testing.T) {
+	// Four bytes that include a null byte so isBinary returns true.
+	binaryContent := []byte{'a', 'b', 0x00, 'c'}
+
+	ts := asanaBinaryAttachmentServer(t, binaryContent)
+	defer ts.Close()
+
+	cfg := AsanaConfig{
+		Token:              "test-token",
+		BaseURL:            ts.URL,
+		Workspace:          "W1",
+		IncludeAttachments: true,
+		RatePerSec:         1000,
+		HTTPClient:         ts.Client(),
+		// Config.ExtractArchives intentionally left empty — gate must fire.
+	}
+
+	e, err := NewAsanaEnumerator(cfg)
+	require.NoError(t, err)
+
+	var blobs []string
+	err = e.Enumerate(context.Background(), func(_ []byte, _ types.BlobID, prov types.Provenance) error {
+		ep, ok := prov.(types.ExtendedProvenance)
+		require.True(t, ok)
+		if resource, _ := ep.Payload["resource"].(string); resource == "attachment" || resource == "attachment_extracted" {
+			blobs = append(blobs, resource)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	assert.Empty(t, blobs, "binary attachment must not emit any blob when ExtractArchives is empty")
+}
+
+// TestAsanaEnumerator_BinaryAttachment_ExtractedWithExtract verifies the happy
+// path: when ExtractArchives is "all" and the attachment is a valid zip, the
+// extracted member text is emitted with resource "attachment_extracted".
+func TestAsanaEnumerator_BinaryAttachment_ExtractedWithExtract(t *testing.T) {
+	zipContent := buildZipBytesWithMember(t, "member.txt", "extracted-secret")
+
+	ts := asanaBinaryAttachmentServer(t, zipContent)
+	defer ts.Close()
+
+	cfg := AsanaConfig{
+		Token:              "test-token",
+		BaseURL:            ts.URL,
+		Workspace:          "W1",
+		IncludeAttachments: true,
+		RatePerSec:         1000,
+		HTTPClient:         ts.Client(),
+		Config: Config{
+			ExtractArchives: "all",
+			ExtractLimits:   DefaultExtractionLimits(),
+		},
+	}
+
+	e, err := NewAsanaEnumerator(cfg)
+	require.NoError(t, err)
+
+	var extractedTexts []string
+	err = e.Enumerate(context.Background(), func(content []byte, _ types.BlobID, prov types.Provenance) error {
+		ep, ok := prov.(types.ExtendedProvenance)
+		require.True(t, ok)
+		if resource, _ := ep.Payload["resource"].(string); resource == "attachment_extracted" {
+			extractedTexts = append(extractedTexts, string(content))
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	assert.Contains(t, extractedTexts, "extracted-secret",
+		"extracted zip member text must be emitted with resource=attachment_extracted")
+}

--- a/pkg/enum/asana_url.go
+++ b/pkg/enum/asana_url.go
@@ -1,0 +1,58 @@
+package enum
+
+import "strings"
+
+// AsanaScope identifies which Asana resource to scan.
+type AsanaScope int
+
+const (
+	AsanaScopeAll       AsanaScope = iota // asana://         — all workspaces visible to token
+	AsanaScopeWorkspace                   // asana://workspace/<gid>
+	AsanaScopeTeam                        // asana://team/<gid>
+	AsanaScopeProject                     // asana://project/<gid>
+)
+
+// ParseAsanaURL parses asana:// URL forms. Returns (scope, gid, true) on
+// success, or (_, _, false) if the target is not an Asana URL.
+//
+//	asana://                  -> AsanaScopeAll, ""
+//	asana://workspace/<gid>   -> AsanaScopeWorkspace, gid
+//	asana://team/<gid>        -> AsanaScopeTeam, gid
+//	asana://project/<gid>     -> AsanaScopeProject, gid
+func ParseAsanaURL(target string) (AsanaScope, string, bool) {
+	if !strings.HasPrefix(target, "asana://") {
+		return 0, "", false
+	}
+	path := strings.TrimPrefix(target, "asana://")
+	if path == "" {
+		return AsanaScopeAll, "", true
+	}
+	parts := strings.SplitN(path, "/", 3)
+	kind := parts[0]
+	var gid string
+	if len(parts) >= 2 {
+		gid = parts[1]
+	}
+	if len(parts) > 2 && parts[2] != "" {
+		return AsanaScopeAll, "", false
+	}
+	switch kind {
+	case "workspace":
+		if gid == "" {
+			return 0, "", false
+		}
+		return AsanaScopeWorkspace, gid, true
+	case "team":
+		if gid == "" {
+			return 0, "", false
+		}
+		return AsanaScopeTeam, gid, true
+	case "project":
+		if gid == "" {
+			return 0, "", false
+		}
+		return AsanaScopeProject, gid, true
+	default:
+		return 0, "", false
+	}
+}

--- a/pkg/enum/asana_url_test.go
+++ b/pkg/enum/asana_url_test.go
@@ -1,0 +1,83 @@
+package enum
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseAsanaURL_All(t *testing.T) {
+	scope, gid, ok := ParseAsanaURL("asana://")
+	assert.True(t, ok)
+	assert.Equal(t, AsanaScopeAll, scope)
+	assert.Equal(t, "", gid)
+}
+
+func TestParseAsanaURL_Workspace(t *testing.T) {
+	scope, gid, ok := ParseAsanaURL("asana://workspace/123456789")
+	assert.True(t, ok)
+	assert.Equal(t, AsanaScopeWorkspace, scope)
+	assert.Equal(t, "123456789", gid)
+}
+
+func TestParseAsanaURL_Team(t *testing.T) {
+	scope, gid, ok := ParseAsanaURL("asana://team/987654321")
+	assert.True(t, ok)
+	assert.Equal(t, AsanaScopeTeam, scope)
+	assert.Equal(t, "987654321", gid)
+}
+
+func TestParseAsanaURL_Project(t *testing.T) {
+	scope, gid, ok := ParseAsanaURL("asana://project/111222333")
+	assert.True(t, ok)
+	assert.Equal(t, AsanaScopeProject, scope)
+	assert.Equal(t, "111222333", gid)
+}
+
+func TestParseAsanaURL_NotAsana(t *testing.T) {
+	_, _, ok := ParseAsanaURL("https://app.asana.com/0/1/2")
+	assert.False(t, ok)
+
+	_, _, ok = ParseAsanaURL("s3://bucket/prefix")
+	assert.False(t, ok)
+
+	_, _, ok = ParseAsanaURL("/some/path")
+	assert.False(t, ok)
+
+	_, _, ok = ParseAsanaURL("")
+	assert.False(t, ok)
+}
+
+func TestParseAsanaURL_UnknownKind(t *testing.T) {
+	_, _, ok := ParseAsanaURL("asana://user/123")
+	assert.False(t, ok)
+}
+
+func TestParseAsanaURL_MissingGID(t *testing.T) {
+	_, _, ok := ParseAsanaURL("asana://workspace/")
+	assert.False(t, ok)
+
+	_, _, ok = ParseAsanaURL("asana://workspace")
+	assert.False(t, ok)
+
+	_, _, ok = ParseAsanaURL("asana://team/")
+	assert.False(t, ok)
+
+	_, _, ok = ParseAsanaURL("asana://project/")
+	assert.False(t, ok)
+}
+
+func TestParseAsanaURL_ExtraSegments(t *testing.T) {
+	// Extra non-empty path segment after <kind>/<gid> must be rejected.
+	_, _, ok := ParseAsanaURL("asana://workspace/123/extra")
+	assert.False(t, ok)
+
+	_, _, ok = ParseAsanaURL("asana://team/456/sub/path")
+	assert.False(t, ok)
+
+	// Trailing slash produces an empty third segment and must NOT be rejected.
+	scope, gid, ok := ParseAsanaURL("asana://project/789/")
+	assert.True(t, ok)
+	assert.Equal(t, AsanaScopeProject, scope)
+	assert.Equal(t, "789", gid)
+}


### PR DESCRIPTION
Adds an Asana enumerator under `titus scan` via `asana://` URL forms.

## URL forms

- `asana://` — every workspace visible to the token
- `asana://workspace/<gid>` — a single workspace
- `asana://team/<gid>` — a single team's projects (and team-scoped goals)
- `asana://project/<gid>` — a single project

## Auth

`ASANA_TOKEN` env var (Personal Access Token). Matches the env-var pattern used by S3, Git, and Docker under `titus scan`.

## Coverage

Task names/notes/HTML notes, comments and stories (text + html_text — depth-8 subtask trees included), project descriptions/briefs/status updates (plain + HTML), team descriptions, workspace- and team-scoped goals, task templates, custom text fields, and (opt-in) Asana-hosted attachments. Binary attachments route through `ExtractText` when `--extract` opts in; raw binary never reaches the matcher.

Tasks are deduplicated by GID within a single scan run. Asana's task↔project relationship is many-to-many, so workspace- and team-scoped scans commonly encounter the same task across multiple projects (and the same task across multiple parents as a subtask); the dedup ensures each task — and all its attachments, stories, custom fields, and subtask traversal — is walked exactly once per `Enumerate` call.

## Flags

- `--asana-rate-limit` (default 10 req/s; lower to 2 on free-tier 150/min quotas)
- `--asana-concurrency` (default 5 task workers per project; clamped to [1, 100]). Rate limiter remains the throughput ceiling; concurrency only hides per-request latency.
- `--asana-include-attachments` (off by default)
- `--asana-attachment-max-size` (default 50MB)

## Test plan

- [x] `go build ./...`
- [x] `go vet ./pkg/enum/... ./cmd/titus/...`
- [x] `go test ./pkg/enum/ -run "TestAsana|TestParseAsana"`
- [x] `go test ./cmd/titus/ -run TestScan`
- [x] Smoke against a real workspace with `--asana-include-attachments --extract all`

