### PR TITLE
fix(scanner): keep ScanBatch results aligned with items

### DIFF
--- a/pkg/scanner/core.go
+++ b/pkg/scanner/core.go
@@ -109,14 +109,14 @@ func (c *Core) Scan(content, source string) (*ScanResult, error) {
 
 // ScanBatch scans multiple content items
 func (c *Core) ScanBatch(items []ContentItem) (*BatchScanResult, error) {
-	var results []ScanResult
+	results := make([]ScanResult, 0, len(items))
 	total := 0
 
 	for _, item := range items {
 		matches, err := c.matcher.Match([]byte(item.Content))
 		if err != nil {
-			// Skip items that fail to scan
-			continue
+			// Retain failed items with an empty result so results stay aligned with items.
+			matches = []*types.Match{}
 		}
 
 		results = append(results, ScanResult{


### PR DESCRIPTION
## Summary

`Core.ScanBatch` skipped any item whose match failed and started from a `nil` slice. This produced a `Results` slice shorter than the input `items` (and `null` when a batch produced nothing at all).

`serve`'s `handleScanBatch` pairs results back to items **by index**:

```go
for i, scanResult := range result.Results {
    populateSourcePositions([]byte(p.Items[i].Content), scanResult.Matches)
}
```

Once a single item is skipped, every later result is paired with the wrong item's content, so source positions are computed against the wrong input. Downstream consumers that zip `results` with `items` positionally (the serve JSON protocol, the WASM batch export) hit the same misalignment,.

## Fix

- Preallocate `results` with `make([]ScanResult, 0, len(items))` so an empty batch marshals to `[]` instead of `null`.
- Emit an empty result for a failed item instead of skipping it, keeping `Results` 1:1 with `items`.

Behaviour for valid content is unchanged; the only difference is that a failed item now appears as a result with no matches rather than being dropped.