### PR TITLE
chore: re-point leaderboard-metrics to public-workflows

### DIFF
--- a/.github/workflows/leaderboard-metrics.yml
+++ b/.github/workflows/leaderboard-metrics.yml
@@ -11,6 +11,6 @@ permissions:
 
 jobs:
   metrics:
-    uses: praetorian-inc/.github/.github/workflows/leaderboard-metrics.yml@main
+    uses: praetorian-inc/public-workflows/.github/workflows/leaderboard-metrics.yml@main
     with:
       capability_map: '[{"path": ".", "name": "titus"}]'


### PR DESCRIPTION
Re-points the leaderboard-metrics caller from `praetorian-inc/.github` (internal) to `praetorian-inc/public-workflows` (public).

GitHub forbids a public repo from calling a reusable workflow in an internal repo, so on public repos the current caller fails at startup (`workflow was not found`) and every merged PR permanently loses its leaderboard metric. Internal repos are re-pointed too so the org has one canonical host. No IAM change needed: the deployed trust matches `repo:praetorian-inc/*:*` for both hosts.

Ref: ENG-4165

🤖 Generated with [Claude Code](https://claude.com/claude-code)