### PR TITLE
fix(enum): attribute blobs to introducing commit, not file-creation commit

### DIFF
--- a/pkg/enum/blob_commit_map.go
+++ b/pkg/enum/blob_commit_map.go
@@ -1,0 +1,105 @@
+package enum
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+)
+
+// collectBlobCommitMap runs git log --all --reverse --raw to build a map of
+// blob hash (hex) → the first commit that introduced that blob. Because
+// --reverse outputs oldest-first and we record only the first occurrence per
+// hash, every blob maps to the commit where it first appeared in the repo.
+//
+// This replaces the path-based collectCommitMetadataForRepo approach for the
+// native history enumerator: path-based attribution breaks when a secret is
+// introduced via a modification to an existing file (--diff-filter=A only
+// captures file-creation commits, not modification commits).
+func collectBlobCommitMap(ctx context.Context, repoPath string) (map[string]*types.CommitMetadata, error) {
+	args := []string{"log", "--all", "--reverse",
+		"--format=%H%x00%an%x00%ae%x00%aI%x00%cn%x00%ce%x00%cI%x00%s",
+		"--raw", "--no-abbrev"}
+
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = repoPath
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("git log: pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("git log: start: %w", err)
+	}
+
+	result := make(map[string]*types.CommitMetadata)
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 0, 256*1024), 1024*1024)
+
+	var current *types.CommitMetadata
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+
+		// Commit header: 8 null-separated fields.
+		parts := strings.SplitN(line, "\x00", 8)
+		if len(parts) == 8 && len(parts[0]) == 40 {
+			authorTS, _ := time.Parse(time.RFC3339, parts[3])
+			committerTS, _ := time.Parse(time.RFC3339, parts[6])
+			current = &types.CommitMetadata{
+				CommitID:           parts[0],
+				AuthorName:         parts[1],
+				AuthorEmail:        parts[2],
+				AuthorTimestamp:    authorTS,
+				CommitterName:      parts[4],
+				CommitterEmail:     parts[5],
+				CommitterTimestamp: committerTS,
+				Message:            parts[7],
+			}
+			continue
+		}
+
+		// Raw diff line: ":old_mode new_mode old_hash new_hash status\tpath"
+		if current != nil && len(line) > 0 && line[0] == ':' {
+			newHash := parseRawDiffNewHash(line)
+			if newHash == "" {
+				continue
+			}
+			if _, exists := result[newHash]; !exists {
+				result[newHash] = current
+			}
+		}
+	}
+
+	if err := cmd.Wait(); err != nil {
+		return result, fmt.Errorf("git log: wait: %w", err)
+	}
+
+	return result, nil
+}
+
+const zeroHash = "0000000000000000000000000000000000000000"
+
+// parseRawDiffNewHash extracts the new blob hash from a git raw diff line.
+// Format: ":old_mode new_mode old_hash new_hash status\tpath"
+// Returns "" if the line is malformed or the new hash is the zero hash (deletion).
+func parseRawDiffNewHash(line string) string {
+	// Skip the leading colon and split on whitespace.
+	// Fields: [":old_mode", "new_mode", "old_hash", "new_hash", "status\tpath"]
+	fields := strings.Fields(line)
+	if len(fields) < 5 {
+		return ""
+	}
+	newHash := fields[3]
+	if len(newHash) != 40 || newHash == zeroHash {
+		return ""
+	}
+	return newHash
+}

--- a/pkg/enum/blob_commit_map.go
+++ b/pkg/enum/blob_commit_map.go
@@ -78,6 +78,10 @@ func collectBlobCommitMap(ctx context.Context, repoPath string) (map[string]*typ
 		}
 	}
 
+	if err := scanner.Err(); err != nil {
+		return result, fmt.Errorf("git log: scan: %w", err)
+	}
+
 	if err := cmd.Wait(); err != nil {
 		return result, fmt.Errorf("git log: wait: %w", err)
 	}

--- a/pkg/enum/blob_commit_map_test.go
+++ b/pkg/enum/blob_commit_map_test.go
@@ -101,7 +101,9 @@ func TestBlobCommitMap_DeletedAndReadded(t *testing.T) {
 	writeFile(t, filepath.Join(tmpDir, "creds.txt"), content)
 	gitAddCommit(t, tmpDir, "Add creds")
 
-	os.Remove(filepath.Join(tmpDir, "creds.txt"))
+	if err := os.Remove(filepath.Join(tmpDir, "creds.txt")); err != nil {
+		t.Fatalf("remove creds.txt: %v", err)
+	}
 	gitAddCommit(t, tmpDir, "Delete creds")
 
 	writeFile(t, filepath.Join(tmpDir, "creds.txt"), content)

--- a/pkg/enum/blob_commit_map_test.go
+++ b/pkg/enum/blob_commit_map_test.go
@@ -1,0 +1,187 @@
+package enum
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+)
+
+func TestBlobCommitMap_ModifiedFileAttribution(t *testing.T) {
+	skipIfNoGit(t)
+
+	tmpDir := t.TempDir()
+	initGitRepo(t, tmpDir)
+
+	// Commit 1: create file with innocent content.
+	writeFile(t, filepath.Join(tmpDir, "config.py"), "DATABASE_URL = 'localhost'")
+	gitAddCommit(t, tmpDir, "Initial config")
+
+	// Commit 2: modify file to introduce a secret.
+	writeFile(t, filepath.Join(tmpDir, "config.py"), "DATABASE_URL = 'localhost'\nAWS_SECRET_KEY = 'AKIAIOSFODNN7EXAMPLE'")
+	gitAddCommit(t, tmpDir, "Add AWS key")
+
+	commits := gitLogHashes(t, tmpDir)
+	if len(commits) < 2 {
+		t.Fatalf("expected 2 commits, got %d", len(commits))
+	}
+	secretCommit := commits[0]  // newest — "Add AWS key"
+	initialCommit := commits[1] // oldest — "Initial config"
+
+	blobMap, err := collectBlobCommitMap(context.Background(), tmpDir)
+	if err != nil {
+		t.Fatalf("collectBlobCommitMap: %v", err)
+	}
+
+	initialContent := []byte("DATABASE_URL = 'localhost'")
+	secretContent := []byte("DATABASE_URL = 'localhost'\nAWS_SECRET_KEY = 'AKIAIOSFODNN7EXAMPLE'")
+	initialBlobID := types.ComputeBlobID(initialContent)
+	secretBlobID := types.ComputeBlobID(secretContent)
+
+	if meta, ok := blobMap[initialBlobID.Hex()]; !ok {
+		t.Error("initial blob not found in commit map")
+	} else if meta.CommitID != initialCommit {
+		t.Errorf("initial blob: got commit %s, want %s", meta.CommitID, initialCommit)
+	}
+
+	if meta, ok := blobMap[secretBlobID.Hex()]; !ok {
+		t.Error("secret blob not found in commit map")
+	} else {
+		if meta.CommitID == initialCommit {
+			t.Errorf("secret blob incorrectly attributed to initial commit %s (the --diff-filter=A bug)", initialCommit)
+		}
+		if meta.CommitID != secretCommit {
+			t.Errorf("secret blob: got commit %s, want %s", meta.CommitID, secretCommit)
+		}
+	}
+}
+
+func TestBlobCommitMap_RenamedFile(t *testing.T) {
+	skipIfNoGit(t)
+
+	tmpDir := t.TempDir()
+	initGitRepo(t, tmpDir)
+
+	content := "secret = 'hunter2'"
+	writeFile(t, filepath.Join(tmpDir, "old_name.py"), content)
+	gitAddCommit(t, tmpDir, "Add file")
+
+	runGit(t, tmpDir, "mv", "old_name.py", "new_name.py")
+	gitAddCommit(t, tmpDir, "Rename file")
+
+	commits := gitLogHashes(t, tmpDir)
+	originalCommit := commits[1]
+
+	blobMap, err := collectBlobCommitMap(context.Background(), tmpDir)
+	if err != nil {
+		t.Fatalf("collectBlobCommitMap: %v", err)
+	}
+
+	blobID := types.ComputeBlobID([]byte(content))
+	meta, ok := blobMap[blobID.Hex()]
+	if !ok {
+		t.Fatal("blob not found in commit map")
+	}
+	if meta.CommitID != originalCommit {
+		t.Errorf("renamed file blob: got commit %s, want original %s", meta.CommitID, originalCommit)
+	}
+}
+
+func TestBlobCommitMap_DeletedAndReadded(t *testing.T) {
+	skipIfNoGit(t)
+
+	tmpDir := t.TempDir()
+	initGitRepo(t, tmpDir)
+
+	content := "password = 'supersecret'"
+	writeFile(t, filepath.Join(tmpDir, "creds.txt"), content)
+	gitAddCommit(t, tmpDir, "Add creds")
+
+	os.Remove(filepath.Join(tmpDir, "creds.txt"))
+	gitAddCommit(t, tmpDir, "Delete creds")
+
+	writeFile(t, filepath.Join(tmpDir, "creds.txt"), content)
+	gitAddCommit(t, tmpDir, "Re-add creds")
+
+	commits := gitLogHashes(t, tmpDir)
+	originalCommit := commits[2]
+
+	blobMap, err := collectBlobCommitMap(context.Background(), tmpDir)
+	if err != nil {
+		t.Fatalf("collectBlobCommitMap: %v", err)
+	}
+
+	blobID := types.ComputeBlobID([]byte(content))
+	meta, ok := blobMap[blobID.Hex()]
+	if !ok {
+		t.Fatal("blob not found in commit map")
+	}
+	if meta.CommitID != originalCommit {
+		t.Errorf("got commit %s, want original %s", meta.CommitID, originalCommit)
+	}
+}
+
+func TestNativeEnumerator_ModifiedFileCommitAttribution(t *testing.T) {
+	skipIfNoGit(t)
+
+	tmpDir := t.TempDir()
+	initGitRepo(t, tmpDir)
+
+	writeFile(t, filepath.Join(tmpDir, "app.py"), "print('hello')")
+	gitAddCommit(t, tmpDir, "Initial app")
+
+	secretContent := "print('hello')\nAPI_KEY = 'sk-secret-key-12345'"
+	writeFile(t, filepath.Join(tmpDir, "app.py"), secretContent)
+	gitAddCommit(t, tmpDir, "Add API key")
+
+	commits := gitLogHashes(t, tmpDir)
+	secretCommit := commits[0]
+
+	config := Config{Root: tmpDir}
+	enumerator := NewGitEnumerator(config)
+	enumerator.WalkAll = true
+
+	var found bool
+	err := enumerator.enumerateAllHistoryNative(context.Background(), func(content []byte, blobID types.BlobID, prov types.Provenance) error {
+		if string(content) == secretContent {
+			found = true
+			gp := prov.(types.GitProvenance)
+			if gp.Commit == nil {
+				t.Fatal("expected non-nil commit for secret blob")
+			}
+			if gp.Commit.CommitID != secretCommit {
+				t.Errorf("secret blob attributed to %s (%s), want %s",
+					gp.Commit.CommitID, gp.Commit.Message, secretCommit)
+			}
+		}
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("enumerate failed: %v", err)
+	}
+	if !found {
+		t.Error("secret blob not found in enumeration")
+	}
+}
+
+func gitLogHashes(t *testing.T, dir string) []string {
+	t.Helper()
+	cmd := exec.Command("git", "log", "--format=%H")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git log: %v", err)
+	}
+	var hashes []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line != "" {
+			hashes = append(hashes, line)
+		}
+	}
+	return hashes
+}

--- a/pkg/enum/git_native.go
+++ b/pkg/enum/git_native.go
@@ -27,7 +27,7 @@ func gitBinaryAvailable() bool {
 
 // enumerateAllHistoryNative uses native git commands for fast history enumeration.
 // Phase 1: git rev-list --all --objects → collect unique blob hashes with paths.
-// Phase 2: git log → collect commit metadata keyed by file path.
+// Phase 2: git log --raw → collect commit metadata keyed by blob hash.
 // Phase 3: git cat-file --batch → stream content, filter, and invoke callback.
 func (e *GitEnumerator) enumerateAllHistoryNative(ctx context.Context, callback func(content []byte, blobID types.BlobID, prov types.Provenance) error) error {
 	blobs, err := e.collectBlobEntries(ctx)
@@ -35,9 +35,9 @@ func (e *GitEnumerator) enumerateAllHistoryNative(ctx context.Context, callback 
 		return err
 	}
 
-	commitMap, _ := e.collectCommitMetadata(ctx) // best-effort; nil map is safe
+	blobCommitMap, _ := collectBlobCommitMap(ctx, e.config.Root) // best-effort; nil map is safe
 
-	return e.streamBlobContentsWithMeta(ctx, blobs, commitMap, callback)
+	return e.streamBlobContentsWithMeta(ctx, blobs, blobCommitMap, callback)
 }
 
 // collectBlobEntries runs git rev-list --all --objects and returns deduplicated blob entries.
@@ -101,14 +101,9 @@ func (e *GitEnumerator) collectBlobEntries(ctx context.Context) ([]blobEntry, er
 	return blobs, nil
 }
 
-// collectCommitMetadata runs git log to build a map of file path → first commit metadata.
-func (e *GitEnumerator) collectCommitMetadata(ctx context.Context) (map[string]*types.CommitMetadata, error) {
-	return collectCommitMetadataForRepo(ctx, e.config.Root, true)
-}
-
 // streamBlobContentsWithMeta feeds hashes to git cat-file --batch and invokes callback for text blobs.
-// If commitMap is non-nil, attaches commit metadata to git provenance records.
-func (e *GitEnumerator) streamBlobContentsWithMeta(ctx context.Context, blobs []blobEntry, commitMap map[string]*types.CommitMetadata, callback func(content []byte, blobID types.BlobID, prov types.Provenance) error) error {
+// blobCommitMap maps blob hash (hex) → commit metadata for the commit that first introduced the blob.
+func (e *GitEnumerator) streamBlobContentsWithMeta(ctx context.Context, blobs []blobEntry, blobCommitMap map[string]*types.CommitMetadata, callback func(content []byte, blobID types.BlobID, prov types.Provenance) error) error {
 	if len(blobs) == 0 {
 		return nil
 	}
@@ -237,7 +232,7 @@ func (e *GitEnumerator) streamBlobContentsWithMeta(ctx context.Context, blobs []
 
 		prov := types.GitProvenance{
 			RepoPath: e.config.Root,
-			Commit:   commitMap[blob.path],
+			Commit:   blobCommitMap[hexStr],
 			BlobPath: blob.path,
 		}
 


### PR DESCRIPTION
## Summary

Fixes systematic commit misattribution in the native git history enumerator. Secrets introduced via a **modification** to an existing file were attributed to the file's original creation commit instead of the commit that actually introduced the secret.

### Root cause

The enumerator's Phase 2 (`collectCommitMetadata`) built a `path→commit` map using `git log --all --diff-filter=ARC`, which only captured commits where a file was Added, Renamed, or Copied. Modification commits (`M` status) were excluded entirely. When a blob was scanned in Phase 3, the path lookup returned the file-creation commit — wrong author, wrong date, wrong commit hash.

### Example

A file `talk.py` was created in commit `ca834ff` (2022-02-11). An API key was added to that file in commit `132bd51` (2023-04-04) — a modification. The scanner attributed the secret to `ca834ff` because `--diff-filter=ARC` skipped the modification commit.

### Fix

Replace the path-based commit map with a **blob-hash-based commit map** built from `git log --all --reverse --raw`:

- `--raw` exposes the actual blob hashes introduced by each commit (not just file paths)
- `--reverse` outputs oldest-first, so recording the first occurrence per blob hash gives us the commit that originally introduced that exact content
- Lookup in Phase 3 is now `blobCommitMap[blobHex]` instead of `commitMap[filePath]`

This correctly handles:
- Secrets introduced in file modifications (the original bug)
- Renamed files (blob hash unchanged, path changed)
- Deleted and re-added files (same content → same blob hash → oldest commit wins)

### Files changed

- **`pkg/enum/blob_commit_map.go`** — new `collectBlobCommitMap` function
- **`pkg/enum/git_native.go`** — use blob-hash map in `enumerateAllHistoryNative` and `streamBlobContentsWithMeta`; remove unused `collectCommitMetadata` method
- **`pkg/enum/blob_commit_map_test.go`** — 4 tests covering modification, rename, delete+re-add, and end-to-end enumerator attribution

`commit_metadata.go` and `collectCommitMetadataForRepo` are unchanged — still used by `clone.go`'s filesystem scan path.

## Test plan

- [x] `TestBlobCommitMap_ModifiedFileAttribution` — secret introduced in a modification is attributed to the modification commit, not the file-creation commit
- [x] `TestBlobCommitMap_RenamedFile` — blob attributed to original commit after file rename
- [x] `TestBlobCommitMap_DeletedAndReadded` — blob attributed to first introduction, not re-add
- [x] `TestNativeEnumerator_ModifiedFileCommitAttribution` — end-to-end: full enumerator pipeline returns correct commit for modified-file blob
- [x] All existing `pkg/enum` tests pass