### PR TITLE
ci: add operator-dispatched leaderboard backfill caller (ENG-5690)

### DIFF
--- a/.github/workflows/leaderboard-backfill-caller.yml
+++ b/.github/workflows/leaderboard-backfill-caller.yml
@@ -1,0 +1,49 @@
+# Operator-dispatched REPLAY path for leaderboard metrics. The live caller
+# (leaderboard-metrics.yml) fires only on a real `pull_request_target: closed`
+# event and never retries, so PRs that merged before this repo was onboarded
+# have no metrics at all. titus failed 3 runs beginning 2026-07-06,
+# losing 3 merged PRs.
+#
+# ⚠ The `uses:` pin is COUPLED TO PROD IAM: the LeaderboardMetricsRole trust
+# list names the CALLED reusable at this exact SHA, so bumping it alone fails
+# closed at AssumeRole with no local signal. A bump needs the matching
+# guard-core backend/template.yml entry deployed FIRST (ENG-4164 runbook).
+#
+# This repo has NO .github/dependabot.yml, so Dependabot version updates are
+# off and the pin above is not currently at risk of an automated bump. If a
+# dependabot.yml is ever added here with a `github-actions` ecosystem, it MUST
+# carry ignore entries for BOTH leaderboard reusables, or this pin gets bumped
+# and delivery fails closed and silently — the ENG-5687 incident exactly.
+#
+# `capability_map` is omitted DELIBERATELY — unset means "derive it from this
+# repo's own live leaderboard-metrics.yml on the default branch", so a replay
+# attributes capabilities exactly as live runs do; passing a value is what
+# would drift.
+#
+# Replay is idempotent ONLY while author resolution is unchanged: the consumer
+# upserts CodeCommit on `#code_commit#<repo>#<pr_number>#<author>`, so
+# re-running a PR overwrites its own row — a changed ENGINEER_EMAIL_MAP keys a
+# second row and double-counts (ENG-5693).
+#
+# Sole repo prerequisite: the `leaderboard` GitHub environment (present). NEVER
+# apply the Actions OIDC sub-claim customization (see leaderboard-metrics.yml).
+name: Leaderboard Backfill
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_numbers:
+        description: "PR numbers to replay (comma- or space-separated)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: read
+  id-token: write
+
+jobs:
+  backfill:
+    uses: praetorian-inc/public-workflows/.github/workflows/leaderboard-backfill.yml@6c715ccf351a09bfcb916aede4c542e437e5f31d # v2.17.0
+    with:
+      pr_numbers: ${{ inputs.pr_numbers }}


### PR DESCRIPTION
## What

Adds `.github/workflows/leaderboard-backfill-caller.yml` — a `workflow_dispatch`
caller for the `leaderboard-backfill.yml` reusable that shipped in ENG-5688.
One file, 49 lines, no other change.

## Why this repo

titus failed 3 runs beginning 2026-07-06, losing 3 merged PRs.

Those metrics are not recoverable by any mechanism that fires on its own: the
live caller only ever runs on a real `pull_request_target: closed` event, and by
the reusable's own stated design a blocked run loses that PR's metrics with no
retry. Replay has to be dispatched by an operator, from here.

## Premise gate — SKIP recorded

The trigger (a change building non-trivial machinery) does not fire: this is a
thin caller of an already-reviewed reusable at an already-trusted SHA. It
introduces no new layer, no new abstraction and no new behavior of its own — the
machinery is ENG-5688, which carried its own PROCEED verdict and is merged and
deployed. Size-and-behavior condition that applied: single file, dispatch-only,
defines no behavior beyond forwarding one input.

## Safety

- **No IAM change needed.** `job_workflow_ref` names the *reusable's* path, not
  the caller's repo, so the entry ENG-5688 added already covers this repo.
  Verified empirically: caeruleus ran this same caller successfully as a repo
  that had never used the reusable, with no trust-policy edit.
- **Pin is load-bearing and must not be bumped alone.** Documented in the file
  header; a bump requires the matching guard-core `backend/template.yml` entry
  deployed first (ENG-4164 runbook).
- **`capability_map` deliberately unset**, so a replay attributes capabilities
  exactly as live runs do rather than drifting from a hardcoded copy.
- **Dispatch-only**: no schedule, no push/PR trigger. It cannot fire by itself.
- Sole repo prerequisite is the `leaderboard` GitHub environment — already
  present here (verified).

## Replay is idempotent only while author resolution is unchanged

The consumer upserts `CodeCommit` on `#code_commit#<repo>#<pr_number>#<author>`,
so replaying a PR overwrites its own row — but the author email is part of that
key, so a changed `ENGINEER_EMAIL_MAP` would key a second row and double-count
(ENG-5693). Not a concern for the PRs this exists to replay: they never
delivered, so there is no row to duplicate.

Refs ENG-5690, ENG-5688, ENG-5775.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
