### PR TITLE
fix(rules): fix np.azure.6 collision and over-broad Notification Hub rule

### DIFF
--- a/pkg/rule/loader_test.go
+++ b/pkg/rule/loader_test.go
@@ -671,3 +671,22 @@ func TestLoadRulesFromFileMulti_InvalidRule(t *testing.T) {
 		t.Fatal("expected error for rule missing base_score")
 	}
 }
+
+// TestBuiltinRules_UniqueIDs guards against two builtin rules sharing an ID.
+// LoadBuiltinRules appends every rule without deduping, so a collision makes
+// ID-keyed lookups (scoring, ruleset selection, downstream mapping) resolve to
+// only one of the colliding rules.
+func TestBuiltinRules_UniqueIDs(t *testing.T) {
+	rules, err := NewLoader().LoadBuiltinRules()
+	if err != nil {
+		t.Fatalf("LoadBuiltinRules failed: %v", err)
+	}
+
+	nameByID := make(map[string]string, len(rules))
+	for _, r := range rules {
+		if prev, dup := nameByID[r.ID]; dup {
+			t.Errorf("duplicate rule ID %q: %q and %q", r.ID, prev, r.Name)
+		}
+		nameByID[r.ID] = r.Name
+	}
+}

--- a/pkg/rule/rules/azure-notification-hub.yml
+++ b/pkg/rule/rules/azure-notification-hub.yml
@@ -7,7 +7,7 @@ rules:
   pattern: |
     (?x)
     (?i)
-    (?:["']?(?:hub)?(?:access|api|notification(?:Hub)?)Key|SharedAccessKey)["']?  (?# Key name with optional quotes)
+    (?:["']?(?:hub(?:access|api)|notification(?:hub)?)Key|SharedAccessKey)["']?  (?# Azure-specific key name with optional quotes)
     \s*[:\]=]\s*                                                                    (?# Separator: colon, equals, or bracket-equals)
     ["']?                                                                           (?# Optional opening quote)
     (?P<key>[A-Za-z0-9+/]{32,88}={0,2})                                            (?# Base64-encoded key: 32-88 chars + padding)

--- a/pkg/rule/rules/azure.yml
+++ b/pkg/rule/rules/azure.yml
@@ -239,7 +239,7 @@ rules:
 
 
 - name: Azure Cognitive Services Host
-  id: np.azure.6
+  id: np.azure.9
   base_score: 62
 
   pattern: |

--- a/pkg/rule/rulesets/np.assets.yml
+++ b/pkg/rule/rulesets/np.assets.yml
@@ -15,6 +15,7 @@ rulesets:
   - np.arn.1          # Amazon Resource Name
   - np.aws.1          # AWS API Key
   - np.aws.3          # AWS Account ID
+  - np.azure.9        # Azure Cognitive Services Host
   - np.firebase.2     # Firebase Cloud Messaging Device Token
   - np.gcs.1          # Google Cloud Storage Bucket
   - np.gcs.2          # Google Cloud Storage Bucket


### PR DESCRIPTION
Two independent issues with the `np.azure.6` rules.

## `np.azure.6` ID collision

`np.azure.6` was defined by **two distinct rules** — *Azure Cognitive Services Host* (`azure.yml`) and *Azure Notification Hub Access Key* (`azure-notification-hub.yml`). `LoadBuiltinRules` appends every rule without deduping, so both load under the same ID and any ID-keyed lookup (`pickWinner` scoring, ruleset `include_rule_ids`, downstream mapping) resolves to only one of them. In practice a Cognitive Services **host** match ends up labeled as a Notification Hub **key**.

Fix:
- Give the host rule a unique ID (`np.azure.9`).
- List it in the `np.assets` ruleset (it's a host/asset identifier, next to the bucket/client-ID rules) instead of leaking into `default` via the shared ID.
- Add `TestBuiltinRules_UniqueIDs` to guard the whole builtin corpus — the existing duplicate-ID check only covered rulesets, not the loaded rule set.

## Over-broad Notification Hub pattern

The rule's key-name alternation made the `hub` prefix optional, so it matched bare `apiKey` / `accessKey` — generic field names used across many services, not Azure-specific. Any `<field>: "<base64>"` with one of those names was flagged as an Azure Notification Hub key and, because it shares the captured value with the real rule, won the cluster and mislabeled it (a Google `apiKey: "AIza…"` is one such case).

Require the `hub` prefix on `access`/`api` so only Azure-specific field names match:

```diff
- (?:hub)?(?:access|api|notification(?:Hub)?)Key
+ (?:hub(?:access|api)|notification(?:hub)?)Key
```

`hubAccessKey`, `hubApiKey`, `notificationHubKey`, `SharedAccessKey` still match; bare `apiKey` / `accessKey` no longer.