### PR TITLE
feat(enum): Slack xoxc token support, per-message provenance, and scanning UX

### DIFF
--- a/cmd/titus/slack.go
+++ b/cmd/titus/slack.go
@@ -14,6 +14,7 @@ import (
 
 var (
 	slackToken        string
+	slackCookie       string
 	slackOutputPath   string
 	slackOutputFormat string
 	slackChannels     string
@@ -27,19 +28,25 @@ var slackCmd = &cobra.Command{
 Enumerates channels, messages, and thread replies.
 
 Authentication:
-  Use --token or SLACK_TOKEN env var with a Slack Bot or User token.
-  Bot tokens start with xoxb-, user tokens with xoxp-.
+  Use --token or SLACK_TOKEN env var with a Slack token.
+  Supported token types: xoxb- (bot), xoxp- (user), xoxc- (browser session).
+  Browser session tokens (xoxc-) also require --cookie with the xoxd- session cookie.
+  To get xoxc/xoxd: open Slack in browser → DevTools → Application →
+    token: Local Storage → search for xoxc-
+    cookie: Cookies → cookie named "d" (starts with xoxd-)
 
 Examples:
   titus slack --token xoxb-xxx
   SLACK_TOKEN=xoxb-xxx titus slack
   titus slack --token xoxb-xxx --channels general,engineering
-  titus slack --token xoxb-xxx --output slack-scan.db --format json`,
+  titus slack --token xoxb-xxx --output slack-scan.db --format json
+  titus slack --token xoxc-xxx --cookie xoxd-xxx -v          # browser session token`,
 	RunE: runSlackScan,
 }
 
 func init() {
 	slackCmd.Flags().StringVar(&slackToken, "token", "", "Slack API token (or SLACK_TOKEN env)")
+	slackCmd.Flags().StringVar(&slackCookie, "cookie", "", "Slack session cookie (xoxd-...) — required for xoxc- tokens (or SLACK_COOKIE env)")
 	slackCmd.Flags().StringVar(&slackOutputPath, "output", "titus.db", "Output database path")
 	slackCmd.Flags().StringVar(&slackOutputFormat, "format", "human", "Output format: json, human")
 	slackCmd.Flags().StringVar(&slackChannels, "channels", "", "Comma-separated channel names to scan (default: all)")
@@ -60,6 +67,11 @@ func runSlackScan(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("slack API token is required: use --token or SLACK_TOKEN env var")
 	}
 
+	cookie := slackCookie
+	if cookie == "" {
+		cookie = os.Getenv("SLACK_COOKIE")
+	}
+
 	var verboseWriter io.Writer
 	if verbose {
 		verboseWriter = cmd.ErrOrStderr()
@@ -67,6 +79,7 @@ func runSlackScan(cmd *cobra.Command, args []string) error {
 
 	enumerator, err := enum.NewSlackEnumerator(enum.SlackConfig{
 		Token:     token,
+		Cookie:    cookie,
 		RateLimit: slackRateLimit,
 		Channels:  slackChannels,
 		Verbose:   verboseWriter,

--- a/cmd/titus/slack.go
+++ b/cmd/titus/slack.go
@@ -55,7 +55,7 @@ func init() {
 	slackCmd.Flags().StringVar(&scanRulesExclude, "rules-exclude", "", "Exclude rules matching regex pattern (comma-separated)")
 	slackCmd.Flags().StringVar(&scanRuleset, "ruleset", "default", "Ruleset to use: default, np.assets, np.hashes, all")
 	slackCmd.Flags().BoolVar(&scanIncludeNoisy, "include-noisy", false, "Include noisy rules that may produce more false positives")
-	slackCmd.Flags().Float64Var(&slackRateLimit, "rate-limit", 1.0, "API requests per second (default 1.0)")
+	slackCmd.Flags().Float64Var(&slackRateLimit, "rate-limit", 0.75, "API requests per second (default 0.75, Slack Tier 3 = 50 req/min)")
 }
 
 func runSlackScan(cmd *cobra.Command, args []string) error {

--- a/pkg/enum/slack.go
+++ b/pkg/enum/slack.go
@@ -56,13 +56,14 @@ func NewSlackEnumerator(cfg SlackConfig) (*SlackEnumerator, error) {
 }
 
 // slackProvenance builds an ExtendedProvenance for a Slack message.
-func slackProvenance(channel, channelID, messageURL, author string) types.ExtendedProvenance {
+func slackProvenance(channel, messageURL, author string) types.ExtendedProvenance {
 	return types.ExtendedProvenance{
 		Payload: map[string]interface{}{
 			"source":  "slack",
 			"channel": channel,
 			"author":  author,
 			"url":     messageURL,
+			"path":    messageURL,
 		},
 	}
 }
@@ -157,7 +158,7 @@ func (e *SlackEnumerator) slGet(ctx context.Context, endpoint string) ([]byte, e
 			return nil, fmt.Errorf("build request: %w", err)
 		}
 		req.Header.Set("Authorization", "Bearer "+e.config.Token)
-		if e.config.Cookie != "" {
+		if e.config.Cookie != "" && strings.HasPrefix(e.config.Token, "xoxc-") {
 			cookie := e.config.Cookie
 			if !strings.HasPrefix(cookie, "d=") {
 				cookie = "d=" + cookie
@@ -425,7 +426,11 @@ func (e *SlackEnumerator) slFetchUserNames(ctx context.Context) map[string]strin
 			}
 			names[m.ID] = name
 		}
-		cursor = resp.ResponseMetadata.NextCursor
+		newCursor := resp.ResponseMetadata.NextCursor
+		if newCursor == cursor {
+			break // stale cursor, prevent infinite loop
+		}
+		cursor = newCursor
 		if cursor == "" {
 			break
 		}
@@ -568,13 +573,14 @@ func (e *SlackEnumerator) Enumerate(ctx context.Context, callback func(content [
 
 			blob := slBuildMessageBlob(channelName, messageURL, conv.ID, msg, replies, userNames)
 			blobID := types.ComputeBlobID(blob)
-			prov := slackProvenance(channelName, conv.ID, messageURL, authorName)
+			prov := slackProvenance(channelName, messageURL, authorName)
 
 			if err := callback(blob, blobID, prov); err != nil {
 				return err
 			}
 		}
 
+		e.progressf("")
 		n := channelCount.Add(1)
 		if total > 0 {
 			e.progressf("Scanning channels: %d/%d (%d%%)", n, total, n*100/int64(total))

--- a/pkg/enum/slack.go
+++ b/pkg/enum/slack.go
@@ -21,7 +21,8 @@ const slackAPIBase = "https://slack.com/api/"
 
 // SlackConfig configures the Slack workspace enumerator.
 type SlackConfig struct {
-	Token     string    // Slack Bot or User token (xoxb-... or xoxp-...)
+	Token     string    // Slack API token (xoxb-..., xoxp-..., or xoxc-...)
+	Cookie    string    // Session cookie (xoxd-...) — required when using xoxc- tokens
 	RateLimit float64   // requests per second (default 1.0)
 	Channels  string    // comma-separated channel name filter (empty = all)
 	Verbose   io.Writer // progress output (nil = silent)
@@ -40,6 +41,9 @@ func NewSlackEnumerator(cfg SlackConfig) (*SlackEnumerator, error) {
 	if cfg.Token == "" {
 		return nil, fmt.Errorf("slack API token is required")
 	}
+	if strings.HasPrefix(cfg.Token, "xoxc-") && cfg.Cookie == "" {
+		return nil, fmt.Errorf("xoxc- tokens require a session cookie (--cookie with xoxd-... value)")
+	}
 	if cfg.RateLimit <= 0 {
 		cfg.RateLimit = 1.0
 	}
@@ -51,15 +55,14 @@ func NewSlackEnumerator(cfg SlackConfig) (*SlackEnumerator, error) {
 	}, nil
 }
 
-// slackProvenance builds an ExtendedProvenance for a Slack channel.
-func slackProvenance(channel, channelID, url, path string) types.ExtendedProvenance {
+// slackProvenance builds an ExtendedProvenance for a Slack message.
+func slackProvenance(channel, channelID, messageURL, author string) types.ExtendedProvenance {
 	return types.ExtendedProvenance{
 		Payload: map[string]interface{}{
-			"source":    "slack",
-			"channel":   channel,
-			"channelID": channelID,
-			"url":       url,
-			"path":      path,
+			"source":  "slack",
+			"channel": channel,
+			"author":  author,
+			"url":     messageURL,
 		},
 	}
 }
@@ -154,6 +157,13 @@ func (e *SlackEnumerator) slGet(ctx context.Context, endpoint string) ([]byte, e
 			return nil, fmt.Errorf("build request: %w", err)
 		}
 		req.Header.Set("Authorization", "Bearer "+e.config.Token)
+		if e.config.Cookie != "" {
+			cookie := e.config.Cookie
+			if !strings.HasPrefix(cookie, "d=") {
+				cookie = "d=" + cookie
+			}
+			req.Header.Set("Cookie", cookie)
+		}
 
 		resp, err := e.client.Do(req)
 		if err != nil {
@@ -328,22 +338,26 @@ func (e *SlackEnumerator) slFetchReplies(ctx context.Context, channelID, threadT
 }
 
 // slBuildMessageBlob assembles a single message and its thread replies into a blob.
-func slBuildMessageBlob(channelName, channelURL, channelID string, msg slMessage, replies []slMessage) []byte {
+func slBuildMessageBlob(channelName, messageURL, channelID string, msg slMessage, replies []slMessage, userNames map[string]string) []byte {
 	var sb strings.Builder
 	sb.WriteString("Channel: " + channelName + "\n")
-	sb.WriteString("URL: " + channelURL + "\n")
+	sb.WriteString("URL: " + messageURL + "\n")
 	sb.WriteString("ID: " + channelID + "\n")
 	sb.WriteString("---\n")
-	slWriteMessage(&sb, msg)
+	slWriteMessage(&sb, msg, userNames)
 	for _, reply := range replies {
-		slWriteMessage(&sb, reply)
+		slWriteMessage(&sb, reply, userNames)
 	}
 	return []byte(sb.String())
 }
 
 // slWriteMessage writes a single message's text and attachment content to a builder.
-func slWriteMessage(sb *strings.Builder, msg slMessage) {
-	sb.WriteString("[" + msg.User + "] [" + msg.TS + "]: " + msg.Text + "\n")
+func slWriteMessage(sb *strings.Builder, msg slMessage, userNames map[string]string) {
+	author := msg.User
+	if name, ok := userNames[msg.User]; ok {
+		author = name
+	}
+	sb.WriteString("[" + author + "] [" + msg.TS + "]: " + msg.Text + "\n")
 	for _, att := range msg.Attachments {
 		if att.Text != "" {
 			sb.WriteString("  [attachment]: " + att.Text + "\n")
@@ -354,9 +368,67 @@ func slWriteMessage(sb *strings.Builder, msg slMessage) {
 	}
 }
 
+// slMessagePermalink builds a deep link to a specific Slack message.
+// Format: https://{team}.slack.com/archives/{channelID}/p{timestamp_without_dot}
+func slMessagePermalink(teamDomain, channelID, ts string) string {
+	if teamDomain == "" {
+		return ""
+	}
+	tsNoDot := strings.ReplaceAll(ts, ".", "")
+	return teamDomain + "/archives/" + channelID + "/p" + tsNoDot
+}
+
 // slChannelURL returns the Slack web URL for a channel.
 func slChannelURL(channelID string) string {
 	return "https://app.slack.com/client/" + channelID
+}
+
+// slFetchUserNames builds a user ID to display name lookup by paginating users.list.
+func (e *SlackEnumerator) slFetchUserNames(ctx context.Context) map[string]string {
+	names := make(map[string]string)
+	cursor := ""
+	for {
+		endpoint := "users.list?limit=200"
+		if cursor != "" {
+			endpoint += "&cursor=" + url.QueryEscape(cursor)
+		}
+		body, err := e.slGet(ctx, endpoint)
+		if err != nil {
+			break
+		}
+		var resp struct {
+			OK      bool `json:"ok"`
+			Members []struct {
+				ID      string `json:"id"`
+				Name    string `json:"name"`
+				Profile struct {
+					DisplayName string `json:"display_name"`
+					RealName    string `json:"real_name"`
+				} `json:"profile"`
+			} `json:"members"`
+			ResponseMetadata struct {
+				NextCursor string `json:"next_cursor"`
+			} `json:"response_metadata"`
+		}
+		if json.Unmarshal(body, &resp) != nil || !resp.OK {
+			break
+		}
+		for _, m := range resp.Members {
+			name := m.Profile.DisplayName
+			if name == "" {
+				name = m.Profile.RealName
+			}
+			if name == "" {
+				name = m.Name
+			}
+			names[m.ID] = name
+		}
+		cursor = resp.ResponseMetadata.NextCursor
+		if cursor == "" {
+			break
+		}
+	}
+	return names
 }
 
 // slFilterChannels filters conversations by the --channels flag.
@@ -396,6 +468,19 @@ func slIsAccessError(errMsg string) bool {
 
 // Enumerate discovers content from a Slack workspace and yields blobs.
 func (e *SlackEnumerator) Enumerate(ctx context.Context, callback func(content []byte, blobID types.BlobID, prov types.Provenance) error) error {
+	// Get workspace info for building message permalinks
+	teamDomain := ""
+	authBody, err := e.slGet(ctx, "auth.test")
+	if err == nil {
+		var authResp struct {
+			OK  bool   `json:"ok"`
+			URL string `json:"url"`
+		}
+		if json.Unmarshal(authBody, &authResp) == nil && authResp.OK {
+			teamDomain = strings.TrimSuffix(authResp.URL, "/")
+		}
+	}
+
 	e.logf("Listing conversations...")
 
 	conversations, err := e.slListConversations(ctx)
@@ -408,6 +493,11 @@ func (e *SlackEnumerator) Enumerate(ctx context.Context, callback func(content [
 	total := len(conversations)
 	e.logf("Found %d conversations, scanning for secrets...", total)
 
+	// Build user lookup for display names
+	e.logf("Fetching user directory...")
+	userNames := e.slFetchUserNames(ctx)
+	e.logf("Loaded %d users", len(userNames))
+
 	var channelCount atomic.Int64
 
 	for _, conv := range conversations {
@@ -415,7 +505,6 @@ func (e *SlackEnumerator) Enumerate(ctx context.Context, callback func(content [
 		if channelName == "" {
 			channelName = conv.ID
 		}
-		channelURL := slChannelURL(conv.ID)
 
 		// Fetch channel history; skip inaccessible channels
 		messages, err := e.slFetchHistory(ctx, conv.ID)
@@ -450,9 +539,21 @@ func (e *SlackEnumerator) Enumerate(ctx context.Context, callback func(content [
 				}
 			}
 
-			blob := slBuildMessageBlob(channelName, channelURL, conv.ID, msg, replies)
+			// Resolve author name
+			authorName := msg.User
+			if name, ok := userNames[msg.User]; ok {
+				authorName = name
+			}
+
+			// Build message permalink
+			messageURL := slMessagePermalink(teamDomain, conv.ID, msg.TS)
+			if messageURL == "" {
+				messageURL = slChannelURL(conv.ID)
+			}
+
+			blob := slBuildMessageBlob(channelName, messageURL, conv.ID, msg, replies, userNames)
 			blobID := types.ComputeBlobID(blob)
-			prov := slackProvenance(channelName, conv.ID, channelURL, channelURL)
+			prov := slackProvenance(channelName, conv.ID, messageURL, authorName)
 
 			if err := callback(blob, blobID, prov); err != nil {
 				return err

--- a/pkg/enum/slack.go
+++ b/pkg/enum/slack.go
@@ -23,7 +23,7 @@ const slackAPIBase = "https://slack.com/api/"
 type SlackConfig struct {
 	Token     string    // Slack API token (xoxb-..., xoxp-..., or xoxc-...)
 	Cookie    string    // Session cookie (xoxd-...) — required when using xoxc- tokens
-	RateLimit float64   // requests per second (default 1.0)
+	RateLimit float64   // requests per second (default 0.75)
 	Channels  string    // comma-separated channel name filter (empty = all)
 	Verbose   io.Writer // progress output (nil = silent)
 }
@@ -45,7 +45,7 @@ func NewSlackEnumerator(cfg SlackConfig) (*SlackEnumerator, error) {
 		return nil, fmt.Errorf("xoxc- tokens require a session cookie (--cookie with xoxd-... value)")
 	}
 	if cfg.RateLimit <= 0 {
-		cfg.RateLimit = 1.0
+		cfg.RateLimit = 0.75
 	}
 	return &SlackEnumerator{
 		config:  cfg,
@@ -70,7 +70,7 @@ func slackProvenance(channel, channelID, messageURL, author string) types.Extend
 // logf writes a progress message when verbose output is enabled.
 func (e *SlackEnumerator) logf(format string, args ...interface{}) {
 	if e.config.Verbose != nil {
-		_, _ = fmt.Fprintf(e.config.Verbose, format+"\n", args...)
+		_, _ = fmt.Fprintf(e.config.Verbose, "\r%-80s\n", fmt.Sprintf(format, args...))
 	}
 }
 
@@ -193,11 +193,13 @@ func (e *SlackEnumerator) slGet(ctx context.Context, endpoint string) ([]byte, e
 				}
 			}
 			if attempt < maxAttempts-1 {
+				e.progressf("Rate limited — waiting %ds...", int(backoff.Seconds()))
 				select {
 				case <-ctx.Done():
 					return nil, ctx.Err()
 				case <-time.After(backoff):
 				}
+				e.progressf("")
 				continue
 			}
 			return nil, fmt.Errorf("slack API %s rate limited after %d attempts", endpoint, maxAttempts)
@@ -517,10 +519,23 @@ func (e *SlackEnumerator) Enumerate(ctx context.Context, callback func(content [
 			return fmt.Errorf("fetching history for %s: %w", channelName, err)
 		}
 
+		// Count threads for progress reporting
+		threadCount := 0
+		totalThreads := 0
+		for _, m := range messages {
+			if m.ReplyCount > 0 {
+				totalThreads++
+			}
+		}
+
 		// Emit one blob per message (with thread replies inline)
 		for _, msg := range messages {
 			var replies []slMessage
 			if msg.ReplyCount > 0 {
+				threadCount++
+				if totalThreads > 10 {
+					e.progressf("Scanning %s: thread %d/%d", channelName, threadCount, totalThreads)
+				}
 				threadReplies, err := e.slFetchReplies(ctx, conv.ID, msg.TS)
 				if err != nil {
 					if slIsAccessError(err.Error()) {
@@ -569,7 +584,7 @@ func (e *SlackEnumerator) Enumerate(ctx context.Context, callback func(content [
 	}
 
 	if total > 0 {
-		e.progressf("Scanning channels: %d/%d (100%%)\n", channelCount.Load(), total)
+		e.logf("Scanning channels: %d/%d (100%%)", channelCount.Load(), total)
 	}
 
 	e.logf("Scanned %d channels", channelCount.Load())

--- a/pkg/enum/slack_test.go
+++ b/pkg/enum/slack_test.go
@@ -128,15 +128,14 @@ func TestSlackEnumerator_Interface(t *testing.T) {
 }
 
 func TestSlackProvenance(t *testing.T) {
-	prov := slackProvenance("general", "C12345", "https://myteam.slack.com/archives/C12345/p10000001", "Alice")
+	prov := slackProvenance("general", "https://myteam.slack.com/archives/C12345/p10000001", "Alice")
 	assert.Equal(t, "extended", prov.Kind())
 	assert.Equal(t, "slack", prov.Payload["source"])
 	assert.Equal(t, "general", prov.Payload["channel"])
 	assert.Equal(t, "Alice", prov.Payload["author"])
 	assert.Equal(t, "https://myteam.slack.com/archives/C12345/p10000001", prov.Payload["url"])
-	// channelID and path should no longer be present
+	assert.Equal(t, "https://myteam.slack.com/archives/C12345/p10000001", prov.Payload["path"])
 	assert.Nil(t, prov.Payload["channelID"])
-	assert.Nil(t, prov.Payload["path"])
 }
 
 func TestSlackMessagePermalink(t *testing.T) {

--- a/pkg/enum/slack_test.go
+++ b/pkg/enum/slack_test.go
@@ -25,6 +25,102 @@ func TestSlackEnumerator_RequiresToken(t *testing.T) {
 	assert.Contains(t, err.Error(), "token")
 }
 
+func TestSlackEnumerator_XoxcRequiresCookie(t *testing.T) {
+	_, err := NewSlackEnumerator(SlackConfig{Token: "xoxc-browser-session-token"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "xoxc-")
+	assert.Contains(t, err.Error(), "cookie")
+}
+
+func TestSlackEnumerator_XoxcWithCookie(t *testing.T) {
+	e, err := NewSlackEnumerator(SlackConfig{
+		Token:  "xoxc-browser-session-token",
+		Cookie: "xoxd-session-cookie-value",
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, e)
+	assert.Equal(t, "xoxc-browser-session-token", e.config.Token)
+	assert.Equal(t, "xoxd-session-cookie-value", e.config.Cookie)
+}
+
+func TestSlackEnumerator_XoxcCookieHeader(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer xoxc-test-token", r.Header.Get("Authorization"))
+		assert.Equal(t, "d=xoxd-test-cookie", r.Header.Get("Cookie"))
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"ok":       true,
+			"channels": []map[string]interface{}{},
+			"response_metadata": map[string]interface{}{
+				"next_cursor": "",
+			},
+		})
+	}))
+	defer server.Close()
+
+	e, err := NewSlackEnumerator(SlackConfig{
+		Token:     "xoxc-test-token",
+		Cookie:    "xoxd-test-cookie",
+		RateLimit: 1000,
+	})
+	require.NoError(t, err)
+	e.baseURL = server.URL + "/"
+
+	conversations, err := e.slListConversations(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, conversations)
+}
+
+func TestSlackEnumerator_XoxcCookieHeaderWithPrefix(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "d=xoxd-test-cookie", r.Header.Get("Cookie"))
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"ok":       true,
+			"channels": []map[string]interface{}{},
+			"response_metadata": map[string]interface{}{
+				"next_cursor": "",
+			},
+		})
+	}))
+	defer server.Close()
+
+	e, err := NewSlackEnumerator(SlackConfig{
+		Token:     "xoxc-test-token",
+		Cookie:    "d=xoxd-test-cookie",
+		RateLimit: 1000,
+	})
+	require.NoError(t, err)
+	e.baseURL = server.URL + "/"
+
+	_, err = e.slListConversations(context.Background())
+	require.NoError(t, err)
+}
+
+func TestSlackEnumerator_NoCookieHeaderWithoutCookie(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer xoxb-test-token", r.Header.Get("Authorization"))
+		assert.Empty(t, r.Header.Get("Cookie"), "Cookie header should not be set without a cookie config")
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"ok":       true,
+			"channels": []map[string]interface{}{},
+			"response_metadata": map[string]interface{}{
+				"next_cursor": "",
+			},
+		})
+	}))
+	defer server.Close()
+
+	e := testSlackEnumerator(t, server.URL+"/")
+
+	_, err := e.slListConversations(context.Background())
+	require.NoError(t, err)
+}
+
 func TestSlackEnumerator_Interface(t *testing.T) {
 	e, err := NewSlackEnumerator(SlackConfig{Token: "xoxb-test-token"})
 	require.NoError(t, err)
@@ -32,13 +128,23 @@ func TestSlackEnumerator_Interface(t *testing.T) {
 }
 
 func TestSlackProvenance(t *testing.T) {
-	prov := slackProvenance("general", "C12345", "https://app.slack.com/client/C12345", "https://app.slack.com/client/C12345")
+	prov := slackProvenance("general", "C12345", "https://myteam.slack.com/archives/C12345/p10000001", "Alice")
 	assert.Equal(t, "extended", prov.Kind())
 	assert.Equal(t, "slack", prov.Payload["source"])
 	assert.Equal(t, "general", prov.Payload["channel"])
-	assert.Equal(t, "C12345", prov.Payload["channelID"])
-	assert.Equal(t, "https://app.slack.com/client/C12345", prov.Payload["url"])
-	assert.Equal(t, "https://app.slack.com/client/C12345", prov.Payload["path"])
+	assert.Equal(t, "Alice", prov.Payload["author"])
+	assert.Equal(t, "https://myteam.slack.com/archives/C12345/p10000001", prov.Payload["url"])
+	// channelID and path should no longer be present
+	assert.Nil(t, prov.Payload["channelID"])
+	assert.Nil(t, prov.Payload["path"])
+}
+
+func TestSlackMessagePermalink(t *testing.T) {
+	link := slMessagePermalink("https://myteam.slack.com", "C12345", "1234567890.123456")
+	assert.Equal(t, "https://myteam.slack.com/archives/C12345/p1234567890123456", link)
+
+	link = slMessagePermalink("", "C12345", "1234567890.123456")
+	assert.Equal(t, "", link)
 }
 
 // Compile-time assertion that *SlackEnumerator satisfies Enumerator.
@@ -59,7 +165,7 @@ func TestSlackBuildMessageBlob(t *testing.T) {
 	replies := []slMessage{
 		{User: "U002", TS: "1234567890.000200", Text: "API_KEY=sk_live_abc123"},
 	}
-	blob := slBuildMessageBlob("general", "https://app.slack.com/client/C12345", "C12345", msg, replies)
+	blob := slBuildMessageBlob("general", "https://app.slack.com/client/C12345", "C12345", msg, replies, nil)
 
 	content := string(blob)
 	assert.Contains(t, content, "Channel: general")
@@ -74,7 +180,7 @@ func TestSlackBuildMessageBlob(t *testing.T) {
 
 func TestSlackBuildMessageBlob_NoAttachments(t *testing.T) {
 	msg := slMessage{User: "U001", TS: "1000.0001", Text: "plain message"}
-	blob := slBuildMessageBlob("general", "https://app.slack.com/client/C12345", "C12345", msg, nil)
+	blob := slBuildMessageBlob("general", "https://app.slack.com/client/C12345", "C12345", msg, nil, nil)
 	content := string(blob)
 	assert.Contains(t, content, "[U001] [1000.0001]: plain message")
 	assert.NotContains(t, content, "[attachment]")
@@ -89,7 +195,7 @@ func TestSlackBuildMessageBlob_AttachmentSameTextAndFallback(t *testing.T) {
 			{Text: "same", Fallback: "same"},
 		},
 	}
-	blob := slBuildMessageBlob("general", "https://app.slack.com/client/C12345", "C12345", msg, nil)
+	blob := slBuildMessageBlob("general", "https://app.slack.com/client/C12345", "C12345", msg, nil, nil)
 	content := string(blob)
 	assert.Contains(t, content, "[attachment]: same")
 	// Fallback should be omitted when it matches text
@@ -222,6 +328,19 @@ func TestSlackEnumerate_NotInChannelSkipped(t *testing.T) {
 		path := r.URL.Path
 
 		switch {
+		case strings.Contains(path, "auth.test"):
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"ok":  true,
+				"url": "https://testteam.slack.com/",
+			})
+
+		case strings.Contains(path, "users.list"):
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"ok":      true,
+				"members": []map[string]interface{}{},
+				"response_metadata": map[string]interface{}{"next_cursor": ""},
+			})
+
 		case strings.Contains(path, "conversations.list"):
 			_ = json.NewEncoder(w).Encode(map[string]interface{}{
 				"ok": true,
@@ -276,6 +395,44 @@ func TestSlackEnumerate_FullIntegration(t *testing.T) {
 		path := r.URL.Path
 
 		switch {
+		case strings.Contains(path, "auth.test"):
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"ok":  true,
+				"url": "https://testteam.slack.com/",
+			})
+
+		case strings.Contains(path, "users.list"):
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"ok": true,
+				"members": []map[string]interface{}{
+					{
+						"id":   "U001",
+						"name": "alice",
+						"profile": map[string]interface{}{
+							"display_name": "Alice Smith",
+							"real_name":    "Alice S",
+						},
+					},
+					{
+						"id":   "U002",
+						"name": "bob",
+						"profile": map[string]interface{}{
+							"display_name": "",
+							"real_name":    "Bob Jones",
+						},
+					},
+					{
+						"id":   "U003",
+						"name": "charlie",
+						"profile": map[string]interface{}{
+							"display_name": "Charlie",
+							"real_name":    "Charlie D",
+						},
+					},
+				},
+				"response_metadata": map[string]interface{}{"next_cursor": ""},
+			})
+
 		case strings.Contains(path, "conversations.list"):
 			_ = json.NewEncoder(w).Encode(map[string]interface{}{
 				"ok": true,
@@ -344,22 +501,39 @@ func TestSlackEnumerate_FullIntegration(t *testing.T) {
 	e := testSlackEnumerator(t, server.URL+"/")
 
 	var blobs []string
+	var provs []types.Provenance
 	err := e.Enumerate(context.Background(), func(content []byte, blobID types.BlobID, prov types.Provenance) error {
 		blobs = append(blobs, string(content))
+		provs = append(provs, prov)
 		return nil
 	})
 	require.NoError(t, err)
 	// Per-message blobs: one for the thread parent (with reply), one for the standalone
 	require.Len(t, blobs, 2)
 
-	// First blob: thread parent with its reply
+	// First blob: thread parent with its reply — display names resolved
 	assert.Contains(t, blobs[0], "Channel: engineering")
+	assert.Contains(t, blobs[0], "[Alice Smith]")
 	assert.Contains(t, blobs[0], "thread parent")
+	assert.Contains(t, blobs[0], "[Bob Jones]")
 	assert.Contains(t, blobs[0], "SECRET_KEY=abc123")
+	assert.Contains(t, blobs[0], "URL: https://testteam.slack.com/archives/C12345/p10000001")
 
 	// Second blob: standalone message
 	assert.Contains(t, blobs[1], "Channel: engineering")
+	assert.Contains(t, blobs[1], "[Charlie]")
 	assert.Contains(t, blobs[1], "PASSWORD=hunter2")
+	assert.Contains(t, blobs[1], "URL: https://testteam.slack.com/archives/C12345/p10000003")
+
+	// Verify provenance contains per-message data
+	ep0 := provs[0].(types.ExtendedProvenance)
+	assert.Equal(t, "Alice Smith", ep0.Payload["author"])
+	assert.Equal(t, "https://testteam.slack.com/archives/C12345/p10000001", ep0.Payload["url"])
+	assert.Equal(t, "engineering", ep0.Payload["channel"])
+
+	ep1 := provs[1].(types.ExtendedProvenance)
+	assert.Equal(t, "Charlie", ep1.Payload["author"])
+	assert.Equal(t, "https://testteam.slack.com/archives/C12345/p10000003", ep1.Payload["url"])
 }
 
 func TestSlackEnumerate_Attachments(t *testing.T) {
@@ -368,6 +542,19 @@ func TestSlackEnumerate_Attachments(t *testing.T) {
 		path := r.URL.Path
 
 		switch {
+		case strings.Contains(path, "auth.test"):
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"ok":  true,
+				"url": "https://testteam.slack.com/",
+			})
+
+		case strings.Contains(path, "users.list"):
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"ok":      true,
+				"members": []map[string]interface{}{},
+				"response_metadata": map[string]interface{}{"next_cursor": ""},
+			})
+
 		case strings.Contains(path, "conversations.list"):
 			_ = json.NewEncoder(w).Encode(map[string]interface{}{
 				"ok": true,
@@ -434,6 +621,78 @@ func TestSlackListConversations_FiltersByMembership(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, conversations, 1)
 	assert.Equal(t, "C_JOINED", conversations[0].ID)
+}
+
+func TestSlackFetchUserNames(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		callCount++
+
+		if callCount == 1 {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"ok": true,
+				"members": []map[string]interface{}{
+					{
+						"id":   "U001",
+						"name": "alice",
+						"profile": map[string]interface{}{
+							"display_name": "Alice Smith",
+							"real_name":    "Alice S",
+						},
+					},
+					{
+						"id":   "U002",
+						"name": "bob",
+						"profile": map[string]interface{}{
+							"display_name": "",
+							"real_name":    "Bob Jones",
+						},
+					},
+					{
+						"id":   "U003",
+						"name": "charlie_no_profile",
+						"profile": map[string]interface{}{
+							"display_name": "",
+							"real_name":    "",
+						},
+					},
+				},
+				"response_metadata": map[string]interface{}{
+					"next_cursor": "page2cursor",
+				},
+			})
+			return
+		}
+
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"ok": true,
+			"members": []map[string]interface{}{
+				{
+					"id":   "U004",
+					"name": "dana",
+					"profile": map[string]interface{}{
+						"display_name": "Dana Lee",
+						"real_name":    "Dana L",
+					},
+				},
+			},
+			"response_metadata": map[string]interface{}{
+				"next_cursor": "",
+			},
+		})
+	}))
+	defer server.Close()
+
+	e := testSlackEnumerator(t, server.URL+"/")
+	names := e.slFetchUserNames(context.Background())
+
+	assert.Equal(t, 2, callCount, "should paginate through both pages")
+	assert.Len(t, names, 4)
+	assert.Equal(t, "Alice Smith", names["U001"])        // display_name preferred
+	assert.Equal(t, "Bob Jones", names["U002"])           // real_name fallback
+	assert.Equal(t, "charlie_no_profile", names["U003"])  // name fallback
+	assert.Equal(t, "Dana Lee", names["U004"])            // from second page
 }
 
 func TestSlackIsAccessError(t *testing.T) {

--- a/pkg/explore/details.go
+++ b/pkg/explore/details.go
@@ -271,6 +271,16 @@ func renderMatchDetails(m *matchRow, maxWidth int) []string {
 						fieldLabelStyle.Render("Space:"),
 						fieldValueStyle.Render(space)))
 				}
+				if channel, _ := p.Payload["channel"].(string); channel != "" {
+					lines = append(lines, fmt.Sprintf("  %s %s",
+						fieldLabelStyle.Render("Channel:"),
+						fieldValueStyle.Render(channel)))
+				}
+				if author, _ := p.Payload["author"].(string); author != "" {
+					lines = append(lines, fmt.Sprintf("  %s %s",
+						fieldLabelStyle.Render("Author:"),
+						fieldValueStyle.Render(author)))
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- Add `--cookie` flag for `xoxd-` session cookies, enabling `xoxc-` browser token authentication
- Resolve user IDs to display names via `users.list` API
- Build per-message permalink URLs (`archives/{channel}/p{ts}`) in provenance
- Lower default rate limit to 0.75 rps (under Slack Tier 3 = 50 req/min)
- Show rate limit backoff in progress bar ("Rate limited — waiting Xs...")
- Add thread progress for busy channels ("Scanning #channel: thread 42/1337")
- Display Channel and Author fields in `titus explore` for Slack findings
- Fix progress bar / log line collision

## Usage

```bash
# Browser session tokens
titus slack --token xoxc-xxx --cookie xoxd-xxx -v

# Standard bot/user tokens (unchanged)
titus slack --token xoxb-xxx -v
```

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] All Slack tests pass (including new xoxc, user name, permalink tests)
- [x] Tested against Praetorian Slack workspace (2079 channels, 4191 users)
- [x] Rate limit display and thread progress verified
- [x] Channel/Author fields visible in `titus explore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)