### PR TITLE
feat(enum): add SharePoint enumerator with Graph API and device code auth

### DIFF
--- a/cmd/titus/root.go
+++ b/cmd/titus/root.go
@@ -38,6 +38,7 @@ func init() {
 	rootCmd.AddCommand(slackCmd)
 	rootCmd.AddCommand(confluenceCmd)
 	rootCmd.AddCommand(jiraCmd)
+	rootCmd.AddCommand(sharepointCmd)
 }
 
 // Execute runs the root command.

--- a/cmd/titus/sharepoint.go
+++ b/cmd/titus/sharepoint.go
@@ -236,9 +236,6 @@ func runSharePointScan(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("scanning SharePoint: %w", err)
 	}
 
-	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "SharePoint scan complete: %d matches, %d findings\n", matchCount, findingCount)
-	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Results stored in: %s\n", sharepointOutputPath)
-
 	if sharepointFormat == "json" {
 		matches, err := s.GetAllMatches()
 		if err != nil {
@@ -246,6 +243,9 @@ func runSharePointScan(cmd *cobra.Command, args []string) error {
 		}
 		return outputMatches(cmd, matches)
 	}
+
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "SharePoint scan complete: %d matches, %d findings\n", matchCount, findingCount)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Results stored in: %s\n", sharepointOutputPath)
 
 	findings, err := s.GetFindings()
 	if err != nil {

--- a/cmd/titus/sharepoint.go
+++ b/cmd/titus/sharepoint.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"github.com/praetorian-inc/titus/pkg/auth"
 	"github.com/praetorian-inc/titus/pkg/enum"
@@ -15,6 +16,7 @@ import (
 
 var (
 	sharepointToken      string
+	spRefreshToken       string
 	sharepointSite       string
 	sharepointOutputPath string
 	sharepointFormat     string
@@ -31,11 +33,17 @@ Authentication:
   Use --token with an OAuth bearer token that has Sites.Read.All permission,
   or omit --token to use the interactive device code flow.
 
+  Use --refresh-token with a Microsoft refresh token to skip the device code flow.
+  Get a refresh token from GraphRunner, TokenTacticsV2, roadtx, or a previous
+  Titus authentication cached at ~/.titus/microsoft_token.json.
+
 Examples:
   titus sharepoint -v                                          # device code flow (interactive)
   titus sharepoint --token <bearer_token> -v                   # direct token
   titus sharepoint --token <bearer_token> --site https://company.sharepoint.com/sites/Engineering
-  titus sharepoint --client-id 14d82eec-204b-4c2f-b7e8-296a70dab67e -v  # alternate client ID`,
+  titus sharepoint --client-id 14d82eec-204b-4c2f-b7e8-296a70dab67e -v  # alternate client ID
+  titus sharepoint --refresh-token <refresh_token> -v              # use refresh token (no browser needed)
+  SHAREPOINT_REFRESH_TOKEN=<token> titus sharepoint -v             # via env var`,
 	RunE: runSharePointScan,
 }
 
@@ -46,6 +54,12 @@ func init() {
 	sharepointCmd.Flags().StringVar(&sharepointFormat, "format", "human", "Output format: json, human")
 	sharepointCmd.Flags().StringVar(&spClientID, "client-id", auth.AzurePowerShellClientID, "Azure AD application (client) ID for device code auth")
 	sharepointCmd.Flags().StringVar(&spTenantID, "tenant-id", auth.DefaultTenantID, "Azure AD tenant ID (or 'organizations' for multi-tenant)")
+	sharepointCmd.Flags().StringVar(&spRefreshToken, "refresh-token", "", "Microsoft refresh token to exchange for access token (or SHAREPOINT_REFRESH_TOKEN env)")
+	sharepointCmd.Flags().StringVar(&scanRulesPath, "rules", "", "Path to custom rules file or directory (merged with builtins)")
+	sharepointCmd.Flags().StringVar(&scanRulesInclude, "rules-include", "", "Include rules matching regex pattern (comma-separated)")
+	sharepointCmd.Flags().StringVar(&scanRulesExclude, "rules-exclude", "", "Exclude rules matching regex pattern (comma-separated)")
+	sharepointCmd.Flags().StringVar(&scanRuleset, "ruleset", "default", "Ruleset to use: default, np.assets, np.hashes, all")
+	sharepointCmd.Flags().BoolVar(&scanIncludeNoisy, "include-noisy", false, "Include noisy rules that may produce more false positives")
 }
 
 func runSharePointScan(cmd *cobra.Command, args []string) error {
@@ -55,12 +69,60 @@ func runSharePointScan(cmd *cobra.Command, args []string) error {
 	}
 
 	if token == "" {
-		scopes := []string{"https://graph.microsoft.com/Sites.Read.All", "https://graph.microsoft.com/Files.Read.All", "offline_access"}
-		result, err := auth.DeviceCodeAuth(cmd.Context(), spClientID, spTenantID, scopes, cmd.ErrOrStderr())
-		if err != nil {
-			return fmt.Errorf("device code authentication failed: %w", err)
+		refreshToken := spRefreshToken
+		if refreshToken == "" {
+			refreshToken = os.Getenv("SHAREPOINT_REFRESH_TOKEN")
 		}
-		token = result.AccessToken
+
+		scopes := []string{"https://graph.microsoft.com/Sites.Read.All", "https://graph.microsoft.com/Files.Read.All", "offline_access"}
+
+		if refreshToken != "" {
+			// Option 1: Explicit refresh token provided.
+			_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Exchanging refresh token for access token...")
+			result, err := auth.RefreshToken(cmd.Context(), spClientID, spTenantID, refreshToken, scopes)
+			if err != nil {
+				return fmt.Errorf("refresh token exchange failed: %w", err)
+			}
+			_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Authentication successful.")
+			token = result.AccessToken
+			// Save for future runs.
+			_ = auth.SaveCachedToken(result, spClientID, spTenantID)
+		} else {
+			// Option 2: Try cached token first.
+			cached, err := auth.LoadCachedToken()
+			if err == nil && cached.ClientID == spClientID && cached.TenantID == spTenantID {
+				if time.Now().Add(5 * time.Minute).Before(cached.ExpiresAt) {
+					// Cached token still valid.
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Using cached token (expires %s)\n", cached.ExpiresAt.Format("15:04:05"))
+					token = cached.AccessToken
+				} else if cached.RefreshToken != "" {
+					// Cached token expired, refresh it.
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Refreshing cached token...")
+					result, err := auth.RefreshToken(cmd.Context(), spClientID, spTenantID, cached.RefreshToken, scopes)
+					if err == nil {
+						token = result.AccessToken
+						_ = auth.SaveCachedToken(result, spClientID, spTenantID)
+						_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Token refreshed successfully.")
+					} else {
+						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: cached token refresh failed (%v); falling back to device code flow.\n", err)
+					}
+				}
+			}
+
+			if token == "" {
+				// Option 3: Interactive device code flow.
+				result, err := auth.DeviceCodeAuth(cmd.Context(), spClientID, spTenantID, scopes, cmd.ErrOrStderr())
+				if err != nil {
+					return fmt.Errorf("device code authentication failed: %w", err)
+				}
+				token = result.AccessToken
+				// Save for future runs.
+				_ = auth.SaveCachedToken(result, spClientID, spTenantID)
+				if result.RefreshToken != "" {
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Token cached at ~/.titus/microsoft_token.json")
+				}
+			}
+		}
 	}
 
 	var verboseWriter io.Writer
@@ -77,7 +139,7 @@ func runSharePointScan(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("creating SharePoint enumerator: %w", err)
 	}
 
-	rules, err := loadRules("", "", "", scanRuleset, false)
+	rules, err := loadRules(scanRulesPath, scanRulesInclude, scanRulesExclude, scanRuleset, scanIncludeNoisy)
 	if err != nil {
 		return fmt.Errorf("loading rules: %w", err)
 	}
@@ -174,8 +236,8 @@ func runSharePointScan(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("scanning SharePoint: %w", err)
 	}
 
-	_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "SharePoint scan complete: %d matches, %d findings\n", matchCount, findingCount)
-	_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Results stored in: %s\n", sharepointOutputPath)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "SharePoint scan complete: %d matches, %d findings\n", matchCount, findingCount)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Results stored in: %s\n", sharepointOutputPath)
 
 	if sharepointFormat == "json" {
 		matches, err := s.GetAllMatches()

--- a/cmd/titus/sharepoint.go
+++ b/cmd/titus/sharepoint.go
@@ -1,0 +1,193 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/praetorian-inc/titus/pkg/auth"
+	"github.com/praetorian-inc/titus/pkg/enum"
+	"github.com/praetorian-inc/titus/pkg/matcher"
+	"github.com/praetorian-inc/titus/pkg/store"
+	"github.com/praetorian-inc/titus/pkg/types"
+	"github.com/spf13/cobra"
+)
+
+var (
+	sharepointToken      string
+	sharepointSite       string
+	sharepointOutputPath string
+	sharepointFormat     string
+	spClientID           string
+	spTenantID           string
+)
+
+var sharepointCmd = &cobra.Command{
+	Use:   "sharepoint",
+	Short: "Scan SharePoint sites for secrets",
+	Long: `Scan SharePoint sites for secrets via the Microsoft Graph API.
+
+Authentication:
+  Use --token with an OAuth bearer token that has Sites.Read.All permission,
+  or omit --token to use the interactive device code flow.
+
+Examples:
+  titus sharepoint -v                                          # device code flow (interactive)
+  titus sharepoint --token <bearer_token> -v                   # direct token
+  titus sharepoint --token <bearer_token> --site https://company.sharepoint.com/sites/Engineering
+  titus sharepoint --client-id 14d82eec-204b-4c2f-b7e8-296a70dab67e -v  # alternate client ID`,
+	RunE: runSharePointScan,
+}
+
+func init() {
+	sharepointCmd.Flags().StringVar(&sharepointToken, "token", "", "Graph API OAuth bearer token (or SHAREPOINT_TOKEN env)")
+	sharepointCmd.Flags().StringVar(&sharepointSite, "site", "", "Specific site URL or name to scan (empty = all sites)")
+	sharepointCmd.Flags().StringVar(&sharepointOutputPath, "output", "titus.db", "Output database path")
+	sharepointCmd.Flags().StringVar(&sharepointFormat, "format", "human", "Output format: json, human")
+	sharepointCmd.Flags().StringVar(&spClientID, "client-id", auth.AzurePowerShellClientID, "Azure AD application (client) ID for device code auth")
+	sharepointCmd.Flags().StringVar(&spTenantID, "tenant-id", auth.DefaultTenantID, "Azure AD tenant ID (or 'organizations' for multi-tenant)")
+}
+
+func runSharePointScan(cmd *cobra.Command, args []string) error {
+	token := sharepointToken
+	if token == "" {
+		token = os.Getenv("SHAREPOINT_TOKEN")
+	}
+
+	if token == "" {
+		scopes := []string{"https://graph.microsoft.com/Sites.Read.All", "https://graph.microsoft.com/Files.Read.All", "offline_access"}
+		result, err := auth.DeviceCodeAuth(cmd.Context(), spClientID, spTenantID, scopes, cmd.ErrOrStderr())
+		if err != nil {
+			return fmt.Errorf("device code authentication failed: %w", err)
+		}
+		token = result.AccessToken
+	}
+
+	var verboseWriter io.Writer
+	if verbose {
+		verboseWriter = cmd.ErrOrStderr()
+	}
+
+	enumerator, err := enum.NewSharePointEnumerator(enum.SharePointConfig{
+		Token:   token,
+		Site:    sharepointSite,
+		Verbose: verboseWriter,
+	})
+	if err != nil {
+		return fmt.Errorf("creating SharePoint enumerator: %w", err)
+	}
+
+	rules, err := loadRules("", "", "", scanRuleset, false)
+	if err != nil {
+		return fmt.Errorf("loading rules: %w", err)
+	}
+
+	ruleMap := make(map[string]*types.Rule)
+	for _, r := range rules {
+		ruleMap[r.ID] = r
+	}
+
+	m, err := matcher.New(matcher.Config{
+		Rules:        rules,
+		ContextLines: 3,
+	})
+	if err != nil {
+		return fmt.Errorf("creating matcher: %w", err)
+	}
+	defer m.Close()
+
+	s, err := store.New(store.Config{
+		Path: sharepointOutputPath,
+	})
+	if err != nil {
+		return fmt.Errorf("creating store: %w", err)
+	}
+	defer s.Close()
+
+	for _, r := range rules {
+		if err := s.AddRule(r); err != nil {
+			return fmt.Errorf("storing rule: %w", err)
+		}
+	}
+
+	ctx := cmd.Context()
+	matchCount := 0
+	findingCount := 0
+
+	err = enumerator.Enumerate(ctx, func(content []byte, blobID types.BlobID, prov types.Provenance) error {
+		if err := s.AddBlob(blobID, int64(len(content))); err != nil {
+			return fmt.Errorf("storing blob: %w", err)
+		}
+
+		if err := s.AddProvenance(blobID, prov); err != nil {
+			return fmt.Errorf("storing provenance: %w", err)
+		}
+
+		matches, err := m.MatchWithBlobID(content, blobID)
+		if err != nil {
+			return fmt.Errorf("matching content: %w", err)
+		}
+
+		for _, match := range matches {
+			startLine, startCol := types.ComputeLineColumn(content, int(match.Location.Offset.Start))
+			endLine, endCol := types.ComputeLineColumn(content, int(match.Location.Offset.End))
+			match.Location.Source.Start.Line = startLine
+			match.Location.Source.Start.Column = startCol
+			match.Location.Source.End.Line = endLine
+			match.Location.Source.End.Column = endCol
+		}
+
+		for _, match := range matches {
+			matchCount++
+
+			if err := s.AddMatch(match); err != nil {
+				return fmt.Errorf("storing match: %w", err)
+			}
+
+			rule, ok := ruleMap[match.RuleID]
+			if !ok {
+				return fmt.Errorf("rule not found: %s", match.RuleID)
+			}
+			findingID := types.ComputeFindingID(rule.StructuralID, match.Groups)
+			exists, err := s.FindingExists(findingID)
+			if err != nil {
+				return fmt.Errorf("checking finding: %w", err)
+			}
+
+			if !exists {
+				findingCount++
+				finding := &types.Finding{
+					ID:     findingID,
+					RuleID: match.RuleID,
+					Groups: match.Groups,
+				}
+				if err := s.AddFinding(finding); err != nil {
+					return fmt.Errorf("storing finding: %w", err)
+				}
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("scanning SharePoint: %w", err)
+	}
+
+	_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "SharePoint scan complete: %d matches, %d findings\n", matchCount, findingCount)
+	_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Results stored in: %s\n", sharepointOutputPath)
+
+	if sharepointFormat == "json" {
+		matches, err := s.GetAllMatches()
+		if err != nil {
+			return fmt.Errorf("retrieving matches: %w", err)
+		}
+		return outputMatches(cmd, matches)
+	}
+
+	findings, err := s.GetFindings()
+	if err != nil {
+		return fmt.Errorf("retrieving findings: %w", err)
+	}
+	return outputFindings(cmd, findings)
+}

--- a/pkg/auth/microsoft.go
+++ b/pkg/auth/microsoft.go
@@ -353,7 +353,7 @@ func LoadCachedToken() (*CachedToken, error) {
 		return nil, err
 	}
 
-	data, err := os.ReadFile(cachePath) //nolint:gosec // path is constructed from UserHomeDir + hardcoded filename
+	data, err := os.ReadFile(cachePath) // #nosec G304 -- path is constructed from UserHomeDir + hardcoded filename, not user input
 	if err != nil {
 		return nil, fmt.Errorf("reading cached token: %w", err)
 	}

--- a/pkg/auth/microsoft.go
+++ b/pkg/auth/microsoft.go
@@ -349,7 +349,7 @@ func LoadCachedToken() (*CachedToken, error) {
 		return nil, err
 	}
 
-	data, err := os.ReadFile(cachePath)
+	data, err := os.ReadFile(cachePath) //nolint:gosec // path is constructed from UserHomeDir + hardcoded filename
 	if err != nil {
 		return nil, fmt.Errorf("reading cached token: %w", err)
 	}

--- a/pkg/auth/microsoft.go
+++ b/pkg/auth/microsoft.go
@@ -9,6 +9,8 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -215,10 +217,7 @@ func pollForToken(ctx context.Context, client *http.Client, clientID, tenantID, 
 	case "authorization_pending":
 		return nil, nil
 	case "slow_down":
-		// The caller should increase the polling interval, but since we return
-		// nil, nil the caller will continue at its existing interval. The 5s
-		// increase is handled by the spec, but most callers just wait an extra
-		// interval which is acceptable.
+		time.Sleep(5 * time.Second)
 		return nil, nil
 	case "expired_token":
 		return nil, fmt.Errorf("device code expired: %s", tokenResp.ErrorDesc)
@@ -274,4 +273,91 @@ func RefreshToken(ctx context.Context, clientID, tenantID, refreshToken string, 
 		Scope:        tokenResp.Scope,
 		TokenType:    tokenResp.TokenType,
 	}, nil
+}
+
+// CachedToken is the on-disk representation of a cached Microsoft OAuth token.
+type CachedToken struct {
+	AccessToken  string    `json:"access_token"`
+	RefreshToken string    `json:"refresh_token"`
+	ClientID     string    `json:"client_id"`
+	TenantID     string    `json:"tenant_id"`
+	ExpiresAt    time.Time `json:"expires_at"`
+}
+
+// TokenCachePath returns the path to the Microsoft token cache file (~/.titus/microsoft_token.json).
+func TokenCachePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("determining home directory: %w", err)
+	}
+	return filepath.Join(home, ".titus", "microsoft_token.json"), nil
+}
+
+// SaveCachedToken writes the token result to the cache file at ~/.titus/microsoft_token.json.
+func SaveCachedToken(result *DeviceCodeResult, clientID, tenantID string) error {
+	cachePath, err := TokenCachePath()
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(cachePath), 0o700); err != nil {
+		return fmt.Errorf("creating cache directory: %w", err)
+	}
+
+	cached := CachedToken{
+		AccessToken:  result.AccessToken,
+		RefreshToken: result.RefreshToken,
+		ClientID:     clientID,
+		TenantID:     tenantID,
+		ExpiresAt:    time.Now().Add(time.Duration(result.ExpiresIn) * time.Second),
+	}
+
+	data, err := json.MarshalIndent(cached, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling cached token: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(filepath.Dir(cachePath), ".microsoft_token_*.tmp")
+	if err != nil {
+		return fmt.Errorf("creating temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("writing temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("closing temp file: %w", err)
+	}
+	if err := os.Chmod(tmpName, 0o600); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("setting permissions: %w", err)
+	}
+	if err := os.Rename(tmpName, cachePath); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("renaming cache file: %w", err)
+	}
+	return nil
+}
+
+// LoadCachedToken reads the cached token from ~/.titus/microsoft_token.json.
+func LoadCachedToken() (*CachedToken, error) {
+	cachePath, err := TokenCachePath()
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(cachePath)
+	if err != nil {
+		return nil, fmt.Errorf("reading cached token: %w", err)
+	}
+
+	var cached CachedToken
+	if err := json.Unmarshal(data, &cached); err != nil {
+		return nil, fmt.Errorf("parsing cached token: %w", err)
+	}
+
+	return &cached, nil
 }

--- a/pkg/auth/microsoft.go
+++ b/pkg/auth/microsoft.go
@@ -1,0 +1,277 @@
+// Package auth provides OAuth authentication flows for Microsoft Entra ID
+// (Azure AD) that any Microsoft-based Titus subcommand can share.
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	// AzurePowerShellClientID is a well-known first-party public client.
+	// Widely used in pentest tools (GraphRunner, ROADtools, etc.) because it's
+	// pre-consented for Graph API scopes in most tenants.
+	AzurePowerShellClientID = "1950a258-227b-4e31-a9cf-717495945fc2"
+
+	// GraphCLIClientID is the Microsoft Graph Command Line Tools public client.
+	GraphCLIClientID = "14d82eec-204b-4c2f-b7e8-296a70dab67e"
+
+	// DefaultTenantID is used for multi-tenant auth against organizational accounts.
+	DefaultTenantID = "organizations"
+
+	// httpTimeout is the per-request HTTP timeout for OAuth calls.
+	httpTimeout = 30 * time.Second
+)
+
+// DeviceCodeResult contains the tokens returned after successful authentication.
+type DeviceCodeResult struct {
+	AccessToken  string
+	RefreshToken string
+	ExpiresIn    int
+	Scope        string
+	TokenType    string
+}
+
+// deviceCodeResponse is the JSON response from the /devicecode endpoint.
+type deviceCodeResponse struct {
+	DeviceCode      string `json:"device_code"`
+	UserCode        string `json:"user_code"`
+	VerificationURI string `json:"verification_uri"`
+	ExpiresIn       int    `json:"expires_in"`
+	Interval        int    `json:"interval"`
+	Message         string `json:"message"`
+}
+
+// tokenResponse is the JSON response from the /token endpoint.
+type tokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int    `json:"expires_in"`
+	Scope        string `json:"scope"`
+	TokenType    string `json:"token_type"`
+	Error        string `json:"error"`
+	ErrorDesc    string `json:"error_description"`
+}
+
+// tokenEndpoint returns the OAuth 2.0 token endpoint for the given tenant.
+func tokenEndpoint(tenantID string) string {
+	return fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/token", tenantID)
+}
+
+// deviceCodeEndpoint returns the device code endpoint for the given tenant.
+func deviceCodeEndpoint(tenantID string) string {
+	return fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/devicecode", tenantID)
+}
+
+// DeviceCodeAuth performs the OAuth 2.0 device code flow against Microsoft Entra ID.
+// It prints a message to the provided writer instructing the user to authenticate,
+// then polls until the user completes authentication or the code expires.
+//
+// Parameters:
+//   - ctx: context for cancellation
+//   - clientID: Azure AD application (client) ID
+//   - tenantID: Azure AD tenant ID ("organizations" for multi-tenant, "common" for any)
+//   - scopes: OAuth scopes to request (e.g., "https://graph.microsoft.com/.default")
+//   - output: writer for user-facing messages (the "go to this URL" prompt)
+func DeviceCodeAuth(ctx context.Context, clientID, tenantID string, scopes []string, output io.Writer) (*DeviceCodeResult, error) {
+	client := &http.Client{Timeout: httpTimeout}
+
+	// Step 1: Request a device code.
+	dcResp, err := requestDeviceCode(ctx, client, clientID, tenantID, scopes)
+	if err != nil {
+		return nil, fmt.Errorf("requesting device code: %w", err)
+	}
+
+	// Print the user-facing message.
+	_, _ = fmt.Fprintln(output, dcResp.Message)
+
+	// Step 2: Poll for token.
+	interval := time.Duration(dcResp.Interval) * time.Second
+	if interval == 0 {
+		interval = 5 * time.Second
+	}
+
+	deadline := time.Now().Add(time.Duration(dcResp.ExpiresIn) * time.Second)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(interval):
+		}
+
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("device code expired")
+		}
+
+		result, pollErr := pollForToken(ctx, client, clientID, tenantID, dcResp.DeviceCode)
+		if pollErr != nil {
+			return nil, pollErr
+		}
+
+		if result != nil {
+			return result, nil
+		}
+
+		// result == nil && pollErr == nil means authorization_pending, continue polling.
+	}
+}
+
+// requestDeviceCode sends a POST to the /devicecode endpoint and parses the response.
+func requestDeviceCode(ctx context.Context, client *http.Client, clientID, tenantID string, scopes []string) (*deviceCodeResponse, error) {
+	endpoint := deviceCodeEndpoint(tenantID)
+
+	data := url.Values{
+		"client_id": {clientID},
+		"scope":     {strings.Join(scopes, " ")},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("sending request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("device code request failed (HTTP %d): %s", resp.StatusCode, string(body))
+	}
+
+	var dcResp deviceCodeResponse
+	if err := json.Unmarshal(body, &dcResp); err != nil {
+		return nil, fmt.Errorf("parsing device code response: %w", err)
+	}
+
+	if dcResp.DeviceCode == "" {
+		return nil, fmt.Errorf("empty device_code in response")
+	}
+
+	return &dcResp, nil
+}
+
+// pollForToken sends a single token poll request.
+//
+// Returns:
+//   - (*DeviceCodeResult, nil) on success
+//   - (nil, nil) when authorization is still pending (caller should keep polling)
+//   - (nil, error) on terminal errors (expired, declined, network)
+func pollForToken(ctx context.Context, client *http.Client, clientID, tenantID, deviceCode string) (*DeviceCodeResult, error) {
+	endpoint := tokenEndpoint(tenantID)
+
+	data := url.Values{
+		"grant_type":  {"urn:ietf:params:oauth:grant-type:device_code"},
+		"client_id":   {clientID},
+		"device_code": {deviceCode},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("creating token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("sending token request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading token response: %w", err)
+	}
+
+	var tokenResp tokenResponse
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return nil, fmt.Errorf("parsing token response: %w", err)
+	}
+
+	switch tokenResp.Error {
+	case "":
+		// Success.
+		return &DeviceCodeResult{
+			AccessToken:  tokenResp.AccessToken,
+			RefreshToken: tokenResp.RefreshToken,
+			ExpiresIn:    tokenResp.ExpiresIn,
+			Scope:        tokenResp.Scope,
+			TokenType:    tokenResp.TokenType,
+		}, nil
+	case "authorization_pending":
+		return nil, nil
+	case "slow_down":
+		// The caller should increase the polling interval, but since we return
+		// nil, nil the caller will continue at its existing interval. The 5s
+		// increase is handled by the spec, but most callers just wait an extra
+		// interval which is acceptable.
+		return nil, nil
+	case "expired_token":
+		return nil, fmt.Errorf("device code expired: %s", tokenResp.ErrorDesc)
+	case "authorization_declined":
+		return nil, fmt.Errorf("authorization declined: %s", tokenResp.ErrorDesc)
+	default:
+		return nil, fmt.Errorf("token error %q: %s", tokenResp.Error, tokenResp.ErrorDesc)
+	}
+}
+
+// RefreshToken exchanges a refresh token for a new access token.
+func RefreshToken(ctx context.Context, clientID, tenantID, refreshToken string, scopes []string) (*DeviceCodeResult, error) {
+	client := &http.Client{Timeout: httpTimeout}
+	endpoint := tokenEndpoint(tenantID)
+
+	data := url.Values{
+		"grant_type":    {"refresh_token"},
+		"client_id":     {clientID},
+		"refresh_token": {refreshToken},
+		"scope":         {strings.Join(scopes, " ")},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("creating refresh request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("sending refresh request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading refresh response: %w", err)
+	}
+
+	var tokenResp tokenResponse
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return nil, fmt.Errorf("parsing refresh response: %w", err)
+	}
+
+	if tokenResp.Error != "" {
+		return nil, fmt.Errorf("refresh token error %q: %s", tokenResp.Error, tokenResp.ErrorDesc)
+	}
+
+	return &DeviceCodeResult{
+		AccessToken:  tokenResp.AccessToken,
+		RefreshToken: tokenResp.RefreshToken,
+		ExpiresIn:    tokenResp.ExpiresIn,
+		Scope:        tokenResp.Scope,
+		TokenType:    tokenResp.TokenType,
+	}, nil
+}

--- a/pkg/auth/microsoft.go
+++ b/pkg/auth/microsoft.go
@@ -217,7 +217,11 @@ func pollForToken(ctx context.Context, client *http.Client, clientID, tenantID, 
 	case "authorization_pending":
 		return nil, nil
 	case "slow_down":
-		time.Sleep(5 * time.Second)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(5 * time.Second):
+		}
 		return nil, nil
 	case "expired_token":
 		return nil, fmt.Errorf("device code expired: %s", tokenResp.ErrorDesc)

--- a/pkg/auth/microsoft_test.go
+++ b/pkg/auth/microsoft_test.go
@@ -41,7 +41,7 @@ func TestConstants_Values(t *testing.T) {
 	assert.Equal(t, "organizations", DefaultTenantID)
 }
 
-func TestRefreshToken_InvalidToken(t *testing.T) {
+func TestRefreshToken_CancelledContext(t *testing.T) {
 	// Use a cancelled context so the request fails immediately without hitting
 	// the real Microsoft endpoint.
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/auth/microsoft_test.go
+++ b/pkg/auth/microsoft_test.go
@@ -41,15 +41,14 @@ func TestConstants_Values(t *testing.T) {
 	assert.Equal(t, "organizations", DefaultTenantID)
 }
 
-func TestRefreshToken_MalformedURL(t *testing.T) {
-	// A tenant ID with invalid characters that would produce a bad URL cannot
-	// be tested via the HTTP layer because url.Parse is lenient. Instead, we
-	// verify that calling RefreshToken against a server that returns an error
-	// body propagates the error correctly.
-	ctx := context.Background()
+func TestRefreshToken_InvalidToken(t *testing.T) {
+	// Use a cancelled context so the request fails immediately without hitting
+	// the real Microsoft endpoint.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
 
-	_, err := RefreshToken(ctx, "client-id", "tenant-id", "bad-refresh-token", []string{"openid"})
-	require.Error(t, err, "RefreshToken against real Azure should fail with a bad refresh token")
+	_, err := RefreshToken(ctx, "test-client", "test-tenant", "bad-token", []string{"scope"})
+	require.Error(t, err)
 }
 
 func TestRefreshToken_ErrorResponse(t *testing.T) {

--- a/pkg/auth/microsoft_test.go
+++ b/pkg/auth/microsoft_test.go
@@ -1,0 +1,228 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeviceCodeResult_Fields(t *testing.T) {
+	result := DeviceCodeResult{
+		AccessToken:  "eyJ0eXAi...",
+		RefreshToken: "OAQABAAAAAADCoM...",
+		ExpiresIn:    3599,
+		Scope:        "Sites.Read.All Files.Read.All",
+		TokenType:    "Bearer",
+	}
+
+	assert.Equal(t, "eyJ0eXAi...", result.AccessToken)
+	assert.Equal(t, "OAQABAAAAAADCoM...", result.RefreshToken)
+	assert.Equal(t, 3599, result.ExpiresIn)
+	assert.Equal(t, "Sites.Read.All Files.Read.All", result.Scope)
+	assert.Equal(t, "Bearer", result.TokenType)
+}
+
+func TestConstants_NonEmpty(t *testing.T) {
+	assert.NotEmpty(t, AzurePowerShellClientID, "AzurePowerShellClientID should be set")
+	assert.NotEmpty(t, GraphCLIClientID, "GraphCLIClientID should be set")
+	assert.NotEmpty(t, DefaultTenantID, "DefaultTenantID should be set")
+}
+
+func TestConstants_Values(t *testing.T) {
+	assert.Equal(t, "1950a258-227b-4e31-a9cf-717495945fc2", AzurePowerShellClientID)
+	assert.Equal(t, "14d82eec-204b-4c2f-b7e8-296a70dab67e", GraphCLIClientID)
+	assert.Equal(t, "organizations", DefaultTenantID)
+}
+
+func TestRefreshToken_MalformedURL(t *testing.T) {
+	// A tenant ID with invalid characters that would produce a bad URL cannot
+	// be tested via the HTTP layer because url.Parse is lenient. Instead, we
+	// verify that calling RefreshToken against a server that returns an error
+	// body propagates the error correctly.
+	ctx := context.Background()
+
+	_, err := RefreshToken(ctx, "client-id", "tenant-id", "bad-refresh-token", []string{"openid"})
+	require.Error(t, err, "RefreshToken against real Azure should fail with a bad refresh token")
+}
+
+func TestRefreshToken_ErrorResponse(t *testing.T) {
+	// Simulate an Azure AD error response for an invalid refresh token.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"error":             "invalid_grant",
+			"error_description": "The refresh token has expired",
+		})
+	}))
+	defer srv.Close()
+
+	// We cannot easily override the endpoint URL in RefreshToken without
+	// refactoring, so we test the request construction by verifying that
+	// the exported function returns an error for a context-cancelled request.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // immediately cancel
+
+	_, err := RefreshToken(ctx, "client-id", "tenant-id", "refresh-token", []string{"openid"})
+	require.Error(t, err)
+}
+
+func TestDeviceCodeAuth_CancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // immediately cancel
+
+	var buf strings.Builder
+	_, err := DeviceCodeAuth(ctx, "client-id", "tenant-id", []string{"openid"}, &buf)
+	require.Error(t, err)
+}
+
+func TestTokenEndpoint(t *testing.T) {
+	got := tokenEndpoint("my-tenant")
+	assert.Equal(t, "https://login.microsoftonline.com/my-tenant/oauth2/v2.0/token", got)
+}
+
+func TestDeviceCodeEndpoint(t *testing.T) {
+	got := deviceCodeEndpoint("organizations")
+	assert.Equal(t, "https://login.microsoftonline.com/organizations/oauth2/v2.0/devicecode", got)
+}
+
+func TestPollForToken_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(tokenResponse{
+			AccessToken:  "access-tok",
+			RefreshToken: "refresh-tok",
+			ExpiresIn:    3599,
+			Scope:        "openid",
+			TokenType:    "Bearer",
+		})
+	}))
+	defer srv.Close()
+
+	// Override the endpoint by calling pollForToken with a custom client and
+	// endpoint constructed from the test server URL. Since pollForToken uses
+	// tokenEndpoint(), we test it indirectly through the httptest server by
+	// constructing the request manually.
+	client := srv.Client()
+	ctx := context.Background()
+
+	// We'll test the internal function directly since it takes the endpoint via tokenEndpoint.
+	// Instead, test through a hand-crafted POST to verify JSON parsing.
+	result, err := pollTokenDirect(ctx, client, srv.URL, "client-id", "device-code")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "access-tok", result.AccessToken)
+	assert.Equal(t, "refresh-tok", result.RefreshToken)
+	assert.Equal(t, 3599, result.ExpiresIn)
+	assert.Equal(t, "Bearer", result.TokenType)
+}
+
+func TestPollForToken_AuthorizationPending(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(tokenResponse{
+			Error:     "authorization_pending",
+			ErrorDesc: "The user has not yet authenticated",
+		})
+	}))
+	defer srv.Close()
+
+	client := srv.Client()
+	ctx := context.Background()
+
+	result, err := pollTokenDirect(ctx, client, srv.URL, "client-id", "device-code")
+	require.NoError(t, err)
+	assert.Nil(t, result, "authorization_pending should return nil result")
+}
+
+func TestPollForToken_ExpiredToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(tokenResponse{
+			Error:     "expired_token",
+			ErrorDesc: "The device code has expired",
+		})
+	}))
+	defer srv.Close()
+
+	client := srv.Client()
+	ctx := context.Background()
+
+	result, err := pollTokenDirect(ctx, client, srv.URL, "client-id", "device-code")
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "device code expired")
+}
+
+func TestPollForToken_AuthorizationDeclined(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(tokenResponse{
+			Error:     "authorization_declined",
+			ErrorDesc: "The user declined the authorization request",
+		})
+	}))
+	defer srv.Close()
+
+	client := srv.Client()
+	ctx := context.Background()
+
+	result, err := pollTokenDirect(ctx, client, srv.URL, "client-id", "device-code")
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "authorization declined")
+}
+
+// pollTokenDirect is a test helper that sends a token poll directly to a given URL,
+// bypassing the hardcoded Microsoft endpoint. This allows testing with httptest servers.
+func pollTokenDirect(ctx context.Context, client *http.Client, endpoint, clientID, deviceCode string) (*DeviceCodeResult, error) {
+	data := strings.NewReader("grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code&client_id=" + clientID + "&device_code=" + deviceCode)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, data)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var tokenResp tokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		return nil, err
+	}
+
+	switch tokenResp.Error {
+	case "":
+		return &DeviceCodeResult{
+			AccessToken:  tokenResp.AccessToken,
+			RefreshToken: tokenResp.RefreshToken,
+			ExpiresIn:    tokenResp.ExpiresIn,
+			Scope:        tokenResp.Scope,
+			TokenType:    tokenResp.TokenType,
+		}, nil
+	case "authorization_pending", "slow_down":
+		return nil, nil
+	case "expired_token":
+		return nil, fmt.Errorf("device code expired: %s", tokenResp.ErrorDesc)
+	case "authorization_declined":
+		return nil, fmt.Errorf("authorization declined: %s", tokenResp.ErrorDesc)
+	default:
+		return nil, fmt.Errorf("token error %q: %s", tokenResp.Error, tokenResp.ErrorDesc)
+	}
+}

--- a/pkg/auth/microsoft_test.go
+++ b/pkg/auth/microsoft_test.go
@@ -51,27 +51,6 @@ func TestRefreshToken_CancelledContext(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestRefreshToken_ErrorResponse(t *testing.T) {
-	// Simulate an Azure AD error response for an invalid refresh token.
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]string{
-			"error":             "invalid_grant",
-			"error_description": "The refresh token has expired",
-		})
-	}))
-	defer srv.Close()
-
-	// We cannot easily override the endpoint URL in RefreshToken without
-	// refactoring, so we test the request construction by verifying that
-	// the exported function returns an error for a context-cancelled request.
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // immediately cancel
-
-	_, err := RefreshToken(ctx, "client-id", "tenant-id", "refresh-token", []string{"openid"})
-	require.Error(t, err)
-}
-
 func TestDeviceCodeAuth_CancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // immediately cancel

--- a/pkg/enum/sharepoint.go
+++ b/pkg/enum/sharepoint.go
@@ -8,7 +8,9 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -20,12 +22,30 @@ const spGraphBase = "https://graph.microsoft.com/v1.0"
 
 var (
 	spHTMLTagRe = regexp.MustCompile(`<[^>]*>`)
+
+	// spSkipExtensions are file types that can't produce useful text for secrets scanning.
+	spSkipExtensions = map[string]bool{
+		".png": true, ".jpg": true, ".jpeg": true, ".gif": true, ".bmp": true,
+		".ico": true, ".svg": true, ".webp": true, ".tiff": true, ".tif": true,
+		".mp4": true, ".avi": true, ".mov": true, ".wmv": true, ".mkv": true,
+		".mp3": true, ".wav": true, ".flac": true, ".aac": true, ".ogg": true,
+		".iso": true, ".dmg": true, ".exe": true, ".dll": true, ".so": true,
+		".dylib": true, ".msi": true, ".deb": true, ".rpm": true,
+		".woff": true, ".woff2": true, ".ttf": true, ".otf": true, ".eot": true,
+	}
 )
 
 // spStripHTML removes HTML tags and unescapes HTML entities.
 func spStripHTML(s string) string {
 	stripped := spHTMLTagRe.ReplaceAllString(s, "")
 	return html.UnescapeString(stripped)
+}
+
+// spSkipFile returns true if the file extension indicates a binary type
+// that cannot produce useful text for secrets scanning.
+func spSkipFile(name string) bool {
+	ext := strings.ToLower(filepath.Ext(name))
+	return spSkipExtensions[ext]
 }
 
 // SharePointConfig configures the SharePoint enumerator.
@@ -317,6 +337,11 @@ func (e *SharePointEnumerator) walkDriveFolder(ctx context.Context, driveID, fol
 			continue
 		}
 
+		// Skip files we can't extract useful text from.
+		if spSkipFile(name) {
+			continue
+		}
+
 		// Check file size (skip over 100MB — extraction limits handle per-file caps).
 		if size, ok := item["size"].(float64); ok && size > 100*1024*1024 {
 			continue
@@ -518,14 +543,20 @@ func (e *SharePointEnumerator) scanLists(ctx context.Context, siteID, siteName, 
 				continue
 			}
 
-			// Render fields as key: value lines.
+			// Render fields as key: value lines (sorted for deterministic blob IDs).
 			var sb strings.Builder
 			sb.WriteString("List: " + listName + "\n")
 			sb.WriteString("Site: " + siteName + "\n")
 			sb.WriteString("---\n")
 
-			for k, v := range fields {
-				sb.WriteString(fmt.Sprintf("%s: %v\n", k, v))
+			keys := make([]string, 0, len(fields))
+			for k := range fields {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			for _, k := range keys {
+				v := fields[k]
+				fmt.Fprintf(&sb, "%s: %v\n", k, v)
 			}
 
 			blob := []byte(sb.String())

--- a/pkg/enum/sharepoint.go
+++ b/pkg/enum/sharepoint.go
@@ -21,7 +21,8 @@ import (
 const spGraphBase = "https://graph.microsoft.com/v1.0"
 
 var (
-	spHTMLTagRe = regexp.MustCompile(`<[^>]*>`)
+	spHTMLTagRe  = regexp.MustCompile(`<[^>]*>`)
+	spBlockTagRe = regexp.MustCompile(`(?i)<\s*(?:br|/p|/div|/li|/tr|/h[1-6])\s*/?>`)
 
 	// spSkipExtensions are file types that can't produce useful text for secrets scanning.
 	spSkipExtensions = map[string]bool{
@@ -37,8 +38,11 @@ var (
 
 // spStripHTML removes HTML tags and unescapes HTML entities.
 func spStripHTML(s string) string {
-	stripped := spHTMLTagRe.ReplaceAllString(s, "")
-	return html.UnescapeString(stripped)
+	// Replace block-level closing tags and <br> with newlines.
+	s = spBlockTagRe.ReplaceAllString(s, "\n")
+	// Strip remaining tags.
+	s = spHTMLTagRe.ReplaceAllString(s, "")
+	return html.UnescapeString(s)
 }
 
 // spSkipFile returns true if the file extension indicates a binary type
@@ -245,18 +249,39 @@ func (e *SharePointEnumerator) discoverSites(ctx context.Context) ([]map[string]
 				body, err := e.spGet(ctx, url)
 				if err != nil {
 					// Fall back to search.
-					return e.searchSites(ctx, e.config.Site)
+					sites, err := e.searchSites(ctx, e.config.Site)
+					if err != nil {
+						return nil, err
+					}
+					if len(sites) == 0 {
+						return nil, fmt.Errorf("site %q not found or not accessible", e.config.Site)
+					}
+					return sites, nil
 				}
 				var result map[string]interface{}
 				if err := json.Unmarshal(body, &result); err != nil {
-					return e.searchSites(ctx, e.config.Site)
+					sites, err := e.searchSites(ctx, e.config.Site)
+					if err != nil {
+						return nil, err
+					}
+					if len(sites) == 0 {
+						return nil, fmt.Errorf("site %q not found or not accessible", e.config.Site)
+					}
+					return sites, nil
 				}
 				return []map[string]interface{}{result}, nil
 			}
 		}
 
 		// Search for the site by name.
-		return e.searchSites(ctx, site)
+		sites, err := e.searchSites(ctx, site)
+		if err != nil {
+			return nil, err
+		}
+		if len(sites) == 0 {
+			return nil, fmt.Errorf("site %q not found or not accessible", e.config.Site)
+		}
+		return sites, nil
 	}
 
 	// Enumerate all sites.
@@ -450,7 +475,7 @@ func (e *SharePointEnumerator) scanPages(ctx context.Context, siteID, siteName, 
 		blob := []byte(sb.String())
 
 		blobID := types.ComputeBlobID(blob)
-		prov := spProvenance(siteName, "", pageTitle, pageURL)
+		prov := spProvenance(siteName, pageURL, pageTitle, pageURL)
 
 		if err := callback(blob, blobID, prov); err != nil {
 			return err
@@ -572,7 +597,7 @@ func (e *SharePointEnumerator) scanLists(ctx context.Context, siteID, siteName, 
 				itemURL = webURL
 			}
 
-			prov := spProvenance(siteName, "", itemTitle, itemURL)
+			prov := spProvenance(siteName, itemURL, itemTitle, itemURL)
 
 			if err := callback(blob, blobID, prov); err != nil {
 				return err

--- a/pkg/enum/sharepoint.go
+++ b/pkg/enum/sharepoint.go
@@ -7,7 +7,7 @@ import (
 	"html"
 	"io"
 	"net/http"
-	"path/filepath"
+	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
@@ -18,29 +18,9 @@ import (
 
 const spGraphBase = "https://graph.microsoft.com/v1.0"
 
-// spTextExtensions defines file extensions that should be downloaded and scanned.
-var spTextExtensions = map[string]bool{
-	".txt": true, ".md": true, ".csv": true, ".json": true,
-	".yaml": true, ".yml": true, ".xml": true, ".env": true,
-	".config": true, ".cfg": true, ".ini": true, ".properties": true,
-	".toml": true, ".sh": true, ".bash": true, ".ps1": true,
-	".py": true, ".rb": true, ".js": true, ".ts": true,
-	".go": true, ".java": true, ".cs": true, ".tf": true,
-	".tfvars": true, ".sql": true, ".log": true, ".conf": true,
-	".htaccess": true, ".gitconfig": true, ".npmrc": true,
-	".dockerenv": true, ".pem": true, ".key": true, ".crt": true,
-	".pub": true,
-}
-
 var (
 	spHTMLTagRe = regexp.MustCompile(`<[^>]*>`)
 )
-
-// spIsTextFile returns true if the filename has a text-scannable extension.
-func spIsTextFile(name string) bool {
-	ext := strings.ToLower(filepath.Ext(name))
-	return spTextExtensions[ext]
-}
 
 // spStripHTML removes HTML tags and unescapes HTML entities.
 func spStripHTML(s string) string {
@@ -75,7 +55,7 @@ func NewSharePointEnumerator(cfg SharePointConfig) (*SharePointEnumerator, error
 // logf writes a progress message when verbose output is enabled.
 func (e *SharePointEnumerator) logf(format string, args ...interface{}) {
 	if e.config.Verbose != nil {
-		_, _ = fmt.Fprintf(e.config.Verbose, format+"\n", args...)
+		_, _ = fmt.Fprintf(e.config.Verbose, "\r%-80s\n", fmt.Sprintf(format, args...))
 	}
 }
 
@@ -265,8 +245,8 @@ func (e *SharePointEnumerator) discoverSites(ctx context.Context) ([]map[string]
 
 // searchSites searches for sites matching a query.
 func (e *SharePointEnumerator) searchSites(ctx context.Context, query string) ([]map[string]interface{}, error) {
-	url := fmt.Sprintf("%s/sites?search=%s", spGraphBase, query)
-	return e.spGetPaginated(ctx, url)
+	searchURL := fmt.Sprintf("%s/sites?search=%s", spGraphBase, url.QueryEscape(query))
+	return e.spGetPaginated(ctx, searchURL)
 }
 
 // scanDrives scans document libraries for text-scannable files.
@@ -275,12 +255,15 @@ func (e *SharePointEnumerator) scanDrives(ctx context.Context, siteID, siteName,
 	if err != nil {
 		return err
 	}
+	e.logf("  Found %d drives", len(drives))
 
 	for _, drive := range drives {
 		driveID, _ := drive["id"].(string)
 		if driveID == "" {
 			continue
 		}
+		driveName, _ := drive["name"].(string)
+		e.logf("  Drive: %s", driveName)
 
 		err := e.walkDriveFolder(ctx, driveID, "", siteName, siteURL, callback)
 		if err != nil {
@@ -305,6 +288,19 @@ func (e *SharePointEnumerator) walkDriveFolder(ctx context.Context, driveID, fol
 		return err
 	}
 
+	if folderID == "" {
+		fileCount := 0
+		folderCount := 0
+		for _, it := range items {
+			if _, isFolder := it["folder"]; isFolder {
+				folderCount++
+			} else {
+				fileCount++
+			}
+		}
+		e.logf("    Root: %d files, %d folders", fileCount, folderCount)
+	}
+
 	for _, item := range items {
 		if ctx.Err() != nil {
 			return ctx.Err()
@@ -321,13 +317,8 @@ func (e *SharePointEnumerator) walkDriveFolder(ctx context.Context, driveID, fol
 			continue
 		}
 
-		// Check if it's a text-scannable file.
-		if !spIsTextFile(name) {
-			continue
-		}
-
-		// Check file size (skip over 10MB).
-		if size, ok := item["size"].(float64); ok && size > 10*1024*1024 {
+		// Check file size (skip over 100MB — extraction limits handle per-file caps).
+		if size, ok := item["size"].(float64); ok && size > 100*1024*1024 {
 			continue
 		}
 
@@ -352,11 +343,29 @@ func (e *SharePointEnumerator) walkDriveFolder(ctx context.Context, driveID, fol
 			fileURL = webURL
 		}
 
-		blobID := types.ComputeBlobID(content)
-		prov := spProvenance(siteName, filePath, name, fileURL)
-
-		if err := callback(content, blobID, prov); err != nil {
-			return err
+		if isBinary(content) {
+			// Extract text from binary files (Office docs, PDFs, archives, etc.)
+			extracted, err := ExtractText(filePath, content, DefaultExtractionLimits())
+			if err != nil || len(extracted) == 0 {
+				continue
+			}
+			for _, ec := range extracted {
+				blobID := types.ComputeBlobID(ec.Content)
+				extractPath := filePath
+				if ec.Name != "" {
+					extractPath = filePath + "/" + ec.Name
+				}
+				prov := spProvenance(siteName, extractPath, name, fileURL)
+				if err := callback(ec.Content, blobID, prov); err != nil {
+					return err
+				}
+			}
+		} else {
+			blobID := types.ComputeBlobID(content)
+			prov := spProvenance(siteName, filePath, name, fileURL)
+			if err := callback(content, blobID, prov); err != nil {
+				return err
+			}
 		}
 
 		e.progressf("Scanning files: %s", name)
@@ -371,6 +380,7 @@ func (e *SharePointEnumerator) scanPages(ctx context.Context, siteID, siteName, 
 	if err != nil {
 		return err
 	}
+	e.logf("  Found %d pages", len(pages))
 
 	for _, page := range pages {
 		if ctx.Err() != nil {
@@ -470,6 +480,7 @@ func (e *SharePointEnumerator) scanLists(ctx context.Context, siteID, siteName, 
 	if err != nil {
 		return err
 	}
+	e.logf("  Found %d lists", len(lists))
 
 	for _, list := range lists {
 		if ctx.Err() != nil {

--- a/pkg/enum/sharepoint.go
+++ b/pkg/enum/sharepoint.go
@@ -1,0 +1,543 @@
+package enum
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"html"
+	"io"
+	"net/http"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+)
+
+const spGraphBase = "https://graph.microsoft.com/v1.0"
+
+// spTextExtensions defines file extensions that should be downloaded and scanned.
+var spTextExtensions = map[string]bool{
+	".txt": true, ".md": true, ".csv": true, ".json": true,
+	".yaml": true, ".yml": true, ".xml": true, ".env": true,
+	".config": true, ".cfg": true, ".ini": true, ".properties": true,
+	".toml": true, ".sh": true, ".bash": true, ".ps1": true,
+	".py": true, ".rb": true, ".js": true, ".ts": true,
+	".go": true, ".java": true, ".cs": true, ".tf": true,
+	".tfvars": true, ".sql": true, ".log": true, ".conf": true,
+	".htaccess": true, ".gitconfig": true, ".npmrc": true,
+	".dockerenv": true, ".pem": true, ".key": true, ".crt": true,
+	".pub": true,
+}
+
+var (
+	spHTMLTagRe = regexp.MustCompile(`<[^>]*>`)
+)
+
+// spIsTextFile returns true if the filename has a text-scannable extension.
+func spIsTextFile(name string) bool {
+	ext := strings.ToLower(filepath.Ext(name))
+	return spTextExtensions[ext]
+}
+
+// spStripHTML removes HTML tags and unescapes HTML entities.
+func spStripHTML(s string) string {
+	stripped := spHTMLTagRe.ReplaceAllString(s, "")
+	return html.UnescapeString(stripped)
+}
+
+// SharePointConfig configures the SharePoint enumerator.
+type SharePointConfig struct {
+	Token   string    // OAuth bearer token for Microsoft Graph API
+	Site    string    // specific site URL or name to scan (empty = all sites)
+	Verbose io.Writer // progress output
+}
+
+// SharePointEnumerator enumerates blobs from SharePoint via the Microsoft Graph API.
+type SharePointEnumerator struct {
+	config SharePointConfig
+	client *http.Client
+}
+
+// NewSharePointEnumerator creates a new SharePoint enumerator.
+func NewSharePointEnumerator(cfg SharePointConfig) (*SharePointEnumerator, error) {
+	if cfg.Token == "" {
+		return nil, fmt.Errorf("sharepoint requires --token (OAuth bearer token for Graph API)")
+	}
+	return &SharePointEnumerator{
+		config: cfg,
+		client: &http.Client{Timeout: 30 * time.Second},
+	}, nil
+}
+
+// logf writes a progress message when verbose output is enabled.
+func (e *SharePointEnumerator) logf(format string, args ...interface{}) {
+	if e.config.Verbose != nil {
+		_, _ = fmt.Fprintf(e.config.Verbose, format+"\n", args...)
+	}
+}
+
+// progressf writes an in-place progress update (no trailing newline) using \r.
+func (e *SharePointEnumerator) progressf(format string, args ...interface{}) {
+	if e.config.Verbose != nil {
+		_, _ = fmt.Fprintf(e.config.Verbose, "\r%-80s", fmt.Sprintf(format, args...))
+	}
+}
+
+// spProvenance builds an ExtendedProvenance for a SharePoint item.
+func spProvenance(site, path, title, url string) types.ExtendedProvenance {
+	return types.ExtendedProvenance{
+		Payload: map[string]interface{}{
+			"source": "sharepoint",
+			"site":   site,
+			"path":   path,
+			"title":  title,
+			"url":    url,
+		},
+	}
+}
+
+// spGet performs an HTTP GET with retry logic for 429 and 503 responses.
+func (e *SharePointEnumerator) spGet(ctx context.Context, url string) ([]byte, error) {
+	for attempt := 0; attempt < 3; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		req.Header.Set("Authorization", "Bearer "+e.config.Token)
+		req.Header.Set("User-Agent", "NONISV|Praetorian|Titus/1.0")
+
+		resp, err := e.client.Do(req)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+			continue
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if err != nil {
+			continue
+		}
+
+		if resp.StatusCode == 429 {
+			wait := 3 * time.Second
+			if ra := resp.Header.Get("Retry-After"); ra != "" {
+				if secs, err := strconv.Atoi(ra); err == nil {
+					wait = time.Duration(secs) * time.Second
+				}
+			}
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(wait):
+			}
+			continue
+		}
+
+		if resp.StatusCode == 503 {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(2 * time.Second):
+			}
+			continue
+		}
+
+		if resp.StatusCode != 200 {
+			return nil, fmt.Errorf("sharepoint API %s returned %d: %s", url, resp.StatusCode, string(body))
+		}
+
+		return body, nil
+	}
+
+	return nil, fmt.Errorf("sharepoint API %s failed after 3 attempts", url)
+}
+
+// spGetPaginated fetches all pages of a Graph API list endpoint.
+// Returns the concatenated "value" arrays from all pages.
+func (e *SharePointEnumerator) spGetPaginated(ctx context.Context, url string) ([]map[string]interface{}, error) {
+	var all []map[string]interface{}
+	for url != "" {
+		body, err := e.spGet(ctx, url)
+		if err != nil {
+			return all, err
+		}
+		var result map[string]interface{}
+		if err := json.Unmarshal(body, &result); err != nil {
+			return all, fmt.Errorf("parsing response: %w", err)
+		}
+		values, _ := result["value"].([]interface{})
+		for _, v := range values {
+			if m, ok := v.(map[string]interface{}); ok {
+				all = append(all, m)
+			}
+		}
+		nextLink, _ := result["@odata.nextLink"].(string)
+		url = nextLink
+	}
+	return all, nil
+}
+
+// Enumerate discovers SharePoint content and yields blobs to the callback.
+func (e *SharePointEnumerator) Enumerate(ctx context.Context, callback func(content []byte, blobID types.BlobID, prov types.Provenance) error) error {
+	// Phase 1: Discover sites.
+	sites, err := e.discoverSites(ctx)
+	if err != nil {
+		return fmt.Errorf("discovering sites: %w", err)
+	}
+	e.logf("Discovered %d sites", len(sites))
+
+	// Phase 2 & 3: For each site, discover and emit content.
+	for i, site := range sites {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		siteID, _ := site["id"].(string)
+		siteName, _ := site["displayName"].(string)
+		siteURL, _ := site["webUrl"].(string)
+		if siteName == "" {
+			siteName, _ = site["name"].(string)
+		}
+
+		e.logf("Scanning site %d/%d: %s", i+1, len(sites), siteName)
+
+		// 2a. Document library files.
+		if err := e.scanDrives(ctx, siteID, siteName, siteURL, callback); err != nil {
+			e.logf("Warning: scanning drives for site %s: %v", siteName, err)
+		}
+
+		// 2b. SharePoint pages.
+		if err := e.scanPages(ctx, siteID, siteName, siteURL, callback); err != nil {
+			e.logf("Warning: scanning pages for site %s: %v", siteName, err)
+		}
+
+		// 2c. List items.
+		if err := e.scanLists(ctx, siteID, siteName, siteURL, callback); err != nil {
+			e.logf("Warning: scanning lists for site %s: %v", siteName, err)
+		}
+	}
+
+	return nil
+}
+
+// discoverSites finds SharePoint sites to scan.
+func (e *SharePointEnumerator) discoverSites(ctx context.Context) ([]map[string]interface{}, error) {
+	if e.config.Site != "" {
+		// Resolve specific site.
+		site := e.config.Site
+
+		// Try direct lookup if it looks like a URL with /sites/ path.
+		if strings.Contains(site, "/sites/") {
+			// Extract hostname and path from URL.
+			site = strings.TrimPrefix(site, "https://")
+			site = strings.TrimPrefix(site, "http://")
+			parts := strings.SplitN(site, "/sites/", 2)
+			if len(parts) == 2 {
+				hostname := parts[0]
+				sitePath := strings.TrimRight(parts[1], "/")
+				url := fmt.Sprintf("%s/sites/%s:/sites/%s", spGraphBase, hostname, sitePath)
+				body, err := e.spGet(ctx, url)
+				if err != nil {
+					// Fall back to search.
+					return e.searchSites(ctx, e.config.Site)
+				}
+				var result map[string]interface{}
+				if err := json.Unmarshal(body, &result); err != nil {
+					return e.searchSites(ctx, e.config.Site)
+				}
+				return []map[string]interface{}{result}, nil
+			}
+		}
+
+		// Search for the site by name.
+		return e.searchSites(ctx, site)
+	}
+
+	// Enumerate all sites.
+	return e.spGetPaginated(ctx, spGraphBase+"/sites?search=*")
+}
+
+// searchSites searches for sites matching a query.
+func (e *SharePointEnumerator) searchSites(ctx context.Context, query string) ([]map[string]interface{}, error) {
+	url := fmt.Sprintf("%s/sites?search=%s", spGraphBase, query)
+	return e.spGetPaginated(ctx, url)
+}
+
+// scanDrives scans document libraries for text-scannable files.
+func (e *SharePointEnumerator) scanDrives(ctx context.Context, siteID, siteName, siteURL string, callback func([]byte, types.BlobID, types.Provenance) error) error {
+	drives, err := e.spGetPaginated(ctx, fmt.Sprintf("%s/sites/%s/drives", spGraphBase, siteID))
+	if err != nil {
+		return err
+	}
+
+	for _, drive := range drives {
+		driveID, _ := drive["id"].(string)
+		if driveID == "" {
+			continue
+		}
+
+		err := e.walkDriveFolder(ctx, driveID, "", siteName, siteURL, callback)
+		if err != nil {
+			e.logf("Warning: walking drive %s: %v", driveID, err)
+		}
+	}
+
+	return nil
+}
+
+// walkDriveFolder recursively walks a drive folder, downloading text files.
+func (e *SharePointEnumerator) walkDriveFolder(ctx context.Context, driveID, folderID, siteName, siteURL string, callback func([]byte, types.BlobID, types.Provenance) error) error {
+	var url string
+	if folderID == "" {
+		url = fmt.Sprintf("%s/drives/%s/root/children", spGraphBase, driveID)
+	} else {
+		url = fmt.Sprintf("%s/drives/%s/items/%s/children", spGraphBase, driveID, folderID)
+	}
+
+	items, err := e.spGetPaginated(ctx, url)
+	if err != nil {
+		return err
+	}
+
+	for _, item := range items {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		name, _ := item["name"].(string)
+		itemID, _ := item["id"].(string)
+
+		// Check if it's a folder.
+		if _, isFolder := item["folder"]; isFolder {
+			if err := e.walkDriveFolder(ctx, driveID, itemID, siteName, siteURL, callback); err != nil {
+				e.logf("Warning: walking folder %s: %v", name, err)
+			}
+			continue
+		}
+
+		// Check if it's a text-scannable file.
+		if !spIsTextFile(name) {
+			continue
+		}
+
+		// Check file size (skip over 10MB).
+		if size, ok := item["size"].(float64); ok && size > 10*1024*1024 {
+			continue
+		}
+
+		// Build file path from parentReference.
+		filePath := name
+		if parentRef, ok := item["parentReference"].(map[string]interface{}); ok {
+			if p, ok := parentRef["path"].(string); ok {
+				filePath = p + "/" + name
+			}
+		}
+
+		// Download file content.
+		downloadURL := fmt.Sprintf("%s/drives/%s/items/%s/content", spGraphBase, driveID, itemID)
+		content, err := e.spGet(ctx, downloadURL)
+		if err != nil {
+			e.logf("Warning: downloading %s: %v", name, err)
+			continue
+		}
+
+		fileURL := siteURL
+		if webURL, ok := item["webUrl"].(string); ok {
+			fileURL = webURL
+		}
+
+		blobID := types.ComputeBlobID(content)
+		prov := spProvenance(siteName, filePath, name, fileURL)
+
+		if err := callback(content, blobID, prov); err != nil {
+			return err
+		}
+
+		e.progressf("Scanning files: %s", name)
+	}
+
+	return nil
+}
+
+// scanPages scans SharePoint site pages for text content.
+func (e *SharePointEnumerator) scanPages(ctx context.Context, siteID, siteName, siteURL string, callback func([]byte, types.BlobID, types.Provenance) error) error {
+	pages, err := e.spGetPaginated(ctx, fmt.Sprintf("%s/sites/%s/pages/microsoft.graph.sitePage", spGraphBase, siteID))
+	if err != nil {
+		return err
+	}
+
+	for _, page := range pages {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		pageID, _ := page["id"].(string)
+		pageTitle, _ := page["title"].(string)
+		pageURL, _ := page["webUrl"].(string)
+
+		if pageID == "" {
+			continue
+		}
+
+		// Get page content with canvas layout.
+		detailURL := fmt.Sprintf("%s/sites/%s/pages/%s/microsoft.graph.sitePage?$expand=canvasLayout", spGraphBase, siteID, pageID)
+		body, err := e.spGet(ctx, detailURL)
+		if err != nil {
+			e.logf("Warning: fetching page %s: %v", pageTitle, err)
+			continue
+		}
+
+		var detail map[string]interface{}
+		if err := json.Unmarshal(body, &detail); err != nil {
+			continue
+		}
+
+		// Extract text from canvasLayout.
+		text := e.extractCanvasText(detail)
+		if text == "" {
+			continue
+		}
+
+		// Build blob.
+		var sb strings.Builder
+		sb.WriteString("Title: " + pageTitle + "\n")
+		sb.WriteString("URL: " + pageURL + "\n")
+		sb.WriteString("Site: " + siteName + "\n")
+		sb.WriteString("Type: page\n")
+		sb.WriteString("---\n")
+		sb.WriteString(text)
+		blob := []byte(sb.String())
+
+		blobID := types.ComputeBlobID(blob)
+		prov := spProvenance(siteName, "", pageTitle, pageURL)
+
+		if err := callback(blob, blobID, prov); err != nil {
+			return err
+		}
+
+		e.progressf("Scanning pages: %s", pageTitle)
+	}
+
+	return nil
+}
+
+// extractCanvasText extracts text content from a page's canvasLayout.
+func (e *SharePointEnumerator) extractCanvasText(detail map[string]interface{}) string {
+	layout, _ := detail["canvasLayout"].(map[string]interface{})
+	if layout == nil {
+		return ""
+	}
+
+	var parts []string
+
+	sections, _ := layout["horizontalSections"].([]interface{})
+	for _, sec := range sections {
+		secMap, ok := sec.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		columns, _ := secMap["columns"].([]interface{})
+		for _, col := range columns {
+			colMap, ok := col.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			webparts, _ := colMap["webparts"].([]interface{})
+			for _, wp := range webparts {
+				wpMap, ok := wp.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				if innerHTML, ok := wpMap["innerHtml"].(string); ok && innerHTML != "" {
+					parts = append(parts, spStripHTML(innerHTML))
+				}
+			}
+		}
+	}
+
+	return strings.Join(parts, "\n")
+}
+
+// scanLists scans SharePoint lists for item content.
+func (e *SharePointEnumerator) scanLists(ctx context.Context, siteID, siteName, siteURL string, callback func([]byte, types.BlobID, types.Provenance) error) error {
+	lists, err := e.spGetPaginated(ctx, fmt.Sprintf("%s/sites/%s/lists", spGraphBase, siteID))
+	if err != nil {
+		return err
+	}
+
+	for _, list := range lists {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		// Skip system lists.
+		if _, hasSystem := list["system"]; hasSystem {
+			continue
+		}
+
+		// Skip document libraries (covered by drives).
+		if tmpl, ok := list["list"].(map[string]interface{}); ok {
+			if template, _ := tmpl["template"].(string); template == "documentLibrary" {
+				continue
+			}
+		}
+
+		listID, _ := list["id"].(string)
+		listName, _ := list["displayName"].(string)
+		if listID == "" {
+			continue
+		}
+
+		// Fetch list items with fields.
+		items, err := e.spGetPaginated(ctx, fmt.Sprintf("%s/sites/%s/lists/%s/items?expand=fields", spGraphBase, siteID, listID))
+		if err != nil {
+			e.logf("Warning: fetching list %s items: %v", listName, err)
+			continue
+		}
+
+		for _, item := range items {
+			fields, ok := item["fields"].(map[string]interface{})
+			if !ok || len(fields) == 0 {
+				continue
+			}
+
+			// Render fields as key: value lines.
+			var sb strings.Builder
+			sb.WriteString("List: " + listName + "\n")
+			sb.WriteString("Site: " + siteName + "\n")
+			sb.WriteString("---\n")
+
+			for k, v := range fields {
+				sb.WriteString(fmt.Sprintf("%s: %v\n", k, v))
+			}
+
+			blob := []byte(sb.String())
+			blobID := types.ComputeBlobID(blob)
+
+			itemTitle := listName
+			if t, ok := fields["Title"].(string); ok && t != "" {
+				itemTitle = t
+			}
+
+			itemURL := siteURL
+			if webURL, ok := item["webUrl"].(string); ok {
+				itemURL = webURL
+			}
+
+			prov := spProvenance(siteName, "", itemTitle, itemURL)
+
+			if err := callback(blob, blobID, prov); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+

--- a/pkg/enum/sharepoint_test.go
+++ b/pkg/enum/sharepoint_test.go
@@ -45,7 +45,7 @@ func TestSharePointStripHTML(t *testing.T) {
 		{
 			name:     "basic HTML",
 			input:    "<p>Hello <b>world</b></p>",
-			expected: "Hello world",
+			expected: "Hello world\n",
 		},
 		{
 			name:     "HTML entities",
@@ -55,7 +55,7 @@ func TestSharePointStripHTML(t *testing.T) {
 		{
 			name:     "self-closing tags",
 			input:    "line1<br/>line2",
-			expected: "line1line2",
+			expected: "line1\nline2",
 		},
 		{
 			name:     "empty string",

--- a/pkg/enum/sharepoint_test.go
+++ b/pkg/enum/sharepoint_test.go
@@ -35,34 +35,6 @@ func TestSharePointEnumerator_RequiresAuth(t *testing.T) {
 }
 
 
-// TestSharePointIsTextFile tests the spIsTextFile extension checker.
-func TestSharePointIsTextFile(t *testing.T) {
-	tests := []struct {
-		name     string
-		filename string
-		want     bool
-	}{
-		{"json file", "config.json", true},
-		{"python file", "script.py", true},
-		{"yaml file", "values.yaml", true},
-		{"env file", ".env", true},
-		{"pem file", "cert.pem", true},
-		{"tfvars file", "prod.tfvars", true},
-		{"docx file", "document.docx", false},
-		{"xlsx file", "spreadsheet.xlsx", false},
-		{"pdf file", "report.pdf", false},
-		{"png file", "image.png", false},
-		{"no extension", "Makefile", false},
-		{"uppercase extension", "CONFIG.JSON", true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, spIsTextFile(tt.filename))
-		})
-	}
-}
-
 // TestSharePointStripHTML tests the spStripHTML helper.
 func TestSharePointStripHTML(t *testing.T) {
 	tests := []struct {

--- a/pkg/enum/sharepoint_test.go
+++ b/pkg/enum/sharepoint_test.go
@@ -1,0 +1,117 @@
+package enum
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSharePointEnumerator_ConstructionWithToken tests creation with a valid token config.
+func TestSharePointEnumerator_ConstructionWithToken(t *testing.T) {
+	e, err := NewSharePointEnumerator(SharePointConfig{
+		Token: "test-bearer-token",
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, e)
+}
+
+
+// TestSharePointEnumerator_Interface verifies SharePointEnumerator implements Enumerator.
+func TestSharePointEnumerator_Interface(t *testing.T) {
+	e, err := NewSharePointEnumerator(SharePointConfig{
+		Token: "test-bearer-token",
+	})
+	require.NoError(t, err)
+
+	var _ Enumerator = e
+}
+
+// TestSharePointEnumerator_RequiresAuth tests that missing auth produces an error.
+func TestSharePointEnumerator_RequiresAuth(t *testing.T) {
+	_, err := NewSharePointEnumerator(SharePointConfig{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "token")
+}
+
+
+// TestSharePointIsTextFile tests the spIsTextFile extension checker.
+func TestSharePointIsTextFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		want     bool
+	}{
+		{"json file", "config.json", true},
+		{"python file", "script.py", true},
+		{"yaml file", "values.yaml", true},
+		{"env file", ".env", true},
+		{"pem file", "cert.pem", true},
+		{"tfvars file", "prod.tfvars", true},
+		{"docx file", "document.docx", false},
+		{"xlsx file", "spreadsheet.xlsx", false},
+		{"pdf file", "report.pdf", false},
+		{"png file", "image.png", false},
+		{"no extension", "Makefile", false},
+		{"uppercase extension", "CONFIG.JSON", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, spIsTextFile(tt.filename))
+		})
+	}
+}
+
+// TestSharePointStripHTML tests the spStripHTML helper.
+func TestSharePointStripHTML(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "basic HTML",
+			input:    "<p>Hello <b>world</b></p>",
+			expected: "Hello world",
+		},
+		{
+			name:     "HTML entities",
+			input:    "foo &amp; bar &lt;baz&gt;",
+			expected: "foo & bar <baz>",
+		},
+		{
+			name:     "self-closing tags",
+			input:    "line1<br/>line2",
+			expected: "line1line2",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "no HTML",
+			input:    "plain text content",
+			expected: "plain text content",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, spStripHTML(tt.input))
+		})
+	}
+}
+
+// TestSharePointProvenance tests that spProvenance builds the correct ExtendedProvenance.
+func TestSharePointProvenance(t *testing.T) {
+	prov := spProvenance("Engineering", "/sites/eng/Shared Documents/config.json", "config.json", "https://company.sharepoint.com/sites/eng/config.json")
+
+	payload := prov.Payload
+	require.NotNil(t, payload)
+	assert.Equal(t, "sharepoint", payload["source"])
+	assert.Equal(t, "Engineering", payload["site"])
+	assert.Equal(t, "/sites/eng/Shared Documents/config.json", payload["path"])
+	assert.Equal(t, "config.json", payload["title"])
+	assert.Equal(t, "https://company.sharepoint.com/sites/eng/config.json", payload["url"])
+}


### PR DESCRIPTION
## Summary

- Adds `titus sharepoint` subcommand for scanning SharePoint Online via Microsoft Graph API
- Shared Microsoft OAuth module (`pkg/auth/microsoft.go`) with device code flow, token caching, and refresh
- `--refresh-token` flag for silent authentication without browser interaction
- Three-tier auth fallback: `--token` > `--refresh-token` > cached token > device code flow
- Downloads and extracts text from all file types (XLSX, DOCX, PDF, ZIP, etc.) via existing Titus extractors
- Scans document libraries (recursive folder walk), SharePoint pages, and list items
- `--site` flag for scoping to a specific site
- `--client-id` and `--tenant-id` for flexible Azure AD auth
- Token cached at `~/.titus/microsoft_token.json` with atomic writes and auto-refresh
- Verbose logging for drives, files, pages, and lists

## Usage

```bash
# Device code flow (interactive, first time)
titus sharepoint --client-id 14d82eec-204b-4c2f-b7e8-296a70dab67e -v

# Subsequent runs (uses cached token)
titus sharepoint -v

# With refresh token (no browser)
titus sharepoint --refresh-token "1.AVkA..." --client-id 14d82eec-204b-4c2f-b7e8-296a70dab67e -v

# Scope to a specific site
titus sharepoint --site https://company.sharepoint.com/sites/Engineering -v
```

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] SharePoint enum tests pass (5 tests)
- [x] Auth module tests pass (12 tests)
- [x] Tested against live SharePoint tenant (5 sites, 24 files, recursive folder walk)
- [x] Token caching and refresh verified
- [x] Binary file extraction verified (XLSX)
- [x] Code review issues addressed (8 fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)