### PR TITLE
fix(build): ensure pkg-config for the default build; fix README build docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,15 +55,15 @@ build: $(BUILD_DEPS)
 
 # Check vectorscan/hyperscan availability and attempt auto-install if missing
 check-vectorscan:
-	@if ! command -v pkg-config &>/dev/null; then \
+	@if ! command -v pkg-config >/dev/null 2>&1; then \
 		if [ "$$(uname)" = "Darwin" ]; then \
 			brew install pkg-config; \
-		elif command -v apt-get &>/dev/null; then \
+		elif command -v apt-get >/dev/null 2>&1; then \
 			sudo apt-get install -y pkg-config; \
-		elif command -v dnf &>/dev/null; then \
+		elif command -v dnf >/dev/null 2>&1; then \
 			sudo dnf install -y pkgconf-pkg-config; \
 		fi; \
-		command -v pkg-config &>/dev/null || \
+		command -v pkg-config >/dev/null 2>&1 || \
 		(echo "" && \
 		echo "pkg-config is required to locate libhs for the vectorscan build." && \
 		echo "Install it manually:" && \
@@ -99,9 +99,9 @@ ifeq ($(VECTORSCAN_AVAILABLE),0)
 		echo "" && \
 		exit 1); \
 	else \
-		if command -v apt-get &>/dev/null; then \
+		if command -v apt-get >/dev/null 2>&1; then \
 			sudo apt-get install -y libhyperscan-dev; \
-		elif command -v dnf &>/dev/null; then \
+		elif command -v dnf >/dev/null 2>&1; then \
 			sudo dnf install -y vectorscan-devel; \
 		else \
 			echo "No supported package manager found (expected apt-get or dnf)"; \

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,28 @@ build: $(BUILD_DEPS)
 
 # Check vectorscan/hyperscan availability and attempt auto-install if missing
 check-vectorscan:
+	@if ! command -v pkg-config &>/dev/null; then \
+		if [ "$$(uname)" = "Darwin" ]; then \
+			brew install pkg-config; \
+		elif command -v apt-get &>/dev/null; then \
+			sudo apt-get install -y pkg-config; \
+		elif command -v dnf &>/dev/null; then \
+			sudo dnf install -y pkgconf-pkg-config; \
+		fi; \
+		command -v pkg-config &>/dev/null || \
+		(echo "" && \
+		echo "pkg-config is required to locate libhs for the vectorscan build." && \
+		echo "Install it manually:" && \
+		echo "" && \
+		echo "  macOS (Homebrew):  brew install pkg-config" && \
+		echo "  Ubuntu/Debian:     sudo apt-get install pkg-config" && \
+		echo "  Fedora/RHEL:       sudo dnf install pkgconf-pkg-config" && \
+		echo "" && \
+		echo "Or build without vectorscan (slower, but no dependencies):" && \
+		echo "  make build-pure" && \
+		echo "" && \
+		exit 1); \
+	fi
 ifeq ($(VECTORSCAN_AVAILABLE),0)
 	@echo ""
 	@echo "=== Vectorscan/Hyperscan not found ==="

--- a/README.md
+++ b/README.md
@@ -430,12 +430,12 @@ The browser extension removes Content Security Policy and CORS headers from visi
 
 ## Building from Source
 
-### Standard Build (Pure Go)
+### Standard Build (Vectorscan-accelerated)
 
-The default build uses a pure-Go regex engine — no C dependencies required:
+By default Titus compiles with [Vectorscan](https://github.com/VectorCamp/vectorscan) (ARM) / [Hyperscan](https://github.com/intel/hyperscan) (x86) for SIMD-accelerated regex matching. This needs CGO, the C library, and `pkg-config` (which cgo uses to locate the library). `make build` checks for these and attempts to install anything missing via Homebrew / apt / dnf:
 
 ```bash
-# Build the CLI binary (outputs to dist/titus)
+# Build the CLI binary with vectorscan acceleration (outputs to dist/titus)
 make build
 
 # Build the Burp Suite extension JAR
@@ -451,28 +451,26 @@ make test
 make integration-test
 ```
 
-### Vectorscan/Hyperscan Build (Recommended for Performance)
+You'll see `[vectorscan] N/N rules compiled for Hyperscan` on startup when the accelerated engine is active.
 
-For significantly faster regex matching, build with [Vectorscan](https://github.com/VectorCamp/vectorscan) (ARM) or [Hyperscan](https://github.com/intel/hyperscan) (x86). This requires the C library installed and CGO enabled.
-
-**Install Vectorscan:**
+To install the C library yourself instead of relying on auto-install:
 
 ```bash
 # macOS (Homebrew)
-brew install vectorscan
+brew install pkg-config vectorscan
 
 # Ubuntu/Debian
-sudo apt-get install libhyperscan-dev
+sudo apt-get install pkg-config libhyperscan-dev
 
 # Fedora/RHEL
-sudo dnf install hyperscan-devel
+sudo dnf install pkgconf-pkg-config vectorscan-devel
 
-# Or build from source:
+# Or build vectorscan from source:
 git clone --depth 1 --branch vectorscan/5.4.11 https://github.com/VectorCamp/vectorscan.git
 cd vectorscan && cmake -B build -DCMAKE_INSTALL_PREFIX=/usr/local && cmake --build build && sudo cmake --install build
 ```
 
-**Build with Vectorscan:**
+If you invoke `go build` directly (for example, when embedding Titus), pass the tag and enable CGO:
 
 ```bash
 # macOS (Homebrew) — adjust PKG_CONFIG_PATH to your installed version
@@ -483,7 +481,17 @@ CGO_ENABLED=1 PKG_CONFIG_PATH="$(brew --prefix vectorscan)/lib/pkgconfig" \
 CGO_ENABLED=1 go build -tags vectorscan -o dist/titus ./cmd/titus
 ```
 
-You'll see `[vectorscan] N/N rules compiled for Hyperscan` on startup when the accelerated engine is active. Without vectorscan, Titus falls back to the pure-Go regex engine automatically.
+### Pure-Go Build (no C dependencies)
+
+If you can't install the C library — or want a fully portable, static binary — build the pure-Go engine instead. Titus automatically falls back to it at runtime whenever vectorscan isn't compiled in:
+
+```bash
+# Portable pure-Go binary (no CGO, no vectorscan)
+make build-pure
+
+# Fully static binary
+make build-static
+```
 
 ## Contributing
 


### PR DESCRIPTION
- check-vectorscan now installs pkg-config (brew/apt/dnf) when it's missing. The default `make build` uses the vectorscan cgo matcher, which needs pkg-config to locate libhs; the check previously installed the library but not pkg-config, so `make build` failed on machines without it.
- README "Building from Source" described the default `make build` as pure-Go / no C dependencies. The default is the vectorscan (CGO) build; corrected that section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)