### PR TITLE
build(go): upgrade to Go 1.27

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
     permissions:
       contents: read
     with:
+      golangci-lint-version: "v2.13.1"
       build-cmd-path: ./cmd/titus
       build-binary-name: titus
     secrets: inherit

--- a/.github/workflows/release-new.yml
+++ b/.github/workflows/release-new.yml
@@ -260,6 +260,7 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Set up Go
+      id: setup_go
       uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
       with:
         go-version-file: 'go.mod'
@@ -322,9 +323,17 @@ jobs:
       env:
         CGO_ENABLED: "1"
         PKG_CONFIG_PATH: "/mingw64/lib/pkgconfig"
+        SETUP_GO_VERSION: ${{ steps.setup_go.outputs.go-version }}
+        GOTOOLCHAIN: local
       run: |
-        # Get Go binary from actions/setup-go (Windows native path)
-        export PATH="$(cygpath -u "$GOROOT_1_25_X64/bin"):$PATH"
+        # Get the exact Go binary installed by actions/setup-go
+        go_bin="$(cygpath -u "$RUNNER_TOOL_CACHE/go/$SETUP_GO_VERSION/x64/bin")"
+        if [ ! -x "$go_bin/go.exe" ]; then
+          printf 'Go from actions/setup-go not found: %s\n' "$go_bin/go.exe" >&2
+          exit 1
+        fi
+        export PATH="$go_bin:$PATH"
+        go version
         export GOWORK=off
 
         # Verify pkg-config can find libhs

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -30,4 +30,7 @@ jobs:
       pull-requests: read     # go-sec.yml preflight reads PR files + repo tree
       security-events: write
       actions: read           # required by codeql-action/upload-sarif for run metadata
+    with:
+      gosec-version: "v2.28.0"
+      govulncheck-version: "v1.7.0"
     secrets: inherit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Feature requests are tracked as [GitHub Issues](https://github.com/praetorian-in
 
 ### Prerequisites
 
-- **Go 1.24+**
+- **Go 1.27.0+**
 - **make**
 - For the Burp extension: JDK and Gradle
 - For the Chrome extension: Node.js and npm

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Titus: High-Performance Secrets Scanner
 
-[![Go](https://img.shields.io/badge/Go-1.23+-00ADD8?logo=go&logoColor=white)](https://go.dev)
+[![Go](https://img.shields.io/badge/Go-1.27.0+-00ADD8?logo=go&logoColor=white)](https://go.dev)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![CI](https://img.shields.io/github/actions/workflow/status/praetorian-inc/titus/ci.yml?branch=main&label=CI)](https://github.com/praetorian-inc/titus/actions)
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/praetorian-inc/titus
 
-go 1.25.8
+go 1.27.0
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4


### PR DESCRIPTION
## Premise review — skipped

Mechanical toolchain migration; no new layer or abstraction.

## Summary
- raise the module and documented minimum to Go 1.27.0
- pin gosec v2.28.0, govulncheck v1.7.0, and golangci-lint v2.13.1 through existing workflow inputs

Scanner behavior and policy are unchanged. Gosec adds 6 unique reports; all remain surfaced. Govulncheck adds no IDs (28 → 13).

## Verification
Exact Go 1.27 Linux: module verify/tidy, build, vet, full tests, race, lint, scanners, pure/static/WASM builds, integration tests, validator tests, score lint, and fixture scan.