### PR TITLE
feat(serve): add rule-selection flags

### DIFF
--- a/cmd/titus/serve.go
+++ b/cmd/titus/serve.go
@@ -25,13 +25,32 @@ stdin closes or SIGTERM is received.`,
 	RunE: runServe,
 }
 
+var (
+	serveRulesPath    string
+	serveRulesInclude string
+	serveRulesExclude string
+	serveRuleset      string
+	serveIncludeNoisy bool
+)
+
 func init() {
+	serveCmd.Flags().StringVar(&serveRulesPath, "rules", "", "Path to custom rules file or directory")
+	serveCmd.Flags().StringVar(&serveRulesInclude, "rules-include", "", "Include rules matching regex pattern (comma-separated)")
+	serveCmd.Flags().StringVar(&serveRulesExclude, "rules-exclude", "", "Exclude rules matching regex pattern (comma-separated)")
+	serveCmd.Flags().StringVar(&serveRuleset, "ruleset", "all", "Ruleset to use: default, np.assets, np.hashes, all (all = no filtering)")
+	serveCmd.Flags().BoolVar(&serveIncludeNoisy, "include-noisy", true, "Enable rules marked noisy: true (high false-positive rate)")
 	rootCmd.AddCommand(serveCmd)
 }
 
 func runServe(cmd *cobra.Command, args []string) error {
-	// Create scanner core with builtin rules
-	core, err := scanner.NewCore("builtin", nil)
+	rules, err := loadRules(serveRulesPath, serveRulesInclude, serveRulesExclude, serveRuleset, serveIncludeNoisy)
+	if err != nil {
+		return fmt.Errorf("loading rules: %w", err)
+	}
+
+	core, err := scanner.NewCoreWithRules(rules, nil, func(format string, args ...any) {
+		fmt.Fprintf(os.Stderr, format, args...)
+	})
 	if err != nil {
 		return err
 	}

--- a/cmd/titus/serve_test.go
+++ b/cmd/titus/serve_test.go
@@ -58,3 +58,36 @@ func TestServeCommand_Integration(t *testing.T) {
 	// Verify ready signal was sent
 	assert.Contains(t, out.String(), `"type":"ready"`)
 }
+
+func TestServeCommand_RulesExcludeDisablesRule(t *testing.T) {
+	scan := func() string {
+		pr, pw := io.Pipe()
+		out := &bytes.Buffer{}
+		cmd := &cobra.Command{Use: "serve", RunE: runServe}
+		cmd.SetIn(pr)
+		cmd.SetOut(out)
+
+		done := make(chan error, 1)
+		go func() { done <- cmd.Execute() }()
+
+		time.Sleep(500 * time.Millisecond)
+		_, err := pw.Write([]byte(`{"type":"scan","payload":{"content":"sk_live_dhhfUUyfrAace5dBAZ10JrAD","source":""}}` + "\n"))
+		require.NoError(t, err)
+		time.Sleep(500 * time.Millisecond)
+		_, _ = pw.Write([]byte(`{"type":"close","payload":{}}` + "\n"))
+		_ = pw.Close()
+		require.NoError(t, <-done)
+		return out.String()
+	}
+
+	original := serveRulesExclude
+	defer func() { serveRulesExclude = original }()
+
+	// Rule enabled: the value matches np.stripe.1.
+	serveRulesExclude = ""
+	assert.Contains(t, scan(), "np.stripe.1")
+
+	// Rule excluded: the value no longer matches.
+	serveRulesExclude = `^np\.stripe\.1$`
+	assert.NotContains(t, scan(), "np.stripe.1")
+}


### PR DESCRIPTION
## Context

`titus serve` loaded all builtin rules unconditionally (`NewCore("builtin")`), unlike `scan` and `enum` which let the caller select rules. An integration driving `serve` had no way to exclude a rule (e.g. drop a redundant rule so its cleaner sibling wins, or turn off noisy rules).

## Change

Add the same rule-selection flags `scan`/`enum` already expose, reusing the shared `loadRules` helper and building the core via `NewCoreWithRules`:

- `--rules`
- `--rules-include`
- `--rules-exclude`
- `--ruleset`
- `--include-noisy`

## Defaults

Serve's defaults intentionally differ from `scan`, to preserve its historical behavior:

| Flag | `serve` | `scan` |
|------|---------|--------|
| `--ruleset` | `all` (no filtering) | `default` (curated) |
| `--include-noisy` | `true` | `false` |

The flags are additive and opt-in, so existing `serve` callers are unaffected.