### PR TITLE
feat(enum): add stealth scanning with jitter for clone-based scanners

### DIFF
--- a/cmd/titus/github.go
+++ b/cmd/titus/github.go
@@ -240,7 +240,7 @@ func runGitHubScan(cmd *cobra.Command, args []string) error {
 				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Estimated scan time: %s (with %d repos)\n", formatDuration(estimate), len(repos))
 				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Continue? [Y/n] ")
 				var response string
-				fmt.Scanln(&response)
+				_, _ = fmt.Scanln(&response)
 				response = strings.TrimSpace(strings.ToLower(response))
 				if response == "n" || response == "no" {
 					return fmt.Errorf("scan cancelled by user")

--- a/cmd/titus/github.go
+++ b/cmd/titus/github.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/praetorian-inc/titus/pkg/enum"
@@ -24,6 +25,7 @@ var (
 	githubGit          bool
 	githubSkipForks    bool
 	githubRateLimit    float64
+	githubJitter       float64
 )
 
 var githubCmd = &cobra.Command{
@@ -44,11 +46,19 @@ Rate limiting:
   Use --rate-limit to add a delay between repository clones (recommended for large, self-hosted orgs).
   Example: --rate-limit 2 adds a 2-second delay between each repo.
 
+Stealth scanning:
+  Use --jitter to add random delays between repository clones.
+  Combined with --rate-limit, it creates a random delay between the
+  rate-limit (minimum) and jitter (maximum) values.
+  Example: --rate-limit 300 --jitter 1200 = random 5-20 minute delays.
+
 Examples:
   titus github praetorian-inc/titus                          # single public repo
   titus github --token ghp_xxx --org praetorian-inc          # all repos in org
   titus github --url https://ghe.corp.com --token ghp_xxx --org myorg --rate-limit 2
-  titus github --token ghp_xxx --user octocat --git          # user repos with full history`,
+  titus github --token ghp_xxx --user octocat --git          # user repos with full history
+  titus github --token ghp_xxx --org myorg --jitter 1200             # 0-20min random delay between clones
+  titus github --token ghp_xxx --org myorg --rate-limit 300 --jitter 1200  # 5-20min random delay (stealth)`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runGitHubScan,
 }
@@ -75,6 +85,7 @@ func init() {
 	githubScanCmd.Flags().BoolVar(&githubGit, "git", false, "Scan full git history (slower; default scans only current files)")
 	githubScanCmd.Flags().BoolVar(&githubSkipForks, "skip-forks", false, "Skip forked repositories when scanning orgs or users")
 	githubScanCmd.Flags().Float64Var(&githubRateLimit, "rate-limit", 0, "Delay in seconds between repository clones (e.g., 2 or 0.5; 0 = no delay)")
+	githubScanCmd.Flags().Float64Var(&githubJitter, "jitter", 0, "Maximum random delay in seconds between repository clones (e.g., 1200 for 20min; combined with --rate-limit as minimum)")
 	githubScanCmd.Flags().StringVar(&scanRulesPath, "rules", "", "Path to custom rules file or directory (merged with builtins)")
 	githubScanCmd.Flags().StringVar(&scanRulesInclude, "rules-include", "", "Include rules matching regex pattern (comma-separated)")
 	githubScanCmd.Flags().StringVar(&scanRulesExclude, "rules-exclude", "", "Exclude rules matching regex pattern (comma-separated)")
@@ -90,6 +101,7 @@ func init() {
 	githubCmd.Flags().BoolVar(&githubGit, "git", false, "Scan full git history (slower; default scans only current files)")
 	githubCmd.Flags().BoolVar(&githubSkipForks, "skip-forks", false, "Skip forked repositories when scanning orgs or users")
 	githubCmd.Flags().Float64Var(&githubRateLimit, "rate-limit", 0, "Delay in seconds between repository clones (e.g., 2 or 0.5; 0 = no delay)")
+	githubCmd.Flags().Float64Var(&githubJitter, "jitter", 0, "Maximum random delay in seconds between repository clones (e.g., 1200 for 20min; combined with --rate-limit as minimum)")
 	githubCmd.Flags().StringVar(&scanRulesPath, "rules", "", "Path to custom rules file or directory (merged with builtins)")
 	githubCmd.Flags().StringVar(&scanRulesInclude, "rules-include", "", "Include rules matching regex pattern (comma-separated)")
 	githubCmd.Flags().StringVar(&scanRulesExclude, "rules-exclude", "", "Exclude rules matching regex pattern (comma-separated)")
@@ -217,6 +229,25 @@ func runGitHubScan(cmd *cobra.Command, args []string) error {
 		if githubRateLimit > 0 {
 			cloneEnum.Delay = time.Duration(githubRateLimit * float64(time.Second))
 		}
+		if githubJitter > 0 {
+			cloneEnum.Jitter = time.Duration(githubJitter * float64(time.Second))
+		}
+
+		// Estimate scan time and prompt for confirmation if delay/jitter is enabled
+		if cloneEnum.Jitter > 0 || cloneEnum.Delay > 0 {
+			estimate := cloneEnum.EstimateScanTime()
+			if estimate > 0 {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Estimated scan time: %s (with %d repos)\n", formatDuration(estimate), len(repos))
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Continue? [Y/n] ")
+				var response string
+				fmt.Scanln(&response)
+				response = strings.TrimSpace(strings.ToLower(response))
+				if response == "n" || response == "no" {
+					return fmt.Errorf("scan cancelled by user")
+				}
+			}
+		}
+
 		enumerator = cloneEnum
 	}
 
@@ -299,6 +330,30 @@ func runGitHubScan(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("retrieving findings: %w", err)
 	}
 	return outputFindings(cmd, findings)
+}
+
+// formatDuration formats a duration in a human-friendly way.
+func formatDuration(d time.Duration) string {
+	if d < time.Minute {
+		return d.Round(time.Second).String()
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	}
+	hours := int(d.Hours())
+	mins := int(d.Minutes()) % 60
+	if hours >= 24 {
+		days := hours / 24
+		hours = hours % 24
+		if hours > 0 {
+			return fmt.Sprintf("%dd %dh", days, hours)
+		}
+		return fmt.Sprintf("%dd", days)
+	}
+	if mins > 0 {
+		return fmt.Sprintf("%dh %dm", hours, mins)
+	}
+	return fmt.Sprintf("%dh", hours)
 }
 
 // splitOwnerRepo splits "owner/repo" into ["owner", "repo"].

--- a/cmd/titus/github.go
+++ b/cmd/titus/github.go
@@ -26,6 +26,7 @@ var (
 	githubSkipForks    bool
 	githubRateLimit    float64
 	githubJitter       float64
+	githubYes          bool
 )
 
 var githubCmd = &cobra.Command{
@@ -90,6 +91,7 @@ func init() {
 	githubScanCmd.Flags().StringVar(&scanRulesInclude, "rules-include", "", "Include rules matching regex pattern (comma-separated)")
 	githubScanCmd.Flags().StringVar(&scanRulesExclude, "rules-exclude", "", "Exclude rules matching regex pattern (comma-separated)")
 	githubScanCmd.Flags().StringVar(&scanRuleset, "ruleset", "default", "Ruleset to use: default, np.assets, np.hashes, all (all = no filtering)")
+	githubScanCmd.Flags().BoolVarP(&githubYes, "yes", "y", false, "Skip confirmation prompt for scan time estimate")
 
 	githubCmd.Flags().StringVar(&githubToken, "token", "", "GitHub API token (or GITHUB_TOKEN env; optional for public repos)")
 	githubCmd.Flags().StringVar(&githubBaseURL, "url", "", "GitHub Enterprise base URL (or GITHUB_BASE_URL env; e.g., https://github.example.com)")
@@ -106,6 +108,7 @@ func init() {
 	githubCmd.Flags().StringVar(&scanRulesInclude, "rules-include", "", "Include rules matching regex pattern (comma-separated)")
 	githubCmd.Flags().StringVar(&scanRulesExclude, "rules-exclude", "", "Exclude rules matching regex pattern (comma-separated)")
 	githubCmd.Flags().StringVar(&scanRuleset, "ruleset", "default", "Ruleset to use: default, np.assets, np.hashes, all (all = no filtering)")
+	githubCmd.Flags().BoolVarP(&githubYes, "yes", "y", false, "Skip confirmation prompt for scan time estimate")
 
 	githubCmd.AddCommand(githubScanCmd)
 }
@@ -238,12 +241,14 @@ func runGitHubScan(cmd *cobra.Command, args []string) error {
 			estimate := cloneEnum.EstimateScanTime()
 			if estimate > 0 {
 				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Estimated scan time: %s (with %d repos)\n", formatDuration(estimate), len(repos))
-				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Continue? [Y/n] ")
-				var response string
-				_, _ = fmt.Scanln(&response)
-				response = strings.TrimSpace(strings.ToLower(response))
-				if response == "n" || response == "no" {
-					return fmt.Errorf("scan cancelled by user")
+				if !githubYes {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Continue? [Y/n] ")
+					var response string
+					_, _ = fmt.Scanln(&response)
+					response = strings.TrimSpace(strings.ToLower(response))
+					if response == "n" || response == "no" {
+						return fmt.Errorf("scan cancelled by user")
+					}
 				}
 			}
 		}

--- a/cmd/titus/gitlab.go
+++ b/cmd/titus/gitlab.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/praetorian-inc/titus/pkg/enum"
@@ -23,6 +24,7 @@ var (
 	gitlabNoClone      bool
 	gitlabGit          bool
 	gitlabRateLimit    float64
+	gitlabJitter       float64
 )
 
 var gitlabCmd = &cobra.Command{
@@ -31,7 +33,13 @@ var gitlabCmd = &cobra.Command{
 	Long: `Scan GitLab projects by cloning and scanning locally.
 No API token needed for public projects.
 Use --token or GITLAB_TOKEN for private projects and higher rate limits.
-Use --git to scan full git history (slower but finds deleted secrets).`,
+Use --git to scan full git history (slower but finds deleted secrets).
+
+Stealth scanning:
+  Use --jitter to add random delays between project clones.
+  Combined with --rate-limit, it creates a random delay between the
+  rate-limit (minimum) and jitter (maximum) values.
+  Example: --rate-limit 300 --jitter 1200 = random 5-20 minute delays.`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runGitLabScan,
 }
@@ -57,6 +65,7 @@ func init() {
 	gitlabScanCmd.Flags().BoolVar(&gitlabNoClone, "no-clone", false, "Fetch files via API instead of cloning (requires token, no git history)")
 	gitlabScanCmd.Flags().BoolVar(&gitlabGit, "git", false, "Scan full git history (slower; default scans only current files)")
 	gitlabScanCmd.Flags().Float64Var(&gitlabRateLimit, "rate-limit", 0, "Delay in seconds between project clones (e.g., 2 or 0.5; 0 = no delay)")
+	gitlabScanCmd.Flags().Float64Var(&gitlabJitter, "jitter", 0, "Maximum random delay in seconds between project clones (e.g., 1200 for 20min; combined with --rate-limit as minimum)")
 	gitlabScanCmd.Flags().StringVar(&scanRulesPath, "rules", "", "Path to custom rules file or directory (merged with builtins)")
 	gitlabScanCmd.Flags().StringVar(&scanRulesInclude, "rules-include", "", "Include rules matching regex pattern (comma-separated)")
 	gitlabScanCmd.Flags().StringVar(&scanRulesExclude, "rules-exclude", "", "Exclude rules matching regex pattern (comma-separated)")
@@ -71,6 +80,7 @@ func init() {
 	gitlabCmd.Flags().BoolVar(&gitlabNoClone, "no-clone", false, "Fetch files via API instead of cloning (requires token, no git history)")
 	gitlabCmd.Flags().BoolVar(&gitlabGit, "git", false, "Scan full git history (slower; default scans only current files)")
 	gitlabCmd.Flags().Float64Var(&gitlabRateLimit, "rate-limit", 0, "Delay in seconds between project clones (e.g., 2 or 0.5; 0 = no delay)")
+	gitlabCmd.Flags().Float64Var(&gitlabJitter, "jitter", 0, "Maximum random delay in seconds between project clones (e.g., 1200 for 20min; combined with --rate-limit as minimum)")
 	gitlabCmd.Flags().StringVar(&scanRulesPath, "rules", "", "Path to custom rules file or directory (merged with builtins)")
 	gitlabCmd.Flags().StringVar(&scanRulesInclude, "rules-include", "", "Include rules matching regex pattern (comma-separated)")
 	gitlabCmd.Flags().StringVar(&scanRulesExclude, "rules-exclude", "", "Exclude rules matching regex pattern (comma-separated)")
@@ -185,6 +195,25 @@ func runGitLabScan(cmd *cobra.Command, args []string) error {
 		if gitlabRateLimit > 0 {
 			cloneEnum.Delay = time.Duration(gitlabRateLimit * float64(time.Second))
 		}
+		if gitlabJitter > 0 {
+			cloneEnum.Jitter = time.Duration(gitlabJitter * float64(time.Second))
+		}
+
+		// Estimate scan time and prompt for confirmation if delay/jitter is enabled
+		if cloneEnum.Jitter > 0 || cloneEnum.Delay > 0 {
+			estimate := cloneEnum.EstimateScanTime()
+			if estimate > 0 {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Estimated scan time: %s (with %d projects)\n", formatDuration(estimate), len(projects))
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Continue? [Y/n] ")
+				var response string
+				fmt.Scanln(&response)
+				response = strings.TrimSpace(strings.ToLower(response))
+				if response == "n" || response == "no" {
+					return fmt.Errorf("scan cancelled by user")
+				}
+			}
+		}
+
 		enumerator = cloneEnum
 	}
 

--- a/cmd/titus/gitlab.go
+++ b/cmd/titus/gitlab.go
@@ -25,6 +25,7 @@ var (
 	gitlabGit          bool
 	gitlabRateLimit    float64
 	gitlabJitter       float64
+	gitlabYes          bool
 )
 
 var gitlabCmd = &cobra.Command{
@@ -70,6 +71,7 @@ func init() {
 	gitlabScanCmd.Flags().StringVar(&scanRulesInclude, "rules-include", "", "Include rules matching regex pattern (comma-separated)")
 	gitlabScanCmd.Flags().StringVar(&scanRulesExclude, "rules-exclude", "", "Exclude rules matching regex pattern (comma-separated)")
 	gitlabScanCmd.Flags().StringVar(&scanRuleset, "ruleset", "default", "Ruleset to use: default, np.assets, np.hashes, all (all = no filtering)")
+	gitlabScanCmd.Flags().BoolVarP(&gitlabYes, "yes", "y", false, "Skip confirmation prompt for scan time estimate")
 
 	gitlabCmd.Flags().StringVar(&gitlabToken, "token", "", "GitLab token (or GITLAB_TOKEN env; optional for public projects)")
 	gitlabCmd.Flags().StringVar(&gitlabGroup, "group", "", "Scan all projects in group")
@@ -85,6 +87,7 @@ func init() {
 	gitlabCmd.Flags().StringVar(&scanRulesInclude, "rules-include", "", "Include rules matching regex pattern (comma-separated)")
 	gitlabCmd.Flags().StringVar(&scanRulesExclude, "rules-exclude", "", "Exclude rules matching regex pattern (comma-separated)")
 	gitlabCmd.Flags().StringVar(&scanRuleset, "ruleset", "default", "Ruleset to use: default, np.assets, np.hashes, all (all = no filtering)")
+	gitlabCmd.Flags().BoolVarP(&gitlabYes, "yes", "y", false, "Skip confirmation prompt for scan time estimate")
 
 	gitlabCmd.AddCommand(gitlabScanCmd)
 }
@@ -204,12 +207,14 @@ func runGitLabScan(cmd *cobra.Command, args []string) error {
 			estimate := cloneEnum.EstimateScanTime()
 			if estimate > 0 {
 				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Estimated scan time: %s (with %d projects)\n", formatDuration(estimate), len(projects))
-				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Continue? [Y/n] ")
-				var response string
-				_, _ = fmt.Scanln(&response)
-				response = strings.TrimSpace(strings.ToLower(response))
-				if response == "n" || response == "no" {
-					return fmt.Errorf("scan cancelled by user")
+				if !gitlabYes {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Continue? [Y/n] ")
+					var response string
+					_, _ = fmt.Scanln(&response)
+					response = strings.TrimSpace(strings.ToLower(response))
+					if response == "n" || response == "no" {
+						return fmt.Errorf("scan cancelled by user")
+					}
 				}
 			}
 		}

--- a/cmd/titus/gitlab.go
+++ b/cmd/titus/gitlab.go
@@ -206,7 +206,7 @@ func runGitLabScan(cmd *cobra.Command, args []string) error {
 				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Estimated scan time: %s (with %d projects)\n", formatDuration(estimate), len(projects))
 				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Continue? [Y/n] ")
 				var response string
-				fmt.Scanln(&response)
+				_, _ = fmt.Scanln(&response)
 				response = strings.TrimSpace(strings.ToLower(response))
 				if response == "n" || response == "no" {
 					return fmt.Errorf("scan cancelled by user")

--- a/go.sum
+++ b/go.sum
@@ -7,10 +7,8 @@ cloud.google.com/go v0.45.1/go.mod h1:RpBamKRgapWJb87xiFSdk4g1CME7QZg3uwTez+TSTj
 cloud.google.com/go v0.46.3/go.mod h1:a6bKKbmY7er1mI7TEI4lsAkts/mkhTSZK8w33B4RAg0=
 cloud.google.com/go v0.50.0/go.mod h1:r9sluTvynVuxRIOHXQEHMFffphuXHOMZMycpNR5e6To=
 cloud.google.com/go v0.53.0/go.mod h1:fp/UouUEsRkN6ryDKNW/Upv/JBKnv6WDthjR6+vze6M=
-cloud.google.com/go v0.110.10 h1:LXy9GEO+timppncPIAZoOj3l58LIU9k+kn48AN7IO3Y=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/bigquery v1.3.0/go.mod h1:PjpwJnslEMmckchkHFfq+HTD2DmtT67aNFKH1/VBDHE=
-cloud.google.com/go/compute v1.23.3 h1:6sVlXXBmbd7jNX0Ipq0trII3e4n1/MsADLK6a+aiVlk=
 cloud.google.com/go/compute/metadata v0.7.0 h1:PBWF+iiAerVNe8UCHxdOt6eHLVc3ydFeOCw78U8ytSU=
 cloud.google.com/go/compute/metadata v0.7.0/go.mod h1:j5MvL9PprKL39t166CoB1uVHfQMs4tFQZZcKwksXUjo=
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=

--- a/pkg/enum/clone.go
+++ b/pkg/enum/clone.go
@@ -49,9 +49,12 @@ func (e *CloneEnumerator) stealthDelay() time.Duration {
 		if maxDelay <= minDelay {
 			return minDelay
 		}
-		rangeMs := (maxDelay - minDelay).Milliseconds()
-		randomMs := rand.Int63n(rangeMs)
-		return minDelay + time.Duration(randomMs)*time.Millisecond
+		rangeNs := (maxDelay - minDelay).Nanoseconds()
+		if rangeNs <= 0 {
+			return minDelay
+		}
+		randomNs := rand.Int63n(rangeNs) //nolint:gosec // jitter timing does not need crypto-grade randomness
+		return minDelay + time.Duration(randomNs)
 	}
 	return e.Delay
 }

--- a/pkg/enum/clone.go
+++ b/pkg/enum/clone.go
@@ -3,6 +3,7 @@ package enum
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -27,13 +28,49 @@ type CloneEnumerator struct {
 	config Config
 	Git    bool          // false = full clone + filesystem scan, true = full clone + git history (thorough)
 	Depth  int           // override clone depth (0 = automatic: full clone for filesystem mode, unlimited for git mode)
-	Delay  time.Duration // delay between repository clones (0 = no delay)
+	Delay  time.Duration // minimum delay between clones (from --rate-limit)
+	Jitter time.Duration // maximum delay between clones (from --jitter); actual delay is random(Delay, Jitter)
 	Token  string        // API token for authenticated cloning (passed via ephemeral credential helper)
 }
 
 // NewCloneEnumerator creates a new clone-based enumerator.
 func NewCloneEnumerator(repos []RepoInfo, config Config) *CloneEnumerator {
 	return &CloneEnumerator{repos: repos, config: config}
+}
+
+// stealthDelay returns the delay to wait before the next operation.
+// If Jitter is set, returns a random duration between Delay and Jitter.
+// If only Delay is set, returns Delay (fixed).
+// If neither is set, returns 0.
+func (e *CloneEnumerator) stealthDelay() time.Duration {
+	if e.Jitter > 0 {
+		minDelay := e.Delay
+		maxDelay := e.Jitter
+		if maxDelay <= minDelay {
+			return minDelay
+		}
+		rangeMs := (maxDelay - minDelay).Milliseconds()
+		randomMs := rand.Int63n(rangeMs)
+		return minDelay + time.Duration(randomMs)*time.Millisecond
+	}
+	return e.Delay
+}
+
+// EstimateScanTime returns the estimated total scan time based on delay/jitter settings.
+// It calculates the average delay per repo multiplied by the number of repos.
+func (e *CloneEnumerator) EstimateScanTime() time.Duration {
+	if len(e.repos) == 0 {
+		return 0
+	}
+	var avgDelay time.Duration
+	if e.Jitter > 0 {
+		// Average of uniform distribution between Delay and Jitter
+		avgDelay = (e.Delay + e.Jitter) / 2
+	} else {
+		avgDelay = e.Delay
+	}
+	// n-1 delays (no delay before the first repo)
+	return avgDelay * time.Duration(len(e.repos)-1)
 }
 
 // Enumerate clones each repository, scans it, and cleans up.
@@ -45,12 +82,16 @@ func (e *CloneEnumerator) Enumerate(ctx context.Context, callback func(content [
 		default:
 		}
 
-		// Rate limit: delay between repos (skip before first)
-		if e.Delay > 0 && i > 0 {
-			select {
-			case <-time.After(e.Delay):
-			case <-ctx.Done():
-				return ctx.Err()
+		// Stealth/rate-limit: delay between repos (skip before first)
+		if (e.Delay > 0 || e.Jitter > 0) && i > 0 {
+			wait := e.stealthDelay()
+			if wait > 0 {
+				fmt.Fprintf(os.Stderr, "Waiting %s before next repo (%d/%d)...\n", wait.Round(time.Second), i+1, len(e.repos))
+				select {
+				case <-time.After(wait):
+				case <-ctx.Done():
+					return ctx.Err()
+				}
 			}
 		}
 

--- a/pkg/enum/clone.go
+++ b/pkg/enum/clone.go
@@ -2,8 +2,9 @@ package enum
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
-	"math/rand"
+	"math/big"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -53,7 +54,11 @@ func (e *CloneEnumerator) stealthDelay() time.Duration {
 		if rangeNs <= 0 {
 			return minDelay
 		}
-		randomNs := rand.Int63n(rangeNs) //nolint:gosec // jitter timing does not need crypto-grade randomness
+		n, err := rand.Int(rand.Reader, big.NewInt(rangeNs))
+		if err != nil {
+			return minDelay
+		}
+		randomNs := n.Int64()
 		return minDelay + time.Duration(randomNs)
 	}
 	return e.Delay


### PR DESCRIPTION
## Summary

- Adds `--jitter` flag to GitHub and GitLab commands for randomized delays between repository clones
- `--rate-limit` sets the minimum delay, `--jitter` sets the maximum — actual delay is random between the two
- After enumerating repos, displays estimated scan time and prompts `Continue? [Y/n]`
- Progress output shows wait duration between each clone

## Usage

```bash
# Random 0-20min delay between clones
titus github --token ghp_xxx --org myorg --jitter 1200

# Random 5-20min delay (stealth mode)
titus github --token ghp_xxx --org myorg --rate-limit 300 --jitter 1200
```

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] Existing clone tests pass
- [x] Tested against praetorian-inc org (580 repos) — enumeration fast, jitter applied between clones, scan time estimate displayed

🤖 Generated with [Claude Code](https://claude.com/claude-code)