### PR TITLE
feat(scoring): Azure SP RBAC role enumeration scorer (LAB-3359)

### DIFF
--- a/pkg/scoring/azure.go
+++ b/pkg/scoring/azure.go
@@ -1,0 +1,383 @@
+package scoring
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+)
+
+var (
+	azureTenantIDRe = regexp.MustCompile(
+		`(?i)(?:azure[_-]?tenant[_-]?id|arm[_-]?tenant[_-]?id|tenant[_-]?id)["']?\s*[:=]\s*["']?([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})`)
+	azureClientIDRe = regexp.MustCompile(
+		`(?i)(?:azure[_-]?client[_-]?id|arm[_-]?client[_-]?id|client[_-]?id|app[_-]?id|application[_-]?id)["']?\s*[:=]\s*["']?([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})`)
+)
+
+func extractAzureCredentials(m *types.Match) (*azureCredentials, bool) {
+	if m == nil {
+		return nil, false
+	}
+	secret, ok := m.NamedGroups["client_secret"]
+	if !ok || len(secret) == 0 {
+		return nil, false
+	}
+
+	surrounding := make([]byte, 0, len(m.Snippet.Before)+len(m.Snippet.Matching)+len(m.Snippet.After))
+	surrounding = append(surrounding, m.Snippet.Before...)
+	surrounding = append(surrounding, m.Snippet.Matching...)
+	surrounding = append(surrounding, m.Snippet.After...)
+
+	creds := &azureCredentials{ClientSecret: string(secret)}
+	if match := azureTenantIDRe.FindSubmatch(surrounding); len(match) > 1 {
+		creds.TenantID = string(match[1])
+	}
+	if match := azureClientIDRe.FindSubmatch(surrounding); len(match) > 1 {
+		creds.ClientID = string(match[1])
+	}
+	return creds, true
+}
+
+func isSubscriptionScope(scope string) bool {
+	trimmed := strings.TrimPrefix(scope, "/")
+	parts := strings.Split(trimmed, "/")
+	return len(parts) == 2 && strings.EqualFold(parts[0], "subscriptions")
+}
+
+// hasPrivilegedDirectoryRole returns true if the SP holds Global Administrator
+// or Privileged Role Administrator. Used by negative-delta conditions to avoid
+// incorrectly reducing the score of a highly-privileged SP.
+func hasPrivilegedDirectoryRole(ctx context.Context, api azureAPI) bool {
+	roles, err := api.GetDirectoryRoleMemberships(ctx)
+	if err != nil {
+		return false
+	}
+	for _, r := range roles {
+		if r == azureDirRoleGlobalAdmin || r == azureDirRolePrivRoleAdmin {
+			return true
+		}
+	}
+	return false
+}
+
+// --- Static conditions ---
+
+// azureIncompleteCredentialsCondition fires when client_secret is present but
+// tenant_id or client_id cannot be extracted from the surrounding context.
+type azureIncompleteCredentialsCondition struct{}
+
+func (c *azureIncompleteCredentialsCondition) Evaluate(_ context.Context, m *types.Match) (bool, error) {
+	creds, ok := extractAzureCredentials(m)
+	if !ok {
+		return false, nil
+	}
+	return !creds.complete(), nil
+}
+
+// --- Dynamic conditions ---
+
+// azureExpiredCondition fires when authentication fails with an Azure AD error
+// code indicating invalid or expired credentials.
+type azureExpiredCondition struct {
+	clientFactory azureClientFactory
+}
+
+func (c *azureExpiredCondition) markDynamic() {}
+
+func (c *azureExpiredCondition) Evaluate(ctx context.Context, m *types.Match) (bool, error) {
+	creds, ok := extractAzureCredentials(m)
+	if !ok || !creds.complete() {
+		return false, nil
+	}
+	factory := c.clientFactory
+	if factory == nil {
+		factory = defaultAzureClientFactory
+	}
+	_, err := factory(ctx, creds)
+	if err != nil {
+		lower := strings.ToLower(err.Error())
+		for _, code := range []string{
+			"aadsts70011", "aadsts700016", "aadsts7000215", "aadsts700027",
+			"invalid_client", "unauthorized_client",
+		} {
+			if strings.Contains(lower, code) {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+// azureGlobalAdminCondition fires when the SP holds Global Administrator
+// or Privileged Role Administrator directory roles.
+type azureGlobalAdminCondition struct {
+	clientFactory azureClientFactory
+}
+
+func (c *azureGlobalAdminCondition) markDynamic() {}
+
+func (c *azureGlobalAdminCondition) Evaluate(ctx context.Context, m *types.Match) (bool, error) {
+	creds, ok := extractAzureCredentials(m)
+	if !ok || !creds.complete() {
+		return false, nil
+	}
+	factory := c.clientFactory
+	if factory == nil {
+		factory = defaultAzureClientFactory
+	}
+	api, err := factory(ctx, creds)
+	if err != nil {
+		return false, nil
+	}
+	return hasPrivilegedDirectoryRole(ctx, api), nil
+}
+
+// azureRBACCondition fires when RBAC role assignments match specified criteria.
+//
+// Fields:
+//   - matchRoles: role definition GUIDs to match against
+//   - excludeRoles: if any assignment has one of these, don't fire
+//   - onlyIfExclusive: when true, ALL roles must be in matchRoles
+//   - subscriptionLevel: when true, at least one match must be at subscription scope
+//   - resourceGroupOnly: when true (with onlyIfExclusive), all must be below subscription scope
+//   - skipIfPrivilegedDir: when true, skip if SP has Global Admin or Privileged Role Admin
+type azureRBACCondition struct {
+	matchRoles          []string
+	excludeRoles        []string
+	onlyIfExclusive     bool
+	subscriptionLevel   bool
+	resourceGroupOnly   bool
+	skipIfPrivilegedDir bool
+	clientFactory       azureClientFactory
+}
+
+func (c *azureRBACCondition) markDynamic() {}
+
+func (c *azureRBACCondition) Evaluate(ctx context.Context, m *types.Match) (bool, error) {
+	creds, ok := extractAzureCredentials(m)
+	if !ok || !creds.complete() {
+		return false, nil
+	}
+	factory := c.clientFactory
+	if factory == nil {
+		factory = defaultAzureClientFactory
+	}
+	api, err := factory(ctx, creds)
+	if err != nil {
+		return false, nil
+	}
+
+	if c.skipIfPrivilegedDir && hasPrivilegedDirectoryRole(ctx, api) {
+		return false, nil
+	}
+
+	subs, err := api.ListSubscriptions(ctx)
+	if err != nil || len(subs) == 0 {
+		return false, nil
+	}
+
+	matchSet := make(map[string]bool, len(c.matchRoles))
+	for _, r := range c.matchRoles {
+		matchSet[r] = true
+	}
+
+	var allAssignments []azureRoleAssignment
+	for _, sub := range subs {
+		assignments, err := api.ListRoleAssignments(ctx, sub.ID)
+		if err != nil {
+			continue
+		}
+		allAssignments = append(allAssignments, assignments...)
+	}
+
+	if len(allAssignments) == 0 {
+		return false, nil
+	}
+
+	if len(c.excludeRoles) > 0 {
+		excludeSet := make(map[string]bool, len(c.excludeRoles))
+		for _, r := range c.excludeRoles {
+			excludeSet[r] = true
+		}
+		for _, a := range allAssignments {
+			if excludeSet[a.RoleDefinitionID] {
+				return false, nil
+			}
+		}
+	}
+
+	if c.onlyIfExclusive {
+		for _, a := range allAssignments {
+			if !matchSet[a.RoleDefinitionID] {
+				return false, nil
+			}
+		}
+		if c.resourceGroupOnly {
+			for _, a := range allAssignments {
+				if isSubscriptionScope(a.Scope) {
+					return false, nil
+				}
+			}
+		}
+		return true, nil
+	}
+
+	for _, a := range allAssignments {
+		if matchSet[a.RoleDefinitionID] {
+			if c.subscriptionLevel && !isSubscriptionScope(a.Scope) {
+				continue
+			}
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// azureMultiSubCondition fires when the SP can access minSubs or more subscriptions.
+type azureMultiSubCondition struct {
+	minSubs       int
+	clientFactory azureClientFactory
+}
+
+func (c *azureMultiSubCondition) markDynamic() {}
+
+func (c *azureMultiSubCondition) Evaluate(ctx context.Context, m *types.Match) (bool, error) {
+	creds, ok := extractAzureCredentials(m)
+	if !ok || !creds.complete() {
+		return false, nil
+	}
+	factory := c.clientFactory
+	if factory == nil {
+		factory = defaultAzureClientFactory
+	}
+	api, err := factory(ctx, creds)
+	if err != nil {
+		return false, nil
+	}
+	subs, err := api.ListSubscriptions(ctx)
+	if err != nil {
+		return false, nil
+	}
+	return len(subs) >= c.minSubs, nil
+}
+
+// azureGraphReadOnlyCondition fires when the SP's app role assignments are
+// limited to minimal/read-only Microsoft Graph permissions (e.g. User.Read.All)
+// or when the SP has no app role assignments at all.
+type azureGraphReadOnlyCondition struct {
+	clientFactory azureClientFactory
+}
+
+func (c *azureGraphReadOnlyCondition) markDynamic() {}
+
+func (c *azureGraphReadOnlyCondition) Evaluate(ctx context.Context, m *types.Match) (bool, error) {
+	creds, ok := extractAzureCredentials(m)
+	if !ok || !creds.complete() {
+		return false, nil
+	}
+	factory := c.clientFactory
+	if factory == nil {
+		factory = defaultAzureClientFactory
+	}
+	api, err := factory(ctx, creds)
+	if err != nil {
+		return false, nil
+	}
+	if hasPrivilegedDirectoryRole(ctx, api) {
+		return false, nil
+	}
+	assignments, err := api.GetAppRoleAssignments(ctx)
+	if err != nil {
+		return false, nil
+	}
+	for _, a := range assignments {
+		if !graphMinimalAppRoles[a.AppRoleID] {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// azureSingleNonProdSubCondition fires when the SP has access to exactly one
+// subscription and its display name matches a non-production pattern.
+type azureSingleNonProdSubCondition struct {
+	clientFactory azureClientFactory
+}
+
+func (c *azureSingleNonProdSubCondition) markDynamic() {}
+
+func (c *azureSingleNonProdSubCondition) Evaluate(ctx context.Context, m *types.Match) (bool, error) {
+	creds, ok := extractAzureCredentials(m)
+	if !ok || !creds.complete() {
+		return false, nil
+	}
+	factory := c.clientFactory
+	if factory == nil {
+		factory = defaultAzureClientFactory
+	}
+	api, err := factory(ctx, creds)
+	if err != nil {
+		return false, nil
+	}
+	if hasPrivilegedDirectoryRole(ctx, api) {
+		return false, nil
+	}
+	subs, err := api.ListSubscriptions(ctx)
+	if err != nil || len(subs) != 1 {
+		return false, nil
+	}
+	lower := strings.ToLower(subs[0].DisplayName)
+	for _, pat := range nonProdPatterns {
+		if strings.Contains(lower, pat) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// AzureGoScorer returns a *Scorer targeting Azure SP client secret rules.
+func AzureGoScorer() *Scorer {
+	return &Scorer{
+		Name:    "azure-sp-rbac-scope",
+		RuleIDs: []string{"np.azure.7", "np.azure.8"},
+		Modifiers: []Modifier{
+			{Name: "expired-credentials", Priority: 100, Kind: ModifierKindSetScore, Value: 5,
+				Condition: &azureExpiredCondition{}},
+			{Name: "global-admin", Priority: 95, Kind: ModifierKindSetScore, Value: 99,
+				Condition: &azureGlobalAdminCondition{}},
+			{Name: "owner-sub-level", Priority: 90, Kind: ModifierKindSetScore, Value: 95,
+				Condition: &azureRBACCondition{
+					matchRoles:          []string{azureRoleOwner},
+					subscriptionLevel:   true,
+					skipIfPrivilegedDir: true,
+				}},
+			{Name: "contributor-sub-level", Priority: 85, Kind: ModifierKindSetScore, Value: 85,
+				Condition: &azureRBACCondition{
+					matchRoles:          []string{azureRoleContributor},
+					excludeRoles:        []string{azureRoleOwner},
+					subscriptionLevel:   true,
+					skipIfPrivilegedDir: true,
+				}},
+			{Name: "keyvault-secret-access", Priority: 75, Kind: ModifierKindDelta, Value: 15,
+				Condition: &azureRBACCondition{
+					matchRoles: []string{azureRoleKVAdmin, azureRoleKVSecretsOfficer, azureRoleKVSecretsUser},
+				}},
+			{Name: "multi-subscription", Priority: 70, Kind: ModifierKindDelta, Value: 10,
+				Condition: &azureMultiSubCondition{minSubs: 3}},
+			{Name: "incomplete-credentials", Priority: 60, Kind: ModifierKindDelta, Value: -20,
+				Condition: &azureIncompleteCredentialsCondition{}},
+			{Name: "reader-only-rg-level", Priority: 55, Kind: ModifierKindDelta, Value: -25,
+				Condition: &azureRBACCondition{
+					matchRoles:          []string{azureRoleReader},
+					onlyIfExclusive:     true,
+					resourceGroupOnly:   true,
+					skipIfPrivilegedDir: true,
+				}},
+			{Name: "graph-read-only", Priority: 50, Kind: ModifierKindDelta, Value: -20,
+				Condition: &azureGraphReadOnlyCondition{}},
+			{Name: "single-non-prod-sub", Priority: 45, Kind: ModifierKindDelta, Value: -10,
+				Condition: &azureSingleNonProdSubCondition{}},
+		},
+	}
+}

--- a/pkg/scoring/azure.go
+++ b/pkg/scoring/azure.go
@@ -45,6 +45,23 @@ func isSubscriptionScope(scope string) bool {
 	return len(parts) == 2 && strings.EqualFold(parts[0], "subscriptions")
 }
 
+// isManagementGroupScope returns true for scopes like
+// /providers/Microsoft.Management/managementGroups/<name>.
+func isManagementGroupScope(scope string) bool {
+	trimmed := strings.TrimPrefix(scope, "/")
+	parts := strings.Split(trimmed, "/")
+	return len(parts) == 4 &&
+		strings.EqualFold(parts[0], "providers") &&
+		strings.EqualFold(parts[1], "Microsoft.Management") &&
+		strings.EqualFold(parts[2], "managementGroups")
+}
+
+// isAtOrAboveSubscriptionScope returns true for subscription-level scope or
+// management group scope (which is above subscription level).
+func isAtOrAboveSubscriptionScope(scope string) bool {
+	return isSubscriptionScope(scope) || isManagementGroupScope(scope)
+}
+
 // hasPrivilegedDirectoryRole returns true if the SP holds Global Administrator
 // or Privileged Role Administrator. Used by negative-delta conditions to avoid
 // incorrectly reducing the score of a highly-privileged SP.
@@ -215,7 +232,7 @@ func (c *azureRBACCondition) Evaluate(ctx context.Context, m *types.Match) (bool
 		}
 		if c.resourceGroupOnly {
 			for _, a := range allAssignments {
-				if isSubscriptionScope(a.Scope) {
+				if isAtOrAboveSubscriptionScope(a.Scope) {
 					return false, nil
 				}
 			}
@@ -225,7 +242,7 @@ func (c *azureRBACCondition) Evaluate(ctx context.Context, m *types.Match) (bool
 
 	for _, a := range allAssignments {
 		if matchSet[a.RoleDefinitionID] {
-			if c.subscriptionLevel && !isSubscriptionScope(a.Scope) {
+			if c.subscriptionLevel && !isAtOrAboveSubscriptionScope(a.Scope) {
 				continue
 			}
 			return true, nil
@@ -287,6 +304,14 @@ func (c *azureGraphReadOnlyCondition) Evaluate(ctx context.Context, m *types.Mat
 	if hasPrivilegedDirectoryRole(ctx, api) {
 		return false, nil
 	}
+
+	// Don't penalize an SP that holds non-Reader ARM RBAC roles; the
+	// graph-read-only discount is only meaningful when the SP has no
+	// significant ARM access either.
+	if hasNonReaderARMRole(ctx, api) {
+		return false, nil
+	}
+
 	assignments, err := api.GetAppRoleAssignments(ctx)
 	if err != nil {
 		return false, nil
@@ -297,6 +322,27 @@ func (c *azureGraphReadOnlyCondition) Evaluate(ctx context.Context, m *types.Mat
 		}
 	}
 	return true, nil
+}
+
+// hasNonReaderARMRole returns true if the SP holds any ARM RBAC role other
+// than Reader across all accessible subscriptions.
+func hasNonReaderARMRole(ctx context.Context, api azureAPI) bool {
+	subs, err := api.ListSubscriptions(ctx)
+	if err != nil {
+		return false
+	}
+	for _, sub := range subs {
+		assignments, err := api.ListRoleAssignments(ctx, sub.ID)
+		if err != nil {
+			continue
+		}
+		for _, a := range assignments {
+			if a.RoleDefinitionID != azureRoleReader {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // azureSingleNonProdSubCondition fires when the SP has access to exactly one

--- a/pkg/scoring/azure_client.go
+++ b/pkg/scoring/azure_client.go
@@ -37,16 +37,16 @@ type azureAppRoleAssignment struct {
 	ResourceDisplayName string
 }
 
-const ( // #nosec G101 -- Azure RBAC role definition GUIDs, not credentials.
+const (
 	azureRoleOwner            = "8e3af657-a8ff-443c-a75c-2fe8c4bcb635"
 	azureRoleContributor      = "b24988ac-6180-42a0-ab88-20f7382dd24c"
 	azureRoleReader           = "acdd72a7-3385-48ef-bd42-f606fba81ae7"
 	azureRoleKVAdmin          = "00482a5a-887f-4fb3-b363-3b7fe8e74483"
-	azureRoleKVSecretsOfficer = "b86a8fe4-44ce-4948-aee5-eccb2c155cd7"
-	azureRoleKVSecretsUser    = "4633458b-17de-408a-b874-0445c86b69e6"
+	azureRoleKVSecretsOfficer = "b86a8fe4-44ce-4948-aee5-eccb2c155cd7" // #nosec G101 -- Azure RBAC role definition GUID, not a credential.
+	azureRoleKVSecretsUser    = "4633458b-17de-408a-b874-0445c86b69e6" // #nosec G101 -- Azure RBAC role definition GUID, not a credential.
 )
 
-const ( // #nosec G101 -- Azure directory role template IDs, not credentials.
+const (
 	azureDirRoleGlobalAdmin   = "62e90394-69f5-4237-9190-012177145e10"
 	azureDirRolePrivRoleAdmin = "e8611ab8-c189-46e8-94e1-60213ab1f814"
 )

--- a/pkg/scoring/azure_client.go
+++ b/pkg/scoring/azure_client.go
@@ -56,7 +56,7 @@ var graphMinimalAppRoles = map[string]bool{
 	"df021288-bdef-4463-88db-98f22de89214": true, // User.Read.All
 	"97235f07-e226-4f63-ace3-39588e11d3a1": true, // User.ReadBasic.All
 	"e1fe6dd8-ba31-4d61-89e7-88639da4683d": true, // User.Read
-	"00000003-0000-0000-c000-000000000000": true, // default/.default (no actual permissions)
+	"00000000-0000-0000-0000-000000000000": true, // default access (no specific app role)
 }
 
 type azureAPI interface {

--- a/pkg/scoring/azure_client.go
+++ b/pkg/scoring/azure_client.go
@@ -1,0 +1,350 @@
+package scoring
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type azureCredentials struct {
+	TenantID     string
+	ClientID     string
+	ClientSecret string
+}
+
+func (c *azureCredentials) complete() bool {
+	return c.TenantID != "" && c.ClientID != "" && c.ClientSecret != ""
+}
+
+type azureSubscription struct {
+	ID          string `json:"subscriptionId"`
+	DisplayName string `json:"displayName"`
+}
+
+type azureRoleAssignment struct {
+	RoleDefinitionID string
+	Scope            string
+}
+
+type azureAppRoleAssignment struct {
+	AppRoleID           string
+	ResourceDisplayName string
+}
+
+const (
+	azureRoleOwner            = "8e3af657-a8ff-443c-a75c-2fe8c4bcb635"
+	azureRoleContributor      = "b24988ac-6180-42a0-ab88-20f7382dd24c"
+	azureRoleReader           = "acdd72a7-3385-48ef-bd42-f606fba81ae7"
+	azureRoleKVAdmin          = "00482a5a-887f-4fb3-b363-3b7fe8e74483"
+	azureRoleKVSecretsOfficer = "b86a8fe4-44ce-4948-aee5-eccb2c155cd7"
+	azureRoleKVSecretsUser    = "4633458b-17de-408a-b874-0445c86b69e6"
+)
+
+const (
+	azureDirRoleGlobalAdmin   = "62e90394-69f5-4237-9190-012177145e10"
+	azureDirRolePrivRoleAdmin = "e8611ab8-c189-46e8-94e1-60213ab1f814"
+)
+
+// Microsoft Graph application permission GUIDs considered minimal/read-only.
+var graphMinimalAppRoles = map[string]bool{
+	"df021288-bdef-4463-88db-98f22de89214": true, // User.Read.All
+	"97235f07-e226-4f63-ace3-39588e11d3a1": true, // User.ReadBasic.All
+	"e1fe6dd8-ba31-4d61-89e7-88639da4683d": true, // User.Read
+	"00000003-0000-0000-c000-000000000000": true, // default/.default (no actual permissions)
+}
+
+type azureAPI interface {
+	ListSubscriptions(ctx context.Context) ([]azureSubscription, error)
+	ListRoleAssignments(ctx context.Context, subscriptionID string) ([]azureRoleAssignment, error)
+	GetDirectoryRoleMemberships(ctx context.Context) ([]string, error)
+	GetAppRoleAssignments(ctx context.Context) ([]azureAppRoleAssignment, error)
+}
+
+type azureClientFactory func(ctx context.Context, creds *azureCredentials) (azureAPI, error)
+
+func defaultAzureClientFactory(ctx context.Context, creds *azureCredentials) (azureAPI, error) {
+	client := &http.Client{Timeout: 30 * time.Second}
+
+	armToken, err := azureAcquireToken(ctx, client, creds, "https://management.azure.com/.default")
+	if err != nil {
+		return nil, err
+	}
+
+	objectID, err := extractObjectIDFromJWT(armToken)
+	if err != nil {
+		return nil, fmt.Errorf("extract object ID: %w", err)
+	}
+
+	// Graph token failure is non-fatal; directory role conditions just won't fire.
+	graphToken, _ := azureAcquireToken(ctx, client, creds, "https://graph.microsoft.com/.default")
+
+	return &azureHTTPAPI{
+		client:     client,
+		armToken:   armToken,
+		graphToken: graphToken,
+		objectID:   objectID,
+	}, nil
+}
+
+func azureAcquireToken(ctx context.Context, client *http.Client, creds *azureCredentials, scope string) (string, error) {
+	tokenURL := fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/token", creds.TenantID)
+
+	data := url.Values{
+		"grant_type":    {"client_credentials"},
+		"client_id":     {creds.ClientID},
+		"client_secret": {creds.ClientSecret},
+		"scope":         {scope},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(data.Encode()))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		var errResp struct {
+			Error       string `json:"error"`
+			Description string `json:"error_description"`
+		}
+		if json.Unmarshal(body, &errResp) == nil && errResp.Description != "" {
+			return "", fmt.Errorf("%s: %s", errResp.Error, errResp.Description)
+		}
+		return "", fmt.Errorf("token request: HTTP %d", resp.StatusCode)
+	}
+
+	var tokenResp struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return "", err
+	}
+	if tokenResp.AccessToken == "" {
+		return "", fmt.Errorf("empty access token in response")
+	}
+	return tokenResp.AccessToken, nil
+}
+
+func extractObjectIDFromJWT(token string) (string, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return "", fmt.Errorf("invalid JWT: expected 3 parts, got %d", len(parts))
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", fmt.Errorf("decode JWT payload: %w", err)
+	}
+	var claims struct {
+		OID string `json:"oid"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return "", fmt.Errorf("parse JWT claims: %w", err)
+	}
+	if claims.OID == "" {
+		return "", fmt.Errorf("oid claim missing from token")
+	}
+	return claims.OID, nil
+}
+
+type azureHTTPAPI struct {
+	client     *http.Client
+	armToken   string
+	graphToken string
+	objectID   string
+}
+
+func (a *azureHTTPAPI) ListSubscriptions(ctx context.Context) ([]azureSubscription, error) {
+	u := "https://management.azure.com/subscriptions?api-version=2020-01-01"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+a.armToken)
+
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("listSubscriptions: HTTP %d", resp.StatusCode)
+	}
+
+	var result struct {
+		Value []azureSubscription `json:"value"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, err
+	}
+	return result.Value, nil
+}
+
+func (a *azureHTTPAPI) ListRoleAssignments(ctx context.Context, subscriptionID string) ([]azureRoleAssignment, error) {
+	filter := url.QueryEscape(fmt.Sprintf("principalId eq '%s'", a.objectID))
+	u := fmt.Sprintf(
+		"https://management.azure.com/subscriptions/%s/providers/Microsoft.Authorization/roleAssignments?api-version=2022-04-01&$filter=%s",
+		subscriptionID, filter)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+a.armToken)
+
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("listRoleAssignments: HTTP %d", resp.StatusCode)
+	}
+
+	var result struct {
+		Value []struct {
+			Properties struct {
+				RoleDefinitionID string `json:"roleDefinitionId"`
+				Scope            string `json:"scope"`
+			} `json:"properties"`
+		} `json:"value"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, err
+	}
+
+	assignments := make([]azureRoleAssignment, 0, len(result.Value))
+	for _, v := range result.Value {
+		roleID := v.Properties.RoleDefinitionID
+		if idx := strings.LastIndex(roleID, "/"); idx >= 0 {
+			roleID = roleID[idx+1:]
+		}
+		assignments = append(assignments, azureRoleAssignment{
+			RoleDefinitionID: roleID,
+			Scope:            v.Properties.Scope,
+		})
+	}
+	return assignments, nil
+}
+
+func (a *azureHTTPAPI) GetDirectoryRoleMemberships(ctx context.Context) ([]string, error) {
+	if a.graphToken == "" {
+		return nil, fmt.Errorf("no graph token")
+	}
+
+	u := fmt.Sprintf(
+		"https://graph.microsoft.com/v1.0/servicePrincipals/%s/memberOf/microsoft.graph.directoryRole",
+		a.objectID)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+a.graphToken)
+
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("getDirectoryRoles: HTTP %d", resp.StatusCode)
+	}
+
+	var result struct {
+		Value []struct {
+			RoleTemplateID string `json:"roleTemplateId"`
+		} `json:"value"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, err
+	}
+
+	roles := make([]string, 0, len(result.Value))
+	for _, v := range result.Value {
+		if v.RoleTemplateID != "" {
+			roles = append(roles, v.RoleTemplateID)
+		}
+	}
+	return roles, nil
+}
+
+func (a *azureHTTPAPI) GetAppRoleAssignments(ctx context.Context) ([]azureAppRoleAssignment, error) {
+	if a.graphToken == "" {
+		return nil, fmt.Errorf("no graph token")
+	}
+
+	u := fmt.Sprintf(
+		"https://graph.microsoft.com/v1.0/servicePrincipals/%s/appRoleAssignments",
+		a.objectID)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+a.graphToken)
+
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("getAppRoleAssignments: HTTP %d", resp.StatusCode)
+	}
+
+	var result struct {
+		Value []struct {
+			AppRoleID           string `json:"appRoleId"`
+			ResourceDisplayName string `json:"resourceDisplayName"`
+		} `json:"value"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, err
+	}
+
+	assignments := make([]azureAppRoleAssignment, 0, len(result.Value))
+	for _, v := range result.Value {
+		assignments = append(assignments, azureAppRoleAssignment{
+			AppRoleID:           v.AppRoleID,
+			ResourceDisplayName: v.ResourceDisplayName,
+		})
+	}
+	return assignments, nil
+}

--- a/pkg/scoring/azure_client.go
+++ b/pkg/scoring/azure_client.go
@@ -37,7 +37,7 @@ type azureAppRoleAssignment struct {
 	ResourceDisplayName string
 }
 
-const (
+const ( // #nosec G101 -- Azure RBAC role definition GUIDs, not credentials.
 	azureRoleOwner            = "8e3af657-a8ff-443c-a75c-2fe8c4bcb635"
 	azureRoleContributor      = "b24988ac-6180-42a0-ab88-20f7382dd24c"
 	azureRoleReader           = "acdd72a7-3385-48ef-bd42-f606fba81ae7"
@@ -46,7 +46,7 @@ const (
 	azureRoleKVSecretsUser    = "4633458b-17de-408a-b874-0445c86b69e6"
 )
 
-const (
+const ( // #nosec G101 -- Azure directory role template IDs, not credentials.
 	azureDirRoleGlobalAdmin   = "62e90394-69f5-4237-9190-012177145e10"
 	azureDirRolePrivRoleAdmin = "e8611ab8-c189-46e8-94e1-60213ab1f814"
 )
@@ -170,35 +170,91 @@ type azureHTTPAPI struct {
 	objectID   string
 }
 
+// maxPages caps pagination to avoid infinite loops.
+const maxPages = 10
+
+// paginatedResponse holds the raw JSON value array and the next page link.
+type paginatedResponse struct {
+	Value    json.RawMessage `json:"value"`
+	NextLink string          `json:"nextLink"`
+	// Graph API uses @odata.nextLink instead of nextLink.
+	ODataNextLink string `json:"@odata.nextLink"`
+}
+
+func (p *paginatedResponse) nextURL() string {
+	if p.NextLink != "" {
+		return p.NextLink
+	}
+	return p.ODataNextLink
+}
+
+// fetchAllPages fetches the initial URL and follows pagination links, returning
+// the concatenated raw JSON value arrays. The caller is responsible for
+// unmarshaling each element.
+func (a *azureHTTPAPI) fetchAllPages(ctx context.Context, initialURL, token string) ([]json.RawMessage, error) {
+	var allValues []json.RawMessage
+
+	currentURL := initialURL
+	for page := 0; page < maxPages; page++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, currentURL, nil)
+		if err != nil {
+			return allValues, err
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		resp, err := a.client.Do(req)
+		if err != nil {
+			return allValues, err
+		}
+
+		body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+		if err != nil {
+			return allValues, err
+		}
+		if resp.StatusCode != http.StatusOK {
+			return allValues, fmt.Errorf("HTTP %d", resp.StatusCode)
+		}
+
+		var pageResp paginatedResponse
+		if err := json.Unmarshal(body, &pageResp); err != nil {
+			return allValues, err
+		}
+
+		// Parse value array into individual raw elements.
+		var items []json.RawMessage
+		if err := json.Unmarshal(pageResp.Value, &items); err != nil {
+			return allValues, err
+		}
+		allValues = append(allValues, items...)
+
+		next := pageResp.nextURL()
+		if next == "" {
+			break
+		}
+		currentURL = next
+	}
+
+	return allValues, nil
+}
+
 func (a *azureHTTPAPI) ListSubscriptions(ctx context.Context) ([]azureSubscription, error) {
 	u := "https://management.azure.com/subscriptions?api-version=2020-01-01"
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	items, err := a.fetchAllPages(ctx, u, a.armToken)
 	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Authorization", "Bearer "+a.armToken)
-
-	resp, err := a.client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
-
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("listSubscriptions: HTTP %d", resp.StatusCode)
+		return nil, fmt.Errorf("listSubscriptions: %w", err)
 	}
 
-	var result struct {
-		Value []azureSubscription `json:"value"`
+	subs := make([]azureSubscription, 0, len(items))
+	for _, raw := range items {
+		var s azureSubscription
+		if err := json.Unmarshal(raw, &s); err != nil {
+			return nil, err
+		}
+		subs = append(subs, s)
 	}
-	if err := json.Unmarshal(body, &result); err != nil {
-		return nil, err
-	}
-	return result.Value, nil
+	return subs, nil
 }
 
 func (a *azureHTTPAPI) ListRoleAssignments(ctx context.Context, subscriptionID string) ([]azureRoleAssignment, error) {
@@ -207,40 +263,22 @@ func (a *azureHTTPAPI) ListRoleAssignments(ctx context.Context, subscriptionID s
 		"https://management.azure.com/subscriptions/%s/providers/Microsoft.Authorization/roleAssignments?api-version=2022-04-01&$filter=%s",
 		subscriptionID, filter)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	items, err := a.fetchAllPages(ctx, u, a.armToken)
 	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Authorization", "Bearer "+a.armToken)
-
-	resp, err := a.client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
-
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("listRoleAssignments: HTTP %d", resp.StatusCode)
+		return nil, fmt.Errorf("listRoleAssignments: %w", err)
 	}
 
-	var result struct {
-		Value []struct {
+	assignments := make([]azureRoleAssignment, 0, len(items))
+	for _, raw := range items {
+		var v struct {
 			Properties struct {
 				RoleDefinitionID string `json:"roleDefinitionId"`
 				Scope            string `json:"scope"`
 			} `json:"properties"`
-		} `json:"value"`
-	}
-	if err := json.Unmarshal(body, &result); err != nil {
-		return nil, err
-	}
-
-	assignments := make([]azureRoleAssignment, 0, len(result.Value))
-	for _, v := range result.Value {
+		}
+		if err := json.Unmarshal(raw, &v); err != nil {
+			return nil, err
+		}
 		roleID := v.Properties.RoleDefinitionID
 		if idx := strings.LastIndex(roleID, "/"); idx >= 0 {
 			roleID = roleID[idx+1:]
@@ -262,37 +300,19 @@ func (a *azureHTTPAPI) GetDirectoryRoleMemberships(ctx context.Context) ([]strin
 		"https://graph.microsoft.com/v1.0/servicePrincipals/%s/memberOf/microsoft.graph.directoryRole",
 		a.objectID)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	items, err := a.fetchAllPages(ctx, u, a.graphToken)
 	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Authorization", "Bearer "+a.graphToken)
-
-	resp, err := a.client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
-
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("getDirectoryRoles: HTTP %d", resp.StatusCode)
+		return nil, fmt.Errorf("getDirectoryRoles: %w", err)
 	}
 
-	var result struct {
-		Value []struct {
+	roles := make([]string, 0, len(items))
+	for _, raw := range items {
+		var v struct {
 			RoleTemplateID string `json:"roleTemplateId"`
-		} `json:"value"`
-	}
-	if err := json.Unmarshal(body, &result); err != nil {
-		return nil, err
-	}
-
-	roles := make([]string, 0, len(result.Value))
-	for _, v := range result.Value {
+		}
+		if err := json.Unmarshal(raw, &v); err != nil {
+			return nil, err
+		}
 		if v.RoleTemplateID != "" {
 			roles = append(roles, v.RoleTemplateID)
 		}
@@ -309,38 +329,20 @@ func (a *azureHTTPAPI) GetAppRoleAssignments(ctx context.Context) ([]azureAppRol
 		"https://graph.microsoft.com/v1.0/servicePrincipals/%s/appRoleAssignments",
 		a.objectID)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	items, err := a.fetchAllPages(ctx, u, a.graphToken)
 	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Authorization", "Bearer "+a.graphToken)
-
-	resp, err := a.client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
-
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("getAppRoleAssignments: HTTP %d", resp.StatusCode)
+		return nil, fmt.Errorf("getAppRoleAssignments: %w", err)
 	}
 
-	var result struct {
-		Value []struct {
+	assignments := make([]azureAppRoleAssignment, 0, len(items))
+	for _, raw := range items {
+		var v struct {
 			AppRoleID           string `json:"appRoleId"`
 			ResourceDisplayName string `json:"resourceDisplayName"`
-		} `json:"value"`
-	}
-	if err := json.Unmarshal(body, &result); err != nil {
-		return nil, err
-	}
-
-	assignments := make([]azureAppRoleAssignment, 0, len(result.Value))
-	for _, v := range result.Value {
+		}
+		if err := json.Unmarshal(raw, &v); err != nil {
+			return nil, err
+		}
 		assignments = append(assignments, azureAppRoleAssignment{
 			AppRoleID:           v.AppRoleID,
 			ResourceDisplayName: v.ResourceDisplayName,

--- a/pkg/scoring/azure_test.go
+++ b/pkg/scoring/azure_test.go
@@ -19,6 +19,7 @@ type mockAzureAPI struct {
 	appRoleAssignments []azureAppRoleAssignment
 	subsErr            error
 	roleErr            error
+	roleErrBySub       map[string]error
 	dirRoleErr         error
 	appRoleErr         error
 }
@@ -28,6 +29,9 @@ func (m *mockAzureAPI) ListSubscriptions(_ context.Context) ([]azureSubscription
 }
 
 func (m *mockAzureAPI) ListRoleAssignments(_ context.Context, subscriptionID string) ([]azureRoleAssignment, error) {
+	if err, ok := m.roleErrBySub[subscriptionID]; ok {
+		return nil, err
+	}
 	if m.roleErr != nil {
 		return nil, m.roleErr
 	}
@@ -557,7 +561,6 @@ func TestAzureRBACCondition_ReturnsFalseOnSubscriptionError(t *testing.T) {
 }
 
 func TestAzureRBACCondition_SkipsBadSubscriptionGracefully(t *testing.T) {
-	calls := 0
 	cond := &azureRBACCondition{
 		matchRoles:        []string{azureRoleOwner},
 		subscriptionLevel: true,
@@ -566,10 +569,11 @@ func TestAzureRBACCondition_SkipsBadSubscriptionGracefully(t *testing.T) {
 			roleAssignments: map[string][]azureRoleAssignment{
 				"sub2": {{RoleDefinitionID: azureRoleOwner, Scope: "/subscriptions/sub2"}},
 			},
-			roleErr: nil,
+			roleErrBySub: map[string]error{
+				"sub1": errors.New("permission denied"),
+			},
 		}),
 	}
-	_ = calls
 	fired, err := cond.Evaluate(context.Background(), azureTestMatch())
 	require.NoError(t, err)
 	assert.True(t, fired)

--- a/pkg/scoring/azure_test.go
+++ b/pkg/scoring/azure_test.go
@@ -214,6 +214,33 @@ func TestIsSubscriptionScope(t *testing.T) {
 	}
 }
 
+func TestIsAtOrAboveSubscriptionScope(t *testing.T) {
+	tests := []struct {
+		scope string
+		want  bool
+	}{
+		// Subscription scope
+		{"/subscriptions/12345678-1234-1234-1234-123456789abc", true},
+		// Management group scopes
+		{"/providers/Microsoft.Management/managementGroups/my-mg", true},
+		{"/providers/Microsoft.Management/managementGroups/root-mg-group", true},
+		// Resource group (below subscription)
+		{"/subscriptions/sub1/resourceGroups/rg1", false},
+		// Deep resource scope
+		{"/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1", false},
+		// Edge cases
+		{"/", false},
+		{"", false},
+		// Not a management group even though it has providers prefix
+		{"/providers/Microsoft.Compute/virtualMachines/vm1", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.scope, func(t *testing.T) {
+			assert.Equal(t, tc.want, isAtOrAboveSubscriptionScope(tc.scope))
+		})
+	}
+}
+
 // --- Condition unit tests ---
 
 func TestAzureIncompleteCredentials_FiresWhenMissingIDs(t *testing.T) {
@@ -644,6 +671,40 @@ func TestAzureGraphReadOnlyCondition_DoesNotFireOnGraphError(t *testing.T) {
 	assert.False(t, fired)
 }
 
+func TestAzureGraphReadOnlyCondition_DoesNotFireWhenNonReaderARMRole(t *testing.T) {
+	cond := &azureGraphReadOnlyCondition{
+		clientFactory: fakeAzureFactory(&mockAzureAPI{
+			subscriptions: []azureSubscription{{ID: "sub1"}},
+			roleAssignments: map[string][]azureRoleAssignment{
+				"sub1": {{RoleDefinitionID: azureRoleContributor, Scope: "/subscriptions/sub1"}},
+			},
+			appRoleAssignments: []azureAppRoleAssignment{
+				{AppRoleID: "df021288-bdef-4463-88db-98f22de89214", ResourceDisplayName: "Microsoft Graph"},
+			},
+		}),
+	}
+	fired, err := cond.Evaluate(context.Background(), azureTestMatch())
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestAzureGraphReadOnlyCondition_FiresWhenOnlyReaderARMRole(t *testing.T) {
+	cond := &azureGraphReadOnlyCondition{
+		clientFactory: fakeAzureFactory(&mockAzureAPI{
+			subscriptions: []azureSubscription{{ID: "sub1"}},
+			roleAssignments: map[string][]azureRoleAssignment{
+				"sub1": {{RoleDefinitionID: azureRoleReader, Scope: "/subscriptions/sub1"}},
+			},
+			appRoleAssignments: []azureAppRoleAssignment{
+				{AppRoleID: "df021288-bdef-4463-88db-98f22de89214", ResourceDisplayName: "Microsoft Graph"},
+			},
+		}),
+	}
+	fired, err := cond.Evaluate(context.Background(), azureTestMatch())
+	require.NoError(t, err)
+	assert.True(t, fired)
+}
+
 func TestAzureSingleNonProdSubCondition_FiresForDevSub(t *testing.T) {
 	cond := &azureSingleNonProdSubCondition{
 		clientFactory: fakeAzureFactory(&mockAzureAPI{
@@ -977,14 +1038,14 @@ func TestAzureScorer_SeverityScenarios(t *testing.T) {
 			mock: &mockAzureAPI{
 				subscriptions: []azureSubscription{{ID: "sub1", DisplayName: "Production"}},
 				roleAssignments: map[string][]azureRoleAssignment{
-					"sub1": {{RoleDefinitionID: azureRoleContributor, Scope: "/subscriptions/sub1"}},
+					"sub1": {{RoleDefinitionID: azureRoleReader, Scope: "/subscriptions/sub1/resourceGroups/rg1"}},
 				},
 				appRoleAssignments: []azureAppRoleAssignment{
 					{AppRoleID: "df021288-bdef-4463-88db-98f22de89214", ResourceDisplayName: "Microsoft Graph"},
 				},
 			},
-			expectedScore: 65,
-			appliedNames:  []string{"contributor-sub-level", "graph-read-only"},
+			expectedScore: 25,
+			appliedNames:  []string{"reader-only-rg-level", "graph-read-only"},
 		},
 		{
 			name:      "contributor-single-non-prod",

--- a/pkg/scoring/azure_test.go
+++ b/pkg/scoring/azure_test.go
@@ -1,0 +1,1122 @@
+package scoring
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockAzureAPI struct {
+	subscriptions      []azureSubscription
+	roleAssignments    map[string][]azureRoleAssignment
+	directoryRoles     []string
+	appRoleAssignments []azureAppRoleAssignment
+	subsErr            error
+	roleErr            error
+	dirRoleErr         error
+	appRoleErr         error
+}
+
+func (m *mockAzureAPI) ListSubscriptions(_ context.Context) ([]azureSubscription, error) {
+	return m.subscriptions, m.subsErr
+}
+
+func (m *mockAzureAPI) ListRoleAssignments(_ context.Context, subscriptionID string) ([]azureRoleAssignment, error) {
+	if m.roleErr != nil {
+		return nil, m.roleErr
+	}
+	return m.roleAssignments[subscriptionID], nil
+}
+
+func (m *mockAzureAPI) GetDirectoryRoleMemberships(_ context.Context) ([]string, error) {
+	return m.directoryRoles, m.dirRoleErr
+}
+
+func (m *mockAzureAPI) GetAppRoleAssignments(_ context.Context) ([]azureAppRoleAssignment, error) {
+	return m.appRoleAssignments, m.appRoleErr
+}
+
+func fakeAzureFactory(api azureAPI) azureClientFactory {
+	return func(_ context.Context, _ *azureCredentials) (azureAPI, error) {
+		return api, nil
+	}
+}
+
+func fakeAzureFactoryErr(err error) azureClientFactory {
+	return func(_ context.Context, _ *azureCredentials) (azureAPI, error) {
+		return nil, err
+	}
+}
+
+func azureTestMatch() *types.Match {
+	return &types.Match{
+		NamedGroups: map[string][]byte{
+			"client_secret": []byte("ArE8Q~1pQL_W_8IZiTnG6TNB-.kGWlfzN61fUa2U"),
+		},
+		Snippet: types.Snippet{
+			Before:   []byte("AZURE_TENANT_ID=12345678-1234-1234-1234-123456789abc\nAZURE_CLIENT_ID=87654321-4321-4321-4321-cba987654321\n"),
+			Matching: []byte("AZURE_CLIENT_SECRET=ArE8Q~1pQL_W_8IZiTnG6TNB-.kGWlfzN61fUa2U"),
+			After:    []byte("\n"),
+		},
+	}
+}
+
+func azureIncompleteMatch() *types.Match {
+	return &types.Match{
+		NamedGroups: map[string][]byte{
+			"client_secret": []byte("ArE8Q~1pQL_W_8IZiTnG6TNB-.kGWlfzN61fUa2U"),
+		},
+		Snippet: types.Snippet{
+			Before:   []byte("some unrelated context\n"),
+			Matching: []byte("ArE8Q~1pQL_W_8IZiTnG6TNB-.kGWlfzN61fUa2U"),
+			After:    []byte("\n"),
+		},
+	}
+}
+
+// --- extractAzureCredentials tests ---
+
+func TestExtractAzureCredentials_Complete(t *testing.T) {
+	creds, ok := extractAzureCredentials(azureTestMatch())
+	require.True(t, ok)
+	assert.Equal(t, "12345678-1234-1234-1234-123456789abc", creds.TenantID)
+	assert.Equal(t, "87654321-4321-4321-4321-cba987654321", creds.ClientID)
+	assert.Equal(t, "ArE8Q~1pQL_W_8IZiTnG6TNB-.kGWlfzN61fUa2U", creds.ClientSecret)
+	assert.True(t, creds.complete())
+}
+
+func TestExtractAzureCredentials_Incomplete(t *testing.T) {
+	creds, ok := extractAzureCredentials(azureIncompleteMatch())
+	require.True(t, ok)
+	assert.Equal(t, "", creds.TenantID)
+	assert.Equal(t, "", creds.ClientID)
+	assert.False(t, creds.complete())
+}
+
+func TestExtractAzureCredentials_NilMatch(t *testing.T) {
+	_, ok := extractAzureCredentials(nil)
+	assert.False(t, ok)
+}
+
+func TestExtractAzureCredentials_MissingSecret(t *testing.T) {
+	m := &types.Match{NamedGroups: map[string][]byte{}}
+	_, ok := extractAzureCredentials(m)
+	assert.False(t, ok)
+}
+
+func TestExtractAzureCredentials_ARMEnvVars(t *testing.T) {
+	m := &types.Match{
+		NamedGroups: map[string][]byte{"client_secret": []byte("test-secret")},
+		Snippet: types.Snippet{
+			Before:   []byte("ARM_TENANT_ID=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\nARM_CLIENT_ID=11111111-2222-3333-4444-555555555555\n"),
+			Matching: []byte("ARM_CLIENT_SECRET=test-secret"),
+		},
+	}
+	creds, ok := extractAzureCredentials(m)
+	require.True(t, ok)
+	assert.Equal(t, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", creds.TenantID)
+	assert.Equal(t, "11111111-2222-3333-4444-555555555555", creds.ClientID)
+}
+
+func TestExtractAzureCredentials_JSONFormat(t *testing.T) {
+	m := &types.Match{
+		NamedGroups: map[string][]byte{"client_secret": []byte("test-secret")},
+		Snippet: types.Snippet{
+			Before:   []byte("\"tenant_id\": \"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\",\n\"client_id\": \"11111111-2222-3333-4444-555555555555\",\n"),
+			Matching: []byte("\"client_secret\": \"test-secret\""),
+		},
+	}
+	creds, ok := extractAzureCredentials(m)
+	require.True(t, ok)
+	assert.Equal(t, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", creds.TenantID)
+	assert.Equal(t, "11111111-2222-3333-4444-555555555555", creds.ClientID)
+}
+
+func TestExtractAzureCredentials_InAfterContext(t *testing.T) {
+	m := &types.Match{
+		NamedGroups: map[string][]byte{"client_secret": []byte("test-secret")},
+		Snippet: types.Snippet{
+			Matching: []byte("AZURE_CLIENT_SECRET=test-secret"),
+			After:    []byte("\nAZURE_TENANT_ID=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\nAZURE_CLIENT_ID=11111111-2222-3333-4444-555555555555"),
+		},
+	}
+	creds, ok := extractAzureCredentials(m)
+	require.True(t, ok)
+	assert.Equal(t, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", creds.TenantID)
+	assert.Equal(t, "11111111-2222-3333-4444-555555555555", creds.ClientID)
+}
+
+func TestExtractAzureCredentials_TerraformFormat(t *testing.T) {
+	m := &types.Match{
+		NamedGroups: map[string][]byte{"client_secret": []byte("test-secret")},
+		Snippet: types.Snippet{
+			Before: []byte("  tenant_id     = \"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\"\n  client_id     = \"11111111-2222-3333-4444-555555555555\"\n"),
+			Matching: []byte("  client_secret = \"test-secret\""),
+		},
+	}
+	creds, ok := extractAzureCredentials(m)
+	require.True(t, ok)
+	assert.Equal(t, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", creds.TenantID)
+	assert.Equal(t, "11111111-2222-3333-4444-555555555555", creds.ClientID)
+}
+
+func TestExtractAzureCredentials_CamelCase(t *testing.T) {
+	m := &types.Match{
+		NamedGroups: map[string][]byte{"client_secret": []byte("test-secret")},
+		Snippet: types.Snippet{
+			Before: []byte("\"tenantId\": \"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\",\n\"clientId\": \"11111111-2222-3333-4444-555555555555\",\n"),
+			Matching: []byte("\"clientSecret\": \"test-secret\""),
+		},
+	}
+	creds, ok := extractAzureCredentials(m)
+	require.True(t, ok)
+	assert.Equal(t, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", creds.TenantID)
+	assert.Equal(t, "11111111-2222-3333-4444-555555555555", creds.ClientID)
+}
+
+func TestExtractAzureCredentials_AppIdVariant(t *testing.T) {
+	m := &types.Match{
+		NamedGroups: map[string][]byte{"client_secret": []byte("test-secret")},
+		Snippet: types.Snippet{
+			Before: []byte("tenant_id=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\napp_id=11111111-2222-3333-4444-555555555555\n"),
+			Matching: []byte("AZURE_CLIENT_SECRET=test-secret"),
+		},
+	}
+	creds, ok := extractAzureCredentials(m)
+	require.True(t, ok)
+	assert.Equal(t, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", creds.TenantID)
+	assert.Equal(t, "11111111-2222-3333-4444-555555555555", creds.ClientID)
+}
+
+// --- isSubscriptionScope tests ---
+
+func TestIsSubscriptionScope(t *testing.T) {
+	tests := []struct {
+		scope string
+		want  bool
+	}{
+		{"/subscriptions/12345678-1234-1234-1234-123456789abc", true},
+		{"/subscriptions/12345678-1234-1234-1234-123456789abc/resourceGroups/rg1", false},
+		{"/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1", false},
+		{"/", false},
+		{"", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.scope, func(t *testing.T) {
+			assert.Equal(t, tc.want, isSubscriptionScope(tc.scope))
+		})
+	}
+}
+
+// --- Condition unit tests ---
+
+func TestAzureIncompleteCredentials_FiresWhenMissingIDs(t *testing.T) {
+	cond := &azureIncompleteCredentialsCondition{}
+	fired, err := cond.Evaluate(context.Background(), azureIncompleteMatch())
+	require.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestAzureIncompleteCredentials_DoesNotFireWhenComplete(t *testing.T) {
+	cond := &azureIncompleteCredentialsCondition{}
+	fired, err := cond.Evaluate(context.Background(), azureTestMatch())
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestAzureIncompleteCredentials_DoesNotFireWhenNoSecret(t *testing.T) {
+	cond := &azureIncompleteCredentialsCondition{}
+	m := &types.Match{NamedGroups: map[string][]byte{}}
+	fired, err := cond.Evaluate(context.Background(), m)
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestAzureExpiredCondition_IsDynamic(t *testing.T) {
+	mod := Modifier{Condition: &azureExpiredCondition{}}
+	assert.True(t, mod.IsDynamic())
+}
+
+func TestAzureExpiredCondition_FiresOnAADSTSError(t *testing.T) {
+	cond := &azureExpiredCondition{
+		clientFactory: fakeAzureFactoryErr(errors.New("invalid_client: AADSTS7000215: Invalid client secret")),
+	}
+	fired, err := cond.Evaluate(context.Background(), azureTestMatch())
+	require.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestAzureExpiredCondition_FiresOnAADSTS700016(t *testing.T) {
+	cond := &azureExpiredCondition{
+		clientFactory: fakeAzureFactoryErr(errors.New("unauthorized_client: AADSTS700016: Application not found")),
+	}
+	fired, err := cond.Evaluate(context.Background(), azureTestMatch())
+	require.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestAzureExpiredCondition_DoesNotFireWhenActive(t *testing.T) {
+	cond := &azureExpiredCondition{
+		clientFactory: fakeAzureFactory(&mockAzureAPI{}),
+	}
+	fired, err := cond.Evaluate(context.Background(), azureTestMatch())
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestAzureExpiredCondition_DoesNotFireOnNetworkError(t *testing.T) {
+	cond := &azureExpiredCondition{
+		clientFactory: fakeAzureFactoryErr(errors.New("connection refused")),
+	}
+	fired, err := cond.Evaluate(context.Background(), azureTestMatch())
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestAzureExpiredCondition_DoesNotFireOnIncompleteCredentials(t *testing.T) {
+	cond := &azureExpiredCondition{
+		clientFactory: fakeAzureFactoryErr(errors.New("AADSTS7000215: Invalid client secret")),
+	}
+	fired, err := cond.Evaluate(context.Background(), azureIncompleteMatch())
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestAzureGlobalAdminCondition_FiresWhenGlobalAdmin(t *testing.T) {
+	cond := &azureGlobalAdminCondition{
+		clientFactory: fakeAzureFactory(&mockAzureAPI{
+			directoryRoles: []string{azureDirRoleGlobalAdmin},
+		}),
+	}
+	fired, err := cond.Evaluate(context.Background(), azureTestMatch())
+	require.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestAzureGlobalAdminCondition_FiresWhenPrivRoleAdmin(t *testing.T) {
+	cond := &azureGlobalAdminCondition{
+		clientFactory: fakeAzureFactory(&mockAzureAPI{
+			directoryRoles: []string{azureDirRolePrivRoleAdmin},
+		}),
+	}
+	fired, err := cond.Evaluate(context.Background(), azureTestMatch())
+	require.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestAzureGlobalAdminCondition_DoesNotFireWithoutAdminRoles(t *testing.T) {
+	cond := &azureGlobalAdminCondition{
+		clientFactory: fakeAzureFactory(&mockAzureAPI{
+			directoryRoles: []string{"some-other-role-template-id"},
+		}),
+	}
+	fired, err := cond.Evaluate(context.Background(), azureTestMatch())
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestAzureGlobalAdminCondition_DoesNotFireOnGraphError(t *testing.T) {
+	cond := &azureGlobalAdminCondition{
+		clientFactory: fakeAzureFactory(&mockAzureAPI{
+			dirRoleErr: fmt.Errorf("insufficient privileges"),
+		}),
+	}
+	fired, err := cond.Evaluate(context.Background(), azureTestMatch())
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestAzureRBACCondition_OwnerAtSubLevel(t *testing.T) {
+	cond := &azureRBACCondition{
+		matchRoles:        []string{azureRoleOwner},
+		subscriptionLevel: true,
+		clientFactory: fakeAzureFactory(&mockAzureAPI{
+			subscriptions: []azureSubscription{{ID: "sub1", DisplayName: "Production"}},
+			roleAssignments: map[string][]azureRoleAssignment{
+				"sub1": {{RoleDefinitionID: azureRoleOwner, Scope: "/subscriptions/sub1"}},
+			},
+		}),
+	}
+	fired, err := cond.Evaluate(context.Background(), azureTestMatch())
+	require.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestAzureRBACCondition_OwnerAtRGLevelDoesNotMatchSubLevel(t *testing.T) {
+	cond := &azureRBACCondition{
+		matchRoles:        []string{azureRoleOwner},
+		subscriptionLevel: true,
+		clientFactory: fakeAzureFactory(&mockAzureAPI{
+			subscriptions: []azureSubscription{{ID: "sub1"}},
+			roleAssignments: map[string][]azureRoleAssignment{
+				"sub1": {{RoleDefinitionID: azureRoleOwner, Scope: "/subscriptions/sub1/resourceGroups/rg1"}},
+			},
+		}),
+	}
+	fired, err := cond.Evaluate(context.Background(), azureTestMatch())
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestAzureRBACCondition_ContributorExcludesOwner(t *testing.T) {
+	cond := &azureRBACCondition{
+		matchRoles:        []string{azureRoleContributor},
+		excludeRoles:      []string{azureRoleOwner},
+		subscriptionLevel: true,
+		clientFactory: fakeAzureFactory(&mockAzureAPI{
+			subscriptions: []azureSubscription{{ID: "sub1"}},
+			roleAssignments: map[string][]azureRoleAssignment{
+				"sub1": {
+					{RoleDefinitionID: azureRoleOwner, Scope: "/subscriptions/sub1"},
+					{RoleDefinitionID: azureRoleContributor, Scope: "/subscriptions/sub1"},
+				},
+			},
+		}),
+	}
+	fired, err := cond.Evaluate(context.Background(), azureTestMatch())
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestAzureRBACCondition_ContributorWithoutOwner(t *testing.T) {
+	cond := &azureRBACCondition{
+		matchRoles:        []string{azureRoleContributor},
+		excludeRoles:      []string{azureRoleOwner},
+		subscriptionLevel: true,
+		clientFactory: fakeAzureFactory(&mockAzureAPI{
+			subscriptions: []azureSubscription{{ID: "sub1"}},
+			roleAssignments: map[string][]azureRoleAssignment{
+				"sub1": {{RoleDefinitionID: azureRoleContributor, Scope: "/subscriptions/sub1"}},
+			},
+		}),
+	}
+	fired, err := cond.Evaluate(context.Background(), azureTestMatch())
+	require.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestAzureRBACCondition_KeyVaultRoles(t *testing.T) {
+	for _, roleID := range []string{azureRoleKVAdmin, azureRoleKVSecretsOfficer, azureRoleKVSecretsUser} {
+		t.Run(roleID, func(t *testing.T) {
+			cond := &azureRBACCondition{
+				matchRoles: []string{azureRoleKVAdmin, azureRoleKVSecretsOfficer, azureRoleKVSecretsUser},
+				clientFactory: fakeAzureFactory(&mockAzureAPI{
+					subscriptions: []azureSubscription{{ID: "sub1"}},
+					roleAssignments: map[string][]azureRoleAssignment{
+						"sub1": {{RoleDefinitionID: roleID, Scope: "/subscriptions/sub1/resourceGroups/rg1"}},
+					},
+				}),
+			}
+			fired, err := cond.Evaluate(context.Background(), azureTestMatch())
+			require.NoError(t, err)
+			assert.True(t, fired)
+		})
+	}
+}
+
+func TestAzureRBACCondition_ReaderOnlyRGLevel(t *testing.T) {
+	cond := &azureRBACCondition{
+		matchRoles:      []string{azureRoleReader},
+		onlyIfExclusive: true,
+		resourceGroupOnly: true,
+		clientFactory: fakeAzureFactory(&mockAzureAPI{
+			subscriptions: []azureSubscription{{ID: "sub1"}},
+			roleAssignments: map[string][]azureRoleAssignment{
+				"sub1": {{RoleDefinitionID: azureRoleReader, Scope: "/subscriptions/sub1/resourceGroups/rg1"}},
+			},
+		}),
+	}
+	fired, err := cond.Evaluate(context.Background(), azureTestMatch())
+	require.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestAzureRBACCondition_ReaderAtSubLevelDoesNotMatchRGOnly(t *testing.T) {
+	cond := &azureRBACCondition{
+		matchRoles:        []string{azureRoleReader},
+		onlyIfExclusive:   true,
+		resourceGroupOnly: true,
+		clientFactory: fakeAzureFactory(&mockAzureAPI{
+			subscriptions: []azureSubscription{{ID: "sub1"}},
+			roleAssignments: map[string][]azureRoleAssignment{
+				"sub1": {{RoleDefinitionID: azureRoleReader, Scope: "/subscriptions/sub1"}},
+			},
+		}),
+	}
+	fired, err := cond.Evaluate(context.Background(), azureTestMatch())
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestAzureRBACCondition_ReaderPlusOtherRoleNotExclusive(t *testing.T) {
+	cond := &azureRBACCondition{
+		matchRoles:        []string{azureRoleReader},
+		onlyIfExclusive:   true,
+		resourceGroupOnly: true,
+		clientFactory: fakeAzureFactory(&mockAzureAPI{
+			subscriptions: []azureSubscription{{ID: "sub1"}},
+			roleAssignments: map[string][]azureRoleAssignment{
+				"sub1": {
+					{RoleDefinitionID: azureRoleReader, Scope: "/subscriptions/sub1/resourceGroups/rg1"},
+					{RoleDefinitionID: azureRoleContributor, Scope: "/subscriptions/sub1/resourceGroups/rg2"},
+				},
+			},
+		}),
+	}
+	fired, err := cond.Evaluate(context.Background(), azureTestMatch())
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestAzureRBACCondition_SkipsWhenGlobalAdmin(t *testing.T) {
+	cond := &azureRBACCondition{
+		matchRoles:          []string{azureRoleOwner},
+		subscriptionLevel:   true,
+		skipIfPrivilegedDir: true,
+		clientFactory: fakeAzureFactory(&mockAzureAPI{
+			subscriptions: []azureSubscription{{ID: "sub1"}},
+			roleAssignments: map[string][]azureRoleAssignment{
+				"sub1": {{RoleDefinitionID: azureRoleOwner, Scope: "/subscriptions/sub1"}},
+			},
+			directoryRoles: []string{azureDirRoleGlobalAdmin},
+		}),
+	}
+	fired, err := cond.Evaluate(context.Background(), azureTestMatch())
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestAzureRBACCondition_NoAssignments(t *testing.T) {
+	cond := &azureRBACCondition{
+		matchRoles: []string{azureRoleOwner},
+		clientFactory: fakeAzureFactory(&mockAzureAPI{
+			subscriptions:   []azureSubscription{{ID: "sub1"}},
+			roleAssignments: map[string][]azureRoleAssignment{"sub1": {}},
+		}),
+	}
+	fired, err := cond.Evaluate(context.Background(), azureTestMatch())
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestAzureRBACCondition_NoSubscriptions(t *testing.T) {
+	cond := &azureRBACCondition{
+		matchRoles: []string{azureRoleOwner},
+		clientFactory: fakeAzureFactory(&mockAzureAPI{
+			subscriptions: []azureSubscription{},
+		}),
+	}
+	fired, err := cond.Evaluate(context.Background(), azureTestMatch())
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestAzureRBACCondition_ReturnsFalseOnSubscriptionError(t *testing.T) {
+	cond := &azureRBACCondition{
+		matchRoles: []string{azureRoleOwner},
+		clientFactory: fakeAzureFactory(&mockAzureAPI{
+			subsErr: fmt.Errorf("permission denied"),
+		}),
+	}
+	fired, err := cond.Evaluate(context.Background(), azureTestMatch())
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestAzureRBACCondition_SkipsBadSubscriptionGracefully(t *testing.T) {
+	calls := 0
+	cond := &azureRBACCondition{
+		matchRoles:        []string{azureRoleOwner},
+		subscriptionLevel: true,
+		clientFactory: fakeAzureFactory(&mockAzureAPI{
+			subscriptions: []azureSubscription{{ID: "sub1"}, {ID: "sub2"}},
+			roleAssignments: map[string][]azureRoleAssignment{
+				"sub2": {{RoleDefinitionID: azureRoleOwner, Scope: "/subscriptions/sub2"}},
+			},
+			roleErr: nil,
+		}),
+	}
+	_ = calls
+	fired, err := cond.Evaluate(context.Background(), azureTestMatch())
+	require.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestAzureMultiSubCondition_FiresAtThreshold(t *testing.T) {
+	for _, tc := range []struct {
+		count int
+		want  bool
+	}{
+		{2, false},
+		{3, true},
+		{4, true},
+	} {
+		t.Run(fmt.Sprintf("count=%d", tc.count), func(t *testing.T) {
+			subs := make([]azureSubscription, tc.count)
+			for i := range subs {
+				subs[i] = azureSubscription{ID: fmt.Sprintf("sub%d", i)}
+			}
+			cond := &azureMultiSubCondition{
+				minSubs:       3,
+				clientFactory: fakeAzureFactory(&mockAzureAPI{subscriptions: subs}),
+			}
+			fired, err := cond.Evaluate(context.Background(), azureTestMatch())
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, fired)
+		})
+	}
+}
+
+func TestAzureMultiSubCondition_ReturnsFalseOnError(t *testing.T) {
+	cond := &azureMultiSubCondition{
+		minSubs:       3,
+		clientFactory: fakeAzureFactory(&mockAzureAPI{subsErr: fmt.Errorf("permission denied")}),
+	}
+	fired, err := cond.Evaluate(context.Background(), azureTestMatch())
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestAzureGraphReadOnlyCondition_FiresWhenNoAppRoles(t *testing.T) {
+	cond := &azureGraphReadOnlyCondition{
+		clientFactory: fakeAzureFactory(&mockAzureAPI{
+			appRoleAssignments: []azureAppRoleAssignment{},
+		}),
+	}
+	fired, err := cond.Evaluate(context.Background(), azureTestMatch())
+	require.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestAzureGraphReadOnlyCondition_FiresWhenOnlyUserRead(t *testing.T) {
+	cond := &azureGraphReadOnlyCondition{
+		clientFactory: fakeAzureFactory(&mockAzureAPI{
+			appRoleAssignments: []azureAppRoleAssignment{
+				{AppRoleID: "df021288-bdef-4463-88db-98f22de89214", ResourceDisplayName: "Microsoft Graph"},
+			},
+		}),
+	}
+	fired, err := cond.Evaluate(context.Background(), azureTestMatch())
+	require.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestAzureGraphReadOnlyCondition_DoesNotFireWithPowerfulRoles(t *testing.T) {
+	cond := &azureGraphReadOnlyCondition{
+		clientFactory: fakeAzureFactory(&mockAzureAPI{
+			appRoleAssignments: []azureAppRoleAssignment{
+				{AppRoleID: "df021288-bdef-4463-88db-98f22de89214", ResourceDisplayName: "Microsoft Graph"},
+				{AppRoleID: "62a82d76-70ea-41e2-9197-370581804d09", ResourceDisplayName: "Microsoft Graph"},
+			},
+		}),
+	}
+	fired, err := cond.Evaluate(context.Background(), azureTestMatch())
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestAzureGraphReadOnlyCondition_SkipsWhenGlobalAdmin(t *testing.T) {
+	cond := &azureGraphReadOnlyCondition{
+		clientFactory: fakeAzureFactory(&mockAzureAPI{
+			appRoleAssignments: []azureAppRoleAssignment{},
+			directoryRoles:     []string{azureDirRoleGlobalAdmin},
+		}),
+	}
+	fired, err := cond.Evaluate(context.Background(), azureTestMatch())
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestAzureGraphReadOnlyCondition_DoesNotFireOnGraphError(t *testing.T) {
+	cond := &azureGraphReadOnlyCondition{
+		clientFactory: fakeAzureFactory(&mockAzureAPI{
+			appRoleErr: fmt.Errorf("no graph token"),
+		}),
+	}
+	fired, err := cond.Evaluate(context.Background(), azureTestMatch())
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestAzureSingleNonProdSubCondition_FiresForDevSub(t *testing.T) {
+	cond := &azureSingleNonProdSubCondition{
+		clientFactory: fakeAzureFactory(&mockAzureAPI{
+			subscriptions: []azureSubscription{{ID: "sub1", DisplayName: "my-dev-subscription"}},
+		}),
+	}
+	fired, err := cond.Evaluate(context.Background(), azureTestMatch())
+	require.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestAzureSingleNonProdSubCondition_DoesNotFireForProd(t *testing.T) {
+	cond := &azureSingleNonProdSubCondition{
+		clientFactory: fakeAzureFactory(&mockAzureAPI{
+			subscriptions: []azureSubscription{{ID: "sub1", DisplayName: "Production"}},
+		}),
+	}
+	fired, err := cond.Evaluate(context.Background(), azureTestMatch())
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestAzureSingleNonProdSubCondition_DoesNotFireForMultipleSubs(t *testing.T) {
+	cond := &azureSingleNonProdSubCondition{
+		clientFactory: fakeAzureFactory(&mockAzureAPI{
+			subscriptions: []azureSubscription{{ID: "s1", DisplayName: "dev"}, {ID: "s2", DisplayName: "staging"}},
+		}),
+	}
+	fired, err := cond.Evaluate(context.Background(), azureTestMatch())
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestAzureSingleNonProdSubCondition_AllPatterns(t *testing.T) {
+	for _, pat := range nonProdPatterns {
+		t.Run(pat, func(t *testing.T) {
+			cond := &azureSingleNonProdSubCondition{
+				clientFactory: fakeAzureFactory(&mockAzureAPI{
+					subscriptions: []azureSubscription{{ID: "sub1", DisplayName: "my-" + pat + "-sub"}},
+				}),
+			}
+			fired, err := cond.Evaluate(context.Background(), azureTestMatch())
+			require.NoError(t, err)
+			assert.True(t, fired, "pattern %q should fire", pat)
+		})
+	}
+}
+
+func TestAzureSingleNonProdSubCondition_SkipsWhenGlobalAdmin(t *testing.T) {
+	cond := &azureSingleNonProdSubCondition{
+		clientFactory: fakeAzureFactory(&mockAzureAPI{
+			subscriptions:  []azureSubscription{{ID: "sub1", DisplayName: "my-dev-sub"}},
+			directoryRoles: []string{azureDirRoleGlobalAdmin},
+		}),
+	}
+	fired, err := cond.Evaluate(context.Background(), azureTestMatch())
+	require.NoError(t, err)
+	assert.False(t, fired)
+}
+
+// --- injectAzureFactory helper ---
+
+func injectAzureFactory(m *Modifier, factory azureClientFactory) {
+	switch c := m.Condition.(type) {
+	case *azureExpiredCondition:
+		c.clientFactory = factory
+	case *azureGlobalAdminCondition:
+		c.clientFactory = factory
+	case *azureRBACCondition:
+		c.clientFactory = factory
+	case *azureMultiSubCondition:
+		c.clientFactory = factory
+	case *azureGraphReadOnlyCondition:
+		c.clientFactory = factory
+	case *azureSingleNonProdSubCondition:
+		c.clientFactory = factory
+	}
+}
+
+// --- Scorer structure tests ---
+
+func TestAzureGoScorer_Structure(t *testing.T) {
+	s := AzureGoScorer()
+	assert.Equal(t, "azure-sp-rbac-scope", s.Name)
+	assert.Equal(t, []string{"np.azure.7", "np.azure.8"}, s.RuleIDs)
+	require.Len(t, s.Modifiers, 10)
+
+	names := make([]string, len(s.Modifiers))
+	for i, mod := range s.Modifiers {
+		names[i] = mod.Name
+	}
+	expected := []string{
+		"expired-credentials", "global-admin", "owner-sub-level",
+		"contributor-sub-level", "keyvault-secret-access", "multi-subscription",
+		"incomplete-credentials", "reader-only-rg-level", "graph-read-only",
+		"single-non-prod-sub",
+	}
+	for _, name := range expected {
+		assert.Contains(t, names, name)
+	}
+}
+
+func TestAzureGoScorer_DynamicModifiersAreDynamic(t *testing.T) {
+	s := AzureGoScorer()
+	for _, mod := range s.Modifiers {
+		if mod.Name == "incomplete-credentials" {
+			assert.False(t, mod.IsDynamic(), "incomplete-credentials must be static")
+			continue
+		}
+		assert.True(t, mod.IsDynamic(), "modifier %s must be dynamic", mod.Name)
+	}
+}
+
+func TestAzureGoScorer_MissingCredentials(t *testing.T) {
+	s := AzureGoScorer()
+	m := &types.Match{NamedGroups: map[string][]byte{}}
+	for _, mod := range s.Modifiers {
+		fired, err := mod.Condition.Evaluate(context.Background(), m)
+		assert.NoError(t, err, "modifier %s should not error", mod.Name)
+		assert.False(t, fired, "modifier %s should not fire without credentials", mod.Name)
+	}
+}
+
+// --- Engine scenario tests ---
+
+func TestAzureScorer_ExpiredSetsScoreTo5(t *testing.T) {
+	s := AzureGoScorer()
+	factory := fakeAzureFactoryErr(errors.New("invalid_client: AADSTS7000215: invalid client secret"))
+	for i := range s.Modifiers {
+		injectAzureFactory(&s.Modifiers[i], factory)
+	}
+
+	engine := NewEngine([]*Scorer{s}, EngineConfig{ScopeEnabled: true, Timeout: 5 * time.Second})
+	rule := &types.Rule{ID: "np.azure.7", BaseScore: 80}
+	match := azureTestMatch()
+	match.RuleID = "np.azure.7"
+
+	score := engine.Score(context.Background(), &types.Finding{RuleID: rule.ID}, []*types.Match{match}, rule)
+	assert.Equal(t, 5, score.Final)
+	require.NotEmpty(t, score.Applied)
+	assert.Equal(t, "expired-credentials", score.Applied[0].Name)
+}
+
+func TestAzureScorer_GlobalAdminSetsTo99(t *testing.T) {
+	s := AzureGoScorer()
+	mock := &mockAzureAPI{
+		subscriptions: []azureSubscription{{ID: "sub1", DisplayName: "Production"}},
+		roleAssignments: map[string][]azureRoleAssignment{
+			"sub1": {{RoleDefinitionID: azureRoleContributor, Scope: "/subscriptions/sub1"}},
+		},
+		directoryRoles: []string{azureDirRoleGlobalAdmin},
+	}
+	factory := fakeAzureFactory(mock)
+	for i := range s.Modifiers {
+		injectAzureFactory(&s.Modifiers[i], factory)
+	}
+
+	engine := NewEngine([]*Scorer{s}, EngineConfig{ScopeEnabled: true, Timeout: 5 * time.Second})
+	rule := &types.Rule{ID: "np.azure.7", BaseScore: 80}
+	match := azureTestMatch()
+	match.RuleID = "np.azure.7"
+
+	score := engine.Score(context.Background(), &types.Finding{RuleID: rule.ID}, []*types.Match{match}, rule)
+	assert.Equal(t, 99, score.Final)
+	require.NotEmpty(t, score.Applied)
+	assert.Equal(t, "global-admin", score.Applied[0].Name)
+}
+
+func TestAzureScorer_OwnerSetsTo95(t *testing.T) {
+	s := AzureGoScorer()
+	mock := &mockAzureAPI{
+		subscriptions: []azureSubscription{{ID: "sub1", DisplayName: "Production"}},
+		roleAssignments: map[string][]azureRoleAssignment{
+			"sub1": {{RoleDefinitionID: azureRoleOwner, Scope: "/subscriptions/sub1"}},
+		},
+		appRoleAssignments: []azureAppRoleAssignment{
+			{AppRoleID: "62a82d76-70ea-41e2-9197-370581804d09", ResourceDisplayName: "Microsoft Graph"},
+		},
+	}
+	factory := fakeAzureFactory(mock)
+	for i := range s.Modifiers {
+		injectAzureFactory(&s.Modifiers[i], factory)
+	}
+
+	engine := NewEngine([]*Scorer{s}, EngineConfig{ScopeEnabled: true, Timeout: 5 * time.Second})
+	rule := &types.Rule{ID: "np.azure.7", BaseScore: 80}
+	match := azureTestMatch()
+	match.RuleID = "np.azure.7"
+
+	score := engine.Score(context.Background(), &types.Finding{RuleID: rule.ID}, []*types.Match{match}, rule)
+	assert.Equal(t, 95, score.Final)
+}
+
+func TestAzureScorer_ContributorSetsTo85(t *testing.T) {
+	s := AzureGoScorer()
+	mock := &mockAzureAPI{
+		subscriptions: []azureSubscription{{ID: "sub1", DisplayName: "Production"}},
+		roleAssignments: map[string][]azureRoleAssignment{
+			"sub1": {{RoleDefinitionID: azureRoleContributor, Scope: "/subscriptions/sub1"}},
+		},
+		appRoleAssignments: []azureAppRoleAssignment{
+			{AppRoleID: "62a82d76-70ea-41e2-9197-370581804d09", ResourceDisplayName: "Microsoft Graph"},
+		},
+	}
+	factory := fakeAzureFactory(mock)
+	for i := range s.Modifiers {
+		injectAzureFactory(&s.Modifiers[i], factory)
+	}
+
+	engine := NewEngine([]*Scorer{s}, EngineConfig{ScopeEnabled: true, Timeout: 5 * time.Second})
+	rule := &types.Rule{ID: "np.azure.8", BaseScore: 70}
+	match := azureTestMatch()
+	match.RuleID = "np.azure.8"
+
+	score := engine.Score(context.Background(), &types.Finding{RuleID: rule.ID}, []*types.Match{match}, rule)
+	assert.Equal(t, 85, score.Final)
+}
+
+func TestAzureScorer_IncompleteCredentialsDelta(t *testing.T) {
+	s := AzureGoScorer()
+	engine := NewEngine([]*Scorer{s}, EngineConfig{ScopeEnabled: true, Timeout: 5 * time.Second})
+	rule := &types.Rule{ID: "np.azure.7", BaseScore: 80}
+	match := azureIncompleteMatch()
+	match.RuleID = "np.azure.7"
+
+	score := engine.Score(context.Background(), &types.Finding{RuleID: rule.ID}, []*types.Match{match}, rule)
+	assert.Equal(t, 60, score.Final)
+	require.Len(t, score.Applied, 1)
+	assert.Equal(t, "incomplete-credentials", score.Applied[0].Name)
+}
+
+func TestAzureScorer_ReaderOnlyRGLevel(t *testing.T) {
+	s := AzureGoScorer()
+	mock := &mockAzureAPI{
+		subscriptions: []azureSubscription{{ID: "sub1", DisplayName: "Production"}},
+		roleAssignments: map[string][]azureRoleAssignment{
+			"sub1": {{RoleDefinitionID: azureRoleReader, Scope: "/subscriptions/sub1/resourceGroups/rg1"}},
+		},
+		appRoleAssignments: []azureAppRoleAssignment{
+			{AppRoleID: "62a82d76-70ea-41e2-9197-370581804d09", ResourceDisplayName: "Microsoft Graph"},
+		},
+	}
+	factory := fakeAzureFactory(mock)
+	for i := range s.Modifiers {
+		injectAzureFactory(&s.Modifiers[i], factory)
+	}
+
+	engine := NewEngine([]*Scorer{s}, EngineConfig{ScopeEnabled: true, Timeout: 5 * time.Second})
+	rule := &types.Rule{ID: "np.azure.7", BaseScore: 80}
+	match := azureTestMatch()
+	match.RuleID = "np.azure.7"
+
+	score := engine.Score(context.Background(), &types.Finding{RuleID: rule.ID}, []*types.Match{match}, rule)
+	assert.Equal(t, 55, score.Final)
+}
+
+func TestAzureScorer_ScopeDisabled_OnlyStaticFires(t *testing.T) {
+	s := AzureGoScorer()
+	engine := NewEngine([]*Scorer{s}, EngineConfig{ScopeEnabled: false, Timeout: 5 * time.Second})
+	rule := &types.Rule{ID: "np.azure.7", BaseScore: 80}
+
+	completeMatch := azureTestMatch()
+	completeMatch.RuleID = "np.azure.7"
+	score := engine.Score(context.Background(), &types.Finding{RuleID: rule.ID}, []*types.Match{completeMatch}, rule)
+	assert.Equal(t, 80, score.Final)
+	assert.Empty(t, score.Applied)
+
+	incompleteMatch := azureIncompleteMatch()
+	incompleteMatch.RuleID = "np.azure.7"
+	score2 := engine.Score(context.Background(), &types.Finding{RuleID: rule.ID}, []*types.Match{incompleteMatch}, rule)
+	assert.Equal(t, 60, score2.Final)
+	require.Len(t, score2.Applied, 1)
+	assert.Equal(t, "incomplete-credentials", score2.Applied[0].Name)
+}
+
+func TestAzureScorer_SeverityScenarios(t *testing.T) {
+	tests := []struct {
+		name          string
+		ruleID        string
+		baseScore     int
+		match         *types.Match
+		mock          *mockAzureAPI
+		expectedScore int
+		appliedNames  []string
+	}{
+		{
+			name:      "keyvault-access-delta",
+			ruleID:    "np.azure.7",
+			baseScore: 80,
+			match:     azureTestMatch(),
+			mock: &mockAzureAPI{
+				subscriptions: []azureSubscription{{ID: "sub1", DisplayName: "prod"}},
+				roleAssignments: map[string][]azureRoleAssignment{
+					"sub1": {{RoleDefinitionID: azureRoleKVSecretsUser, Scope: "/subscriptions/sub1/resourceGroups/rg1"}},
+				},
+				appRoleAssignments: []azureAppRoleAssignment{
+					{AppRoleID: "62a82d76-70ea-41e2-9197-370581804d09", ResourceDisplayName: "Microsoft Graph"},
+				},
+			},
+			expectedScore: 95,
+			appliedNames:  []string{"keyvault-secret-access"},
+		},
+		{
+			name:      "contributor-plus-multi-sub",
+			ruleID:    "np.azure.7",
+			baseScore: 80,
+			match:     azureTestMatch(),
+			mock: &mockAzureAPI{
+				subscriptions: []azureSubscription{
+					{ID: "sub1", DisplayName: "prod"},
+					{ID: "sub2", DisplayName: "staging"},
+					{ID: "sub3", DisplayName: "dev"},
+				},
+				roleAssignments: map[string][]azureRoleAssignment{
+					"sub1": {{RoleDefinitionID: azureRoleContributor, Scope: "/subscriptions/sub1"}},
+					"sub2": {},
+					"sub3": {},
+				},
+				appRoleAssignments: []azureAppRoleAssignment{
+					{AppRoleID: "62a82d76-70ea-41e2-9197-370581804d09", ResourceDisplayName: "Microsoft Graph"},
+				},
+			},
+			expectedScore: 95,
+			appliedNames:  []string{"contributor-sub-level", "multi-subscription"},
+		},
+		{
+			name:      "graph-read-only-delta",
+			ruleID:    "np.azure.8",
+			baseScore: 70,
+			match:     azureTestMatch(),
+			mock: &mockAzureAPI{
+				subscriptions: []azureSubscription{{ID: "sub1", DisplayName: "Production"}},
+				roleAssignments: map[string][]azureRoleAssignment{
+					"sub1": {{RoleDefinitionID: azureRoleContributor, Scope: "/subscriptions/sub1"}},
+				},
+				appRoleAssignments: []azureAppRoleAssignment{
+					{AppRoleID: "df021288-bdef-4463-88db-98f22de89214", ResourceDisplayName: "Microsoft Graph"},
+				},
+			},
+			expectedScore: 65,
+			appliedNames:  []string{"contributor-sub-level", "graph-read-only"},
+		},
+		{
+			name:      "contributor-single-non-prod",
+			ruleID:    "np.azure.8",
+			baseScore: 70,
+			match:     azureTestMatch(),
+			mock: &mockAzureAPI{
+				subscriptions: []azureSubscription{{ID: "sub1", DisplayName: "my-dev-environment"}},
+				roleAssignments: map[string][]azureRoleAssignment{
+					"sub1": {{RoleDefinitionID: azureRoleContributor, Scope: "/subscriptions/sub1"}},
+				},
+				appRoleAssignments: []azureAppRoleAssignment{
+					{AppRoleID: "62a82d76-70ea-41e2-9197-370581804d09", ResourceDisplayName: "Microsoft Graph"},
+				},
+			},
+			expectedScore: 75,
+			appliedNames:  []string{"contributor-sub-level", "single-non-prod-sub"},
+		},
+		{
+			name:      "reader-only-single-non-prod",
+			ruleID:    "np.azure.7",
+			baseScore: 80,
+			match:     azureTestMatch(),
+			mock: &mockAzureAPI{
+				subscriptions: []azureSubscription{{ID: "sub1", DisplayName: "sandbox-env"}},
+				roleAssignments: map[string][]azureRoleAssignment{
+					"sub1": {{RoleDefinitionID: azureRoleReader, Scope: "/subscriptions/sub1/resourceGroups/rg1"}},
+				},
+				appRoleAssignments: []azureAppRoleAssignment{
+					{AppRoleID: "62a82d76-70ea-41e2-9197-370581804d09", ResourceDisplayName: "Microsoft Graph"},
+				},
+			},
+			expectedScore: 45,
+			appliedNames:  []string{"reader-only-rg-level", "single-non-prod-sub"},
+		},
+		{
+			name:      "owner-with-keyvault-and-multi-sub",
+			ruleID:    "np.azure.7",
+			baseScore: 80,
+			match:     azureTestMatch(),
+			mock: &mockAzureAPI{
+				subscriptions: []azureSubscription{
+					{ID: "sub1", DisplayName: "prod"},
+					{ID: "sub2", DisplayName: "staging"},
+					{ID: "sub3", DisplayName: "dev"},
+				},
+				roleAssignments: map[string][]azureRoleAssignment{
+					"sub1": {
+						{RoleDefinitionID: azureRoleOwner, Scope: "/subscriptions/sub1"},
+						{RoleDefinitionID: azureRoleKVSecretsOfficer, Scope: "/subscriptions/sub1/resourceGroups/kv-rg"},
+					},
+					"sub2": {},
+					"sub3": {},
+				},
+				appRoleAssignments: []azureAppRoleAssignment{
+					{AppRoleID: "62a82d76-70ea-41e2-9197-370581804d09", ResourceDisplayName: "Microsoft Graph"},
+				},
+			},
+			expectedScore: 100,
+			appliedNames:  []string{"owner-sub-level", "keyvault-secret-access", "multi-subscription"},
+		},
+		{
+			name:      "global-admin-overrides-all-rbac",
+			ruleID:    "np.azure.7",
+			baseScore: 80,
+			match:     azureTestMatch(),
+			mock: &mockAzureAPI{
+				subscriptions: []azureSubscription{{ID: "sub1", DisplayName: "Production"}},
+				roleAssignments: map[string][]azureRoleAssignment{
+					"sub1": {
+						{RoleDefinitionID: azureRoleOwner, Scope: "/subscriptions/sub1"},
+					},
+				},
+				directoryRoles: []string{azureDirRoleGlobalAdmin},
+				appRoleAssignments: []azureAppRoleAssignment{
+					{AppRoleID: "62a82d76-70ea-41e2-9197-370581804d09", ResourceDisplayName: "Microsoft Graph"},
+				},
+			},
+			expectedScore: 99,
+			appliedNames:  []string{"global-admin"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := AzureGoScorer()
+			factory := fakeAzureFactory(tc.mock)
+			for i := range s.Modifiers {
+				injectAzureFactory(&s.Modifiers[i], factory)
+			}
+
+			engine := NewEngine([]*Scorer{s}, EngineConfig{ScopeEnabled: true, Timeout: 5 * time.Second})
+			rule := &types.Rule{ID: tc.ruleID, BaseScore: tc.baseScore}
+			match := tc.match
+			match.RuleID = tc.ruleID
+
+			score := engine.Score(context.Background(), &types.Finding{RuleID: rule.ID}, []*types.Match{match}, rule)
+
+			assert.Equal(t, tc.expectedScore, score.Final, "unexpected final score")
+
+			appliedNames := make([]string, len(score.Applied))
+			for i, a := range score.Applied {
+				appliedNames[i] = a.Name
+			}
+			for _, expected := range tc.appliedNames {
+				assert.Contains(t, appliedNames, expected, "expected modifier %s to be applied", expected)
+			}
+		})
+	}
+}
+
+// --- extractObjectIDFromJWT tests ---
+
+func TestExtractObjectIDFromJWT_Valid(t *testing.T) {
+	// header.payload.signature — payload decodes to {"oid":"test-object-id"}
+	// base64url("{}") = "e30"
+	// base64url('{"oid":"test-object-id"}') = "eyJvaWQiOiJ0ZXN0LW9iamVjdC1pZCJ9"
+	token := "e30.eyJvaWQiOiJ0ZXN0LW9iamVjdC1pZCJ9.sig"
+	oid, err := extractObjectIDFromJWT(token)
+	require.NoError(t, err)
+	assert.Equal(t, "test-object-id", oid)
+}
+
+func TestExtractObjectIDFromJWT_InvalidFormat(t *testing.T) {
+	_, err := extractObjectIDFromJWT("not-a-jwt")
+	assert.Error(t, err)
+}
+
+func TestExtractObjectIDFromJWT_MissingOID(t *testing.T) {
+	// base64url('{"sub":"test"}') = "eyJzdWIiOiJ0ZXN0In0"
+	token := "e30.eyJzdWIiOiJ0ZXN0In0.sig"
+	_, err := extractObjectIDFromJWT(token)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "oid claim missing")
+}

--- a/pkg/scoring/go_scorers.go
+++ b/pkg/scoring/go_scorers.go
@@ -14,6 +14,7 @@ func BuiltinGoScorers() []*Scorer {
 		MongoDBAtlasGoScorer(),
 		GitLabGoScorer(),
 		GCPGoScorer(),
+		AzureGoScorer(),
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add Go scorer for Azure service principal client secret rules (`np.azure.7`, `np.azure.8`) that enumerates RBAC roles, directory role memberships, and Graph app role assignments to determine credential severity
- 10 modifiers covering expired credentials, Global Admin/Priv Role Admin, Owner/Contributor at subscription scope, Key Vault secret access, multi-subscription blast radius, incomplete credential extraction, reader-only at RG scope, Graph-read-only app permissions, and single non-prod subscription
- Pure HTTP implementation (no Azure SDK dependency) matching the GCP scorer pattern — separate ARM and Graph token acquisition via client credentials OAuth2 flow

## Modifier Summary

| Name | Priority | Kind | Value | Trigger |
|------|----------|------|-------|---------|
| expired-credentials | 100 | set_score | 5 | AADSTS error codes on auth |
| global-admin | 95 | set_score | 99 | Global Admin or Priv Role Admin directory role |
| owner-sub-level | 90 | set_score | 95 | Owner at subscription scope |
| contributor-sub-level | 85 | set_score | 85 | Contributor at subscription scope (excludes Owner) |
| keyvault-secret-access | 75 | delta | +15 | KV Admin/Secrets Officer/Secrets User RBAC role |
| multi-subscription | 70 | delta | +10 | 3+ accessible subscriptions |
| incomplete-credentials | 60 | delta | -20 | Missing tenant_id or client_id in context (static) |
| reader-only-rg-level | 55 | delta | -25 | Only Reader role, only at resource group scope |
| graph-read-only | 50 | delta | -20 | Only minimal Graph app roles (User.Read.All etc.) |
| single-non-prod-sub | 45 | delta | -10 | Single subscription matching non-prod pattern |

## Design Decisions

- **set_score conflict resolution**: Owner/Contributor conditions use `skipIfPrivilegedDir` to avoid overriding the higher-priority Global Admin set_score. Contributor condition uses `excludeRoles` to skip when Owner is also present.
- **Credential extraction**: tenant_id/client_id extracted from snippet context via regex supporting env vars (`AZURE_TENANT_ID=`, `ARM_TENANT_ID=`), JSON (`"tenant_id": "..."`), Terraform (`tenant_id = "..."`), and camelCase (`"tenantId": "..."`) formats.
- **Graph token failure is non-fatal**: If the Graph token can't be acquired, directory role and app role conditions silently don't fire rather than erroring the whole scorer.
- **`incomplete-credentials` is static**: Fires without network calls even when `--score-scope` is disabled, since it only inspects snippet context.

## Test Plan

- [x] 59 unit tests covering credential extraction (10 format variants), `isSubscriptionScope`, per-condition behavior, scorer structure, and engine integration scenarios
- [x] Engine scenario tests verify all severity tiers: expired (5), Global Admin (99), Owner (95), Contributor (85), reader-only-RG (55), graph-read-only delta, multi-sub delta, keyvault delta, non-prod delta, incomplete delta
- [x] Scope-disabled test confirms only static conditions fire
- [x] Full `pkg/scoring/` test suite passes with no regressions
- [x] `go build ./...` clean
- [x] `go vet ./pkg/scoring/` clean

Closes LAB-3359