### PR TITLE
fix(rules): mark URL/curl/JWT rules as generic

### DIFF
--- a/pkg/rule/rules/credentials.yml
+++ b/pkg/rule/rules/credentials.yml
@@ -22,5 +22,7 @@ rules:
       )?
     min_entropy: 3.0
     confidence: medium
+    categories:
+      - generic
     examples:
       - https://eaRIWNkE:qyOIhJiM@j2LYY414Q5cCYD

--- a/pkg/rule/rules/curl.yml
+++ b/pkg/rule/rules/curl.yml
@@ -5,6 +5,8 @@ rules:
     pattern: '(?i)\bcurl\s.*(?:-u|--user)\s+[''"]?(?P<TOKEN>[^:''"\s]+:[^''"\s]+)[''"]?'
     confidence: low
     min_entropy: 3.0
+    categories:
+      - generic
     references:
       - https://curl.se/docs/manpage.html#-u
     examples:
@@ -18,6 +20,8 @@ rules:
     pattern: '(?i)\bcurl\s.*(?:-H|--header)\s+[''"]Authorization:\s*(?:Bearer|Basic|Token)\s+(?P<TOKEN>[a-zA-Z0-9+/=_-]{20,})[''"]'
     confidence: low
     min_entropy: 3.5
+    categories:
+      - generic
     references:
       - https://curl.se/docs/manpage.html#-H
     examples:

--- a/pkg/rule/rules/curl.yml
+++ b/pkg/rule/rules/curl.yml
@@ -2,7 +2,7 @@ rules:
   - name: Curl Basic Authentication Credentials
     id: kingfisher.curl.1
     base_score: 55
-    pattern: '(?i)\bcurl\s.*(?:-u|--user)\s+[''"]?(?P<TOKEN>[^:''"\s]+:[^''"\s]+)[''"]?'
+    pattern: '(?i)\bcurl\s.*(?:-u|--user)\s+[''"]?(?P<username>[^:''"\s]+):(?P<password>[^''"\s]+)[''"]?'
     confidence: low
     min_entropy: 3.0
     categories:

--- a/pkg/rule/rules/jwt.yml
+++ b/pkg/rule/rules/jwt.yml
@@ -19,7 +19,7 @@ rules:
     )
     (?:[^a-zA-Z0-9_-]|$)   (?# this instead of a \b anchor because that doesn't play nicely with `-` )
 
-  categories: [api]
+  categories: [api, generic]
 
   references:
   - https://en.wikipedia.org/wiki/JSON_Web_Token


### PR DESCRIPTION
## Problem

Some rules are broad catch-alls that overlap a more-specific rule on the same secret:

- a credential embedded in a container — a URL or a `curl` invocation
- a generic format that a provider-specific rule refines — a JWT

When a specific rule also matches, `pickWinner` keeps the non-generic match. These rules were never tagged `generic`, so they won over the specific one:

https://user:ghp_xxx@github.com
  → Credentials in a URL   (whole URL)   ❌
  → GitHub Personal Access Token         ✅ (expected)

The specific rule lost, and the stored value carried the surrounding context instead of the bare token.

## Fix

Tag these rules `generic` so the specific rule wins when both fire. Each rule still fires on its own when no specific rule matches, so there's no detection loss.

This mirrors the HTTP Basic/Bearer rules (`np.http.1` / `np.http.2`), already `[secret, fuzzy, generic]`, and follows up on #289 (`prefer provider-specific rules over generic in pickWinner`).

Rules changed:
- `kingfisher.credentials.1` — Credentials in a URL
- `kingfisher.curl.1` — Curl Basic Authentication
- `kingfisher.curl.2` — Curl Header Authentication
- `np.jwt.1` — JSON Web Token

`pickWinner` only compares rules within the same cluster, and clustering is by shared captured-group value. `kingfisher.curl.1` captured the whole `user:pass` as a single group, so a provider token in the password slot (`curl -u user:ghp_...`) never shared a value with the provider rule and the tag had no effect. This PR also splits its pattern into `username` / `password` groups so the password clusters with the provider rule. (The other three already capture the credential as its own group.)