### PR TITLE
feat(scoring): score SendGrid API keys by permission scope (LAB-3371)

### DIFF
--- a/cmd/titus/scan_scoring_scope_test.go
+++ b/cmd/titus/scan_scoring_scope_test.go
@@ -466,7 +466,7 @@ scorers:
         priority: 50
         http: *sg
         fires_when:
-          response_body_contains: '"marketing.contacts.read"'
+          response_body_contains: '"marketing.read"'
         delta: 15
       - name: narrow-scope-set
         priority: 40
@@ -610,4 +610,15 @@ func TestSendGridScorer_RevokedKey_SetScore5(t *testing.T) {
 	// The negated array-length check must not fire on an error body: jsonGet
 	// errors on the missing .scopes path rather than returning false.
 	assert.NotContains(t, appliedNames(score), "narrow-scope-set")
+}
+
+// Email Marketing access exposes contact lists (PII). The documented scope is
+// marketing.read; marketing.contacts.read does not exist.
+func TestSendGridScorer_MarketingAccess_AddsPIIDelta(t *testing.T) {
+	srv := sendgridScopesServer(t, []string{"mail.send", "marketing.read"}, http.StatusOK)
+	defer srv.Close()
+
+	score := scoreSendGridKey(t, srv)
+	assert.Contains(t, appliedNames(score), "contact-pii-access")
+	assert.Equal(t, 60, score.Final, "65 base + 15 marketing PII - 20 narrow scope")
 }

--- a/cmd/titus/scan_scoring_scope_test.go
+++ b/cmd/titus/scan_scoring_scope_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -414,4 +416,198 @@ scorers:
 	assert.Equal(t, rule.BaseScore, score.Final, "scope disabled: no dynamic modifier should fire")
 	assert.Equal(t, 0, int(calls.Load()), "scope disabled: no HTTP calls should be made")
 	assert.Empty(t, score.Applied, "scope disabled: Applied must be empty")
+}
+
+// ----------------------------------------------------------------
+// SendGrid scope scorer (LAB-3371)
+//
+// Mirrors pkg/scoring/scorers/sendgrid.yaml with the API host swapped for an
+// in-process httptest.Server. Priorities matter here: higher priority is
+// evaluated FIRST, and a later set_score replaces an earlier running score, so
+// billing-access (30) deliberately lands after narrow-scope-set (40) and
+// revoked-key (10) lands last of all.
+// ----------------------------------------------------------------
+
+const sendgridTestKey = "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"
+
+func sendgridTestScorerYAML(mockURL string) []byte {
+	return []byte(`
+scorers:
+  - name: sendgrid-key-scope
+    rule_ids:
+      - np.sendgrid.1
+    modifiers:
+      - name: full-access-key
+        priority: 90
+        http: &sg
+          method: GET
+          url: ` + mockURL + `/v3/scopes
+          auth:
+            type: bearer
+            secret_group: "token"
+        fires_when:
+          json_array_length_gte:
+            path: ".scopes"
+            value: 100
+        set_score: 85
+      - name: domain-auth-access
+        priority: 70
+        http: *sg
+        fires_when:
+          response_body_contains: '"whitelabel.read"'
+        delta: 20
+      - name: subuser-management
+        priority: 60
+        http: *sg
+        fires_when:
+          response_body_contains: '"subusers.create"'
+        delta: 15
+      - name: contact-pii-access
+        priority: 50
+        http: *sg
+        fires_when:
+          response_body_contains: '"marketing.contacts.read"'
+        delta: 15
+      - name: narrow-scope-set
+        priority: 40
+        http: *sg
+        fires_when:
+          negative: true
+          json_array_length_gte:
+            path: ".scopes"
+            value: 25
+        delta: -20
+      - name: billing-access
+        priority: 30
+        http: *sg
+        fires_when:
+          response_body_contains: '"billing.read"'
+        set_score: 85
+      - name: revoked-key
+        priority: 10
+        http: *sg
+        fires_when:
+          status_code: 401
+        set_score: 5
+`)
+}
+
+// sendgridScopesServer serves a /v3/scopes payload for the given scope list,
+// rejecting any request that does not carry the expected bearer token.
+func sendgridScopesServer(t *testing.T, scopes []string, status int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+sendgridTestKey {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		if status != http.StatusOK {
+			_, _ = w.Write([]byte(`{"errors":[{"message":"authorization required"}]}`))
+			return
+		}
+		body, err := json.Marshal(map[string][]string{"scopes": scopes})
+		require.NoError(t, err)
+		_, _ = w.Write(body)
+	}))
+}
+
+func scoreSendGridKey(t *testing.T, srv *httptest.Server) *types.Score {
+	t.Helper()
+	const ruleID = "np.sendgrid.1"
+	scorers, err := scoring.NewLoader().LoadScorers(sendgridTestScorerYAML(srv.URL))
+	require.NoError(t, err)
+
+	engine := scoring.NewEngine(scorers, scoring.EngineConfig{
+		ScopeEnabled: true,
+		Timeout:      5 * time.Second,
+	})
+	rule := &types.Rule{ID: ruleID, BaseScore: 65}
+	finding := &types.Finding{ID: "sendgrid-finding-1", RuleID: ruleID}
+	match := &types.Match{
+		RuleID:      ruleID,
+		NamedGroups: map[string][]byte{"token": []byte(sendgridTestKey)},
+	}
+	score := engine.Score(context.Background(), finding, []*types.Match{match}, rule)
+	require.NotNil(t, score)
+	return score
+}
+
+func appliedNames(score *types.Score) []string {
+	var names []string
+	for _, a := range score.Applied {
+		names = append(names, a.Name)
+	}
+	return names
+}
+
+// genericScopes returns n harmless scope names that match none of the
+// sensitive-scope substrings the scorer looks for.
+func genericScopes(n int) []string {
+	out := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		out = append(out, fmt.Sprintf("templates.read.%d", i))
+	}
+	return out
+}
+
+// A Full Access key returns the whole scope catalogue; breadth alone puts it at 85.
+func TestSendGridScorer_FullAccessKey_SetScore85(t *testing.T) {
+	srv := sendgridScopesServer(t, append(genericScopes(120), "mail.send"), http.StatusOK)
+	defer srv.Close()
+
+	score := scoreSendGridKey(t, srv)
+	assert.Equal(t, 85, score.Final)
+	assert.Contains(t, appliedNames(score), "full-access-key")
+	assert.NotContains(t, appliedNames(score), "narrow-scope-set")
+}
+
+// A restricted key with only mail.send is scored DOWN from the 65 base. This is
+// the case the DSL could not express before the negative: flag.
+func TestSendGridScorer_MailSendOnly_ScoredDown(t *testing.T) {
+	srv := sendgridScopesServer(t, []string{"mail.send"}, http.StatusOK)
+	defer srv.Close()
+
+	score := scoreSendGridKey(t, srv)
+	assert.Equal(t, 45, score.Final, "65 base - 20 for a narrow scope set")
+	assert.Contains(t, appliedNames(score), "narrow-scope-set")
+	assert.NotContains(t, appliedNames(score), "full-access-key")
+}
+
+// A billing key is narrow but high value. billing-access is evaluated after
+// narrow-scope-set precisely so its set_score overrides that downgrade.
+func TestSendGridScorer_BillingKey_OverridesNarrowDowngrade(t *testing.T) {
+	srv := sendgridScopesServer(t, []string{"billing.read", "billing.update"}, http.StatusOK)
+	defer srv.Close()
+
+	score := scoreSendGridKey(t, srv)
+	assert.Equal(t, 85, score.Final, "billing set_score must win over the narrow-scope delta")
+	assert.Contains(t, appliedNames(score), "billing-access")
+	assert.Contains(t, appliedNames(score), "narrow-scope-set")
+}
+
+// Sensitive-scope deltas compose with the narrow-scope downgrade.
+func TestSendGridScorer_NarrowKeyWithDomainAuth_NetsToBase(t *testing.T) {
+	srv := sendgridScopesServer(t, []string{"mail.send", "whitelabel.read"}, http.StatusOK)
+	defer srv.Close()
+
+	score := scoreSendGridKey(t, srv)
+	assert.Equal(t, 65, score.Final, "65 base + 20 domain auth - 20 narrow scope")
+	assert.Contains(t, appliedNames(score), "domain-auth-access")
+	assert.Contains(t, appliedNames(score), "narrow-scope-set")
+}
+
+// A revoked key is worthless regardless of what it once could do. revoked-key
+// is the lowest priority so its set_score lands last and wins outright.
+func TestSendGridScorer_RevokedKey_SetScore5(t *testing.T) {
+	srv := sendgridScopesServer(t, nil, http.StatusUnauthorized)
+	defer srv.Close()
+
+	score := scoreSendGridKey(t, srv)
+	assert.Equal(t, 5, score.Final)
+	assert.Contains(t, appliedNames(score), "revoked-key")
+	// The negated array-length check must not fire on an error body: jsonGet
+	// errors on the missing .scopes path rather than returning false.
+	assert.NotContains(t, appliedNames(score), "narrow-scope-set")
 }

--- a/cmd/titus/scan_scoring_scope_test.go
+++ b/cmd/titus/scan_scoring_scope_test.go
@@ -449,7 +449,7 @@ scorers:
           json_array_length_gte:
             path: ".scopes"
             value: 100
-        set_score: 85
+        delta: 30
       - name: domain-auth-access
         priority: 70
         http: *sg
@@ -552,13 +552,15 @@ func genericScopes(n int) []string {
 	return out
 }
 
-// A Full Access key returns the whole scope catalogue; breadth alone puts it at 85.
-func TestSendGridScorer_FullAccessKey_SetScore85(t *testing.T) {
+// Breadth alone is worth +30 over the 65 base. This fixture is deliberately
+// unrealistic -- a real Full Access key also holds the sensitive scopes, which
+// is covered by TestSendGridScorer_RealisticFullAccess_IsMaximal.
+func TestSendGridScorer_BreadthAlone_AddsDelta(t *testing.T) {
 	srv := sendgridScopesServer(t, append(genericScopes(120), "mail.send"), http.StatusOK)
 	defer srv.Close()
 
 	score := scoreSendGridKey(t, srv)
-	assert.Equal(t, 85, score.Final)
+	assert.Equal(t, 95, score.Final, "65 base + 30 breadth")
 	assert.Contains(t, appliedNames(score), "full-access-key")
 	assert.NotContains(t, appliedNames(score), "narrow-scope-set")
 }
@@ -621,4 +623,29 @@ func TestSendGridScorer_MarketingAccess_AddsPIIDelta(t *testing.T) {
 	score := scoreSendGridKey(t, srv)
 	assert.Contains(t, appliedNames(score), "contact-pii-access")
 	assert.Equal(t, 60, score.Final, "65 base + 15 marketing PII - 20 narrow scope")
+}
+
+// A REAL Full Access key returns the whole catalogue, which necessarily
+// includes the sensitive scopes the deltas look for. Scoring it must be
+// monotonic: a Full Access key can never score below a key holding a subset of
+// its scopes. The earlier fixture omitted those scopes, so it exercised a key
+// that cannot exist and hid the interaction between set_score and the deltas.
+func TestSendGridScorer_RealisticFullAccess_IsMaximal(t *testing.T) {
+	full := append(genericScopes(120),
+		"mail.send", "whitelabel.read", "subusers.create", "marketing.read")
+	srvFull := sendgridScopesServer(t, full, http.StatusOK)
+	defer srvFull.Close()
+	fullScore := scoreSendGridKey(t, srvFull)
+
+	// A mid-breadth key holding the same sensitive scopes but far fewer overall.
+	subset := append(genericScopes(30),
+		"mail.send", "whitelabel.read", "subusers.create", "marketing.read")
+	srvSubset := sendgridScopesServer(t, subset, http.StatusOK)
+	defer srvSubset.Close()
+	subsetScore := scoreSendGridKey(t, srvSubset)
+
+	assert.Contains(t, appliedNames(fullScore), "full-access-key")
+	assert.GreaterOrEqual(t, fullScore.Final, subsetScore.Final,
+		"a Full Access key must never score below a key holding a subset of its scopes")
+	assert.Equal(t, 100, fullScore.Final, "full access plus every sensitive scope family is maximal")
 }

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -227,11 +227,34 @@ Dynamic (`http`) modifiers support the following options:
 
 | Condition | Description |
 |-----------|-------------|
-| `status_code_is` | Fires when the HTTP response status matches the given code |
+| `status_code` | Fires when the HTTP response status equals the given code |
+| `status_code_in` | Fires when the response status is any of the given codes |
+| `response_body_contains` | Fires when the response body contains a substring |
 | `header_contains` | Fires when a specific response header contains a substring |
-| `json_path_equals` | Fires when a JSONPath expression equals a specific value |
-| `json_path_matches` | Fires when a JSONPath expression matches a regex |
-| `json_array_length_gte` | Fires when a JSONPath array has at least N elements |
+| `json_path_equals` | Fires when a dot-notation path equals a specific value |
+| `json_path_matches` | Fires when a dot-notation path matches a regex |
+| `json_array_length_gte` | Fires when a dot-notation path is an array with at least N elements |
+
+Paths are simple dot-notation (`.`, `.field`, `.a.b`); array indexing is not supported.
+
+**Negating a condition (`negative`):**
+
+Set `negative: true` alongside a leaf to invert it. It modifies the leaf rather than
+being a leaf itself, so a `fires_when` block still requires exactly one condition:
+
+```yaml
+fires_when:
+  negative: true
+  json_array_length_gte:
+    path: ".scopes"
+    value: 25          # fires when there are FEWER than 25 scopes
+```
+
+This supplies the absence and upper-bound tests the condition list otherwise lacks.
+
+Errors are propagated, never inverted: a path that does not exist is an error rather
+than a `false`, so a negated `json_path_*` will not fire on a response missing the
+field. For absence checks prefer `response_body_contains`, which cannot error.
 
 **Template variables:**
 

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -277,7 +277,9 @@ Note the secret itself is normally injected via `auth.secret_group` rather than 
 
 **Response caching:**
 
-Within a single scan, responses are cached on (method, URL, secret). If several modifiers for the same finding issue the same request, only one network call is made -- so a scorer can split its logic across many modifiers without multiplying traffic. The URL is keyed before template substitution, so plaintext secrets never appear in cache keys.
+Within a single scan, responses are cached on (method, URL, secret). If several modifiers for the same finding issue the same request, only one network call is made -- so a scorer can split its logic across many modifiers without multiplying traffic.
+
+The URL is keyed **before** template substitution, so plaintext secrets never appear in cache keys. That has a consequence worth knowing: two requests whose URL templates are identical but which render differently -- because a non-secret variable such as a region or account identifier differs -- currently share a cache entry, and the second silently receives the first response. No built-in scorer triggers this today (the only templated URL substitutes its own secret), but do not rely on a non-secret template variable to distinguish two requests until this is fixed. Tracked as LAB-6051.
 
 ---
 

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -193,14 +193,16 @@ scorers:
       - name: config-file-context
         priority: 80
         surrounding_context_contains:
-          pattern: 'api_key\s*='
+          value: 'api_key='
+          within: 64
         delta: 5
 
       # Static modifier: fires based on secret length (useful as an entropy proxy)
       - name: long-token
         priority: 70
         match_length:
-          min: 40
+          op: gt          # gt | lt | eq
+          value: 40
         delta: 10
 
       # Dynamic modifier: makes a live HTTP call (only fires with --score-scope)
@@ -210,9 +212,10 @@ scorers:
           method: GET
           url: "https://api.example.com/me"
           auth:
-            bearer: "{{ .Groups.token }}"    # inject named capture group as Bearer token
+            type: bearer
+            secret_group: "token"   # named capture group holding the secret
         fires_when:
-          status_code_is: 200
+          status_code: 200
         delta: 20
 ```
 
@@ -220,8 +223,18 @@ scorers:
 
 Dynamic (`http`) modifiers support the following options:
 
-**Authentication:**
-- `auth.bearer`: injects a named capture group value as a `Bearer` token in the `Authorization` header.
+**Authentication (`auth`):**
+
+`auth.type` selects the scheme and `auth.secret_group` names the rule capture
+group holding the secret:
+
+| Type | Effect |
+|------|--------|
+| `bearer` | `Authorization: Bearer <secret>` |
+| `basic` | `Authorization: Basic base64(<username>:<secret>)` (set `username`) |
+| `header` | Sends the secret in `header_name` |
+| `query` | Sends the secret in the `query_param` query parameter |
+| `api_key` | `Authorization: <key_prefix><secret>` (`key_prefix` defaults to `key=`) |
 
 **Firing conditions (`fires_when`):**
 
@@ -258,11 +271,13 @@ field. For absence checks prefer `response_body_contains`, which cannot error.
 
 **Template variables:**
 
-Use `{{ .Groups.<name> }}` in URL strings or header values to inject named capture groups from the rule regex. Example: if your rule captures a token in a group named `token`, use `{{ .Groups.token }}` anywhere in the HTTP modifier.
+Use `{{name}}` (or `{{ name }}` with spaces) in the URL, header values, or request body to inject a named capture group from the rule regex. If your rule captures a token in a group named `token`, write `{{token}}`.
+
+Note the secret itself is normally injected via `auth.secret_group` rather than a template variable; template variables are for the other captures a request needs, such as an account or region identifier.
 
 **Response caching:**
 
-Within a single scan, identical HTTP requests (same URL, method, and headers) are cached. If multiple modifiers for the same finding make the same call, only one network request is sent.
+Within a single scan, responses are cached on (method, URL, secret). If several modifiers for the same finding issue the same request, only one network call is made -- so a scorer can split its logic across many modifiers without multiplying traffic. The URL is keyed before template substitution, so plaintext secrets never appear in cache keys.
 
 ---
 

--- a/pkg/scoring/condition_http.go
+++ b/pkg/scoring/condition_http.go
@@ -183,3 +183,26 @@ func (l *jsonArrayLengthGteLeaf) evaluate(resp *cachedHTTPResponse) (bool, error
 	}
 	return len(arr) >= l.Value, nil
 }
+
+// ----------------------------------------------------------------
+// negated leaf (`negative: true`)
+// ----------------------------------------------------------------
+
+// negatedLeaf inverts the result of the leaf it wraps, giving the DSL the
+// absence and upper-bound tests it otherwise lacks (e.g. negative: +
+// json_array_length_gte reads as "fewer than N").
+//
+// Errors are propagated unchanged, never inverted: jsonGet returns an error for
+// a missing path rather than false, so inverting errors would make a negated
+// json_path_* condition fire on any response that lacks the field — including
+// the error body returned by a revoked credential. Prefer response_body_contains
+// for absence checks, as it cannot error.
+type negatedLeaf struct{ inner firesWhenLeaf }
+
+func (l *negatedLeaf) evaluate(resp *cachedHTTPResponse) (bool, error) {
+	fired, err := l.inner.evaluate(resp)
+	if err != nil {
+		return false, err
+	}
+	return !fired, nil
+}

--- a/pkg/scoring/condition_http_test.go
+++ b/pkg/scoring/condition_http_test.go
@@ -181,3 +181,45 @@ func TestHTTPCondition_JSONArrayLengthGte_DoesNotFire(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, fired)
 }
+
+// ----------------------------------------------------------------
+// negatedLeaf — `negative: true` on a fires_when block (LAB-3371)
+// ----------------------------------------------------------------
+
+func TestNegatedLeaf_InvertsFalseToTrue(t *testing.T) {
+	cond, _ := httpConditionFixture(t, 200, `{}`, nil)
+	cond.firesWhen = &negatedLeaf{inner: &statusCodeLeaf{Code: 403}}
+	fired, err := cond.Evaluate(context.Background(), matchWithGroups(nil))
+	require.NoError(t, err)
+	assert.True(t, fired, "inner leaf did not fire, so the negation should")
+}
+
+func TestNegatedLeaf_InvertsTrueToFalse(t *testing.T) {
+	cond, _ := httpConditionFixture(t, 200, `{}`, nil)
+	cond.firesWhen = &negatedLeaf{inner: &statusCodeLeaf{Code: 200}}
+	fired, err := cond.Evaluate(context.Background(), matchWithGroups(nil))
+	require.NoError(t, err)
+	assert.False(t, fired, "inner leaf fired, so the negation should not")
+}
+
+// A negated leaf must NOT turn an inner error into a "fires" result. jsonGet
+// errors on a missing path rather than returning false, so inverting errors
+// would make a negated json_path_* fire on any response lacking the field —
+// including error bodies from a revoked key.
+func TestNegatedLeaf_PropagatesErrorWithoutInverting(t *testing.T) {
+	cond, _ := httpConditionFixture(t, 200, `{}`, nil)
+	cond.firesWhen = &negatedLeaf{inner: &jsonPathEqualsLeaf{Path: ".missing", Value: true}}
+	fired, err := cond.Evaluate(context.Background(), matchWithGroups(nil))
+	require.Error(t, err, "inner error must propagate, not be inverted into a match")
+	assert.False(t, fired)
+}
+
+// negative + json_array_length_gte is the "fewer than N" test the DSL otherwise
+// lacks; it is how a restricted-scope key is detected.
+func TestNegatedLeaf_ArrayLengthGte_GivesLessThan(t *testing.T) {
+	cond, _ := httpConditionFixture(t, 200, `{"scopes":["mail.send","stats.read"]}`, nil)
+	cond.firesWhen = &negatedLeaf{inner: &jsonArrayLengthGteLeaf{Path: ".scopes", Value: 25}}
+	fired, err := cond.Evaluate(context.Background(), matchWithGroups(nil))
+	require.NoError(t, err)
+	assert.True(t, fired, "2 scopes is fewer than 25, so the negated gte should fire")
+}

--- a/pkg/scoring/loader.go
+++ b/pkg/scoring/loader.go
@@ -13,6 +13,9 @@ import (
 // ignoring the negative: flag (applied by buildFiresWhenLeaf).
 // Exactly one field must be set; returns an error if zero or multiple are set.
 func buildFiresWhenLeafInner(fw *yamlFiresWhen) (firesWhenLeaf, error) {
+	if n := countFiresWhenLeaves(fw); n != 1 {
+		return nil, fmt.Errorf("fires_when: exactly one condition leaf required (got %d)", n)
+	}
 	switch {
 	case fw.StatusCode != nil:
 		return &statusCodeLeaf{Code: *fw.StatusCode}, nil
@@ -259,4 +262,24 @@ func buildFiresWhenLeaf(fw *yamlFiresWhen) (firesWhenLeaf, error) {
 		return &negatedLeaf{inner: leaf}, nil
 	}
 	return leaf, nil
+}
+
+// countFiresWhenLeaves counts how many condition leaves a fires_when block
+// declares. negative: is a flag on a leaf, not a leaf, so it is not counted.
+func countFiresWhenLeaves(fw *yamlFiresWhen) int {
+	n := 0
+	for _, set := range []bool{
+		fw.StatusCode != nil,
+		len(fw.StatusCodeIn) > 0,
+		fw.ResponseBodyContains != "",
+		fw.HeaderContains != nil,
+		fw.JSONPathEquals != nil,
+		fw.JSONPathMatches != nil,
+		fw.JSONArrayLengthGte != nil,
+	} {
+		if set {
+			n++
+		}
+	}
+	return n
 }

--- a/pkg/scoring/loader.go
+++ b/pkg/scoring/loader.go
@@ -9,9 +9,10 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// buildFiresWhenLeaf converts a yamlFiresWhen into a firesWhenLeaf implementation.
+// buildFiresWhenLeafInner converts a yamlFiresWhen into the underlying firesWhenLeaf,
+// ignoring the negative: flag (applied by buildFiresWhenLeaf).
 // Exactly one field must be set; returns an error if zero or multiple are set.
-func buildFiresWhenLeaf(fw *yamlFiresWhen) (firesWhenLeaf, error) {
+func buildFiresWhenLeafInner(fw *yamlFiresWhen) (firesWhenLeaf, error) {
 	switch {
 	case fw.StatusCode != nil:
 		return &statusCodeLeaf{Code: *fw.StatusCode}, nil
@@ -244,4 +245,18 @@ func convertYAMLModifier(ym yamlModifier) (Modifier, error) {
 		Value:     value,
 		Condition: cond,
 	}, nil
+}
+
+// buildFiresWhenLeaf builds the fires_when leaf and applies the negative: flag.
+// negative: is a modifier ON a leaf rather than a leaf in its own right, so it is
+// deliberately not part of the "exactly one condition leaf" accounting.
+func buildFiresWhenLeaf(fw *yamlFiresWhen) (firesWhenLeaf, error) {
+	leaf, err := buildFiresWhenLeafInner(fw)
+	if err != nil {
+		return nil, err
+	}
+	if fw.Negative {
+		return &negatedLeaf{inner: leaf}, nil
+	}
+	return leaf, nil
 }

--- a/pkg/scoring/loader_test.go
+++ b/pkg/scoring/loader_test.go
@@ -335,3 +335,67 @@ func TestLoadBuiltinScorers_WithCustomFS(t *testing.T) {
 	require.Len(t, scorers, 1)
 	assert.Equal(t, "test-scorer", scorers[0].Name)
 }
+
+// ----------------------------------------------------------------
+// `negative: true` on fires_when (LAB-3371)
+// ----------------------------------------------------------------
+
+// negative: is a modifier ON a leaf, not a leaf itself — it must not be counted
+// by the "exactly one condition leaf" check, or every negated modifier fails to load.
+func TestLoadScorers_NegativeFiresWhen_Loads(t *testing.T) {
+	yamlBytes := []byte(`scorers:
+  - name: sendgrid-key-scope
+    rule_ids: [np.sendgrid.1]
+    modifiers:
+      - name: narrow-scope-set
+        priority: 40
+        http:
+          method: GET
+          url: https://api.sendgrid.com/v3/scopes
+          auth:
+            type: bearer
+            secret_group: "token"
+        fires_when:
+          negative: true
+          json_array_length_gte:
+            path: ".scopes"
+            value: 25
+        delta: -20
+`)
+	scorers, err := NewLoader().LoadScorers(yamlBytes)
+	require.NoError(t, err)
+	require.Len(t, scorers, 1)
+	require.Len(t, scorers[0].Modifiers, 1)
+
+	m := scorers[0].Modifiers[0]
+	assert.Equal(t, ModifierKindDelta, m.Kind)
+	assert.Equal(t, -20, m.Value)
+	assert.True(t, m.IsDynamic(), "http-backed modifier must still count as dynamic")
+
+	httpCond, ok := m.Condition.(*httpCondition)
+	require.True(t, ok, "expected an httpCondition")
+	_, ok = httpCond.firesWhen.(*negatedLeaf)
+	assert.True(t, ok, "fires_when leaf should be wrapped in negatedLeaf")
+}
+
+// negative: alone is not a condition — it still needs a leaf to negate.
+func TestLoadScorers_NegativeWithoutLeaf_Errors(t *testing.T) {
+	yamlBytes := []byte(`scorers:
+  - name: broken
+    rule_ids: [np.sendgrid.1]
+    modifiers:
+      - name: no-leaf
+        http:
+          method: GET
+          url: https://api.sendgrid.com/v3/scopes
+          auth:
+            type: bearer
+            secret_group: "token"
+        fires_when:
+          negative: true
+        delta: -10
+`)
+	_, err := NewLoader().LoadScorers(yamlBytes)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fires_when")
+}

--- a/pkg/scoring/loader_test.go
+++ b/pkg/scoring/loader_test.go
@@ -399,3 +399,28 @@ func TestLoadScorers_NegativeWithoutLeaf_Errors(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "fires_when")
 }
+
+// The switch in buildFiresWhenLeafInner returns on the first field it finds, so
+// extra leaves were silently discarded -- a scorer could declare two conditions
+// and quietly get only one, with no indication which.
+func TestLoadScorers_MultipleFiresWhenLeaves_Errors(t *testing.T) {
+	yamlBytes := []byte(`scorers:
+  - name: ambiguous
+    rule_ids: [np.sendgrid.1]
+    modifiers:
+      - name: two-leaves
+        http:
+          method: GET
+          url: https://api.sendgrid.com/v3/scopes
+          auth:
+            type: bearer
+            secret_group: "token"
+        fires_when:
+          status_code: 401
+          response_body_contains: '"billing.read"'
+        delta: -10
+`)
+	_, err := NewLoader().LoadScorers(yamlBytes)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exactly one")
+}

--- a/pkg/scoring/scorers/sendgrid.yaml
+++ b/pkg/scoring/scorers/sendgrid.yaml
@@ -1,0 +1,112 @@
+# SendGrid API key scorer — permission scope enumeration (LAB-3371).
+#
+# Rule ID covered:
+#   np.sendgrid.1 — SendGrid API key (SG.<id>.<secret>): base_score 65
+#
+# GET /v3/scopes returns the calling key's own permission list and has no side
+# effects, so it is safe to call against a found credential:
+#   {"scopes": ["mail.send", "alerts.create", ...]}
+#
+# All modifiers issue the SAME request. The engine caches HTTP responses on
+# (method, url, secret), so a finding costs one network call, not seven. The
+# YAML anchor below keeps the URL and auth identical by construction — a typo in
+# one copy would silently split the cache and issue duplicate calls.
+#
+# Scope naming, verified against the SendGrid docs (these are easy to get wrong):
+#   - the send scope is `mail.send`, NOT `mail_send`
+#   - domain authentication scopes are `whitelabel.*` (formerly Whitelabel),
+#     NOT `domain_auth.*`
+#
+# A key carries EITHER billing permissions or any other set of permissions, never
+# both, and Full Access covers every endpoint except billing. Billing keys are
+# therefore a narrow-but-valuable class rather than an escalation on top of Full
+# Access, which is why billing-access sets a score instead of adding a delta.
+#
+# PRIORITY IS LOAD-BEARING. Higher priority is evaluated FIRST, and a later
+# set_score replaces the running score:
+#   - billing-access (30) lands after narrow-scope-set (40) so it overrides that
+#     downgrade for a small-but-dangerous billing key.
+#   - revoked-key (10) lands last so a dead key scores 5 regardless of what
+#     scopes it once held.
+#
+# The 100 / 25 thresholds are breadth heuristics and are the intended tuning
+# knobs; they should be calibrated against a real Full Access key's scope count.
+#
+# API documentation:
+#   https://www.twilio.com/docs/sendgrid/api-reference/api-key-permissions
+scorers:
+  - name: sendgrid-key-scope
+    rule_ids:
+      - np.sendgrid.1
+    modifiers:
+      # --- Breadth: a Full Access key returns the whole scope catalogue ---
+      - name: full-access-key
+        priority: 90
+        http: &sendgrid_scopes
+          method: GET
+          url: https://api.sendgrid.com/v3/scopes
+          auth:
+            type: bearer
+            secret_group: "token"
+        fires_when:
+          json_array_length_gte:
+            path: ".scopes"
+            value: 100
+        set_score: 85
+
+      # --- Individually dangerous scope families ---
+
+      # Can modify SPF/DKIM/DMARC and break domain authentication.
+      - name: domain-auth-access
+        priority: 70
+        http: *sendgrid_scopes
+        fires_when:
+          response_body_contains: '"whitelabel.read"'
+        delta: 20
+
+      # Can create subusers, and therefore mint further API keys.
+      - name: subuser-management
+        priority: 60
+        http: *sendgrid_scopes
+        fires_when:
+          response_body_contains: '"subusers.create"'
+        delta: 15
+
+      # Marketing contact lists are PII.
+      - name: contact-pii-access
+        priority: 50
+        http: *sendgrid_scopes
+        fires_when:
+          response_body_contains: '"marketing.contacts.read"'
+        delta: 15
+
+      # --- Restricted key: fewer than 25 scopes ---
+      # negative: + json_array_length_gte is the "fewer than N" test; the DSL has
+      # no lte. json_path errors are not inverted, so this correctly does NOT
+      # fire on an error body that has no .scopes field at all.
+      - name: narrow-scope-set
+        priority: 40
+        http: *sendgrid_scopes
+        fires_when:
+          negative: true
+          json_array_length_gte:
+            path: ".scopes"
+            value: 25
+        delta: -20
+
+      # --- Billing keys: narrow, but financial ---
+      # Deliberately after narrow-scope-set so this overrides that downgrade.
+      - name: billing-access
+        priority: 30
+        http: *sendgrid_scopes
+        fires_when:
+          response_body_contains: '"billing.read"'
+        set_score: 85
+
+      # --- Dead key: evaluated last, wins outright ---
+      - name: revoked-key
+        priority: 10
+        http: *sendgrid_scopes
+        fires_when:
+          status_code: 401
+        set_score: 5

--- a/pkg/scoring/scorers/sendgrid.yaml
+++ b/pkg/scoring/scorers/sendgrid.yaml
@@ -32,8 +32,24 @@
 # The 100 / 25 thresholds are breadth heuristics and are the intended tuning
 # knobs; they should be calibrated against a real Full Access key's scope count.
 #
+# KNOWN LIMITATION -- EU data residency:
+# This scorer probes only the global host. SendGrid EU regional subusers have
+# their own API keys served from https://api.eu.sendgrid.com, so an EU key is
+# expected to fail against the global host and would then be scored 5 by
+# revoked-key -- a live credential reported as dead.
+#
+# This is not fixable in the current DSL. Distinguishing "revoked" from "wrong
+# region" means firing revoked-key only when BOTH hosts reject the key, and
+# fires_when has no conjunction: each modifier carries exactly one leaf. Adding
+# EU modifiers alongside the global ones does not help, because revoked-key
+# evaluates last and its set_score would still overwrite them.
+#
+# The same gap already exists in pkg/validator/validators/sendgrid.yaml, which
+# also checks only the global host. Tracked separately; see LAB-3371 follow-up.
+#
 # API documentation:
 #   https://www.twilio.com/docs/sendgrid/api-reference/api-key-permissions
+#   https://www.twilio.com/docs/sendgrid/data-residency/faq
 scorers:
   - name: sendgrid-key-scope
     rule_ids:
@@ -72,12 +88,14 @@ scorers:
           response_body_contains: '"subusers.create"'
         delta: 15
 
-      # Marketing contact lists are PII.
+      # Email Marketing access covers contacts, lists and segments -- PII.
+      # The documented scope is `marketing.read`; `marketing.contacts.read`
+      # does not exist, and `marketing_campaigns.read` is the legacy scope.
       - name: contact-pii-access
         priority: 50
         http: *sendgrid_scopes
         fires_when:
-          response_body_contains: '"marketing.contacts.read"'
+          response_body_contains: '"marketing.read"'
         delta: 15
 
       # --- Restricted key: fewer than 25 scopes ---

--- a/pkg/scoring/scorers/sendgrid.yaml
+++ b/pkg/scoring/scorers/sendgrid.yaml
@@ -56,6 +56,10 @@ scorers:
       - np.sendgrid.1
     modifiers:
       # --- Breadth: a Full Access key returns the whole scope catalogue ---
+      # A DELTA, not a set_score. set_score is a verdict that overwrites the
+      # running score, so using it here made the result depend on evaluation
+      # order: a Full Access key could score BELOW a key holding a subset of its
+      # scopes. Breadth contributes to the score; it does not decide it.
       - name: full-access-key
         priority: 90
         http: &sendgrid_scopes
@@ -68,7 +72,7 @@ scorers:
           json_array_length_gte:
             path: ".scopes"
             value: 100
-        set_score: 85
+        delta: 30
 
       # --- Individually dangerous scope families ---
 
@@ -122,6 +126,12 @@ scorers:
         set_score: 85
 
       # --- Dead key: evaluated last, wins outright ---
+      # Side effect: on a 401 the two json_array_length_gte modifiers above cannot
+      # find .scopes and return an error, so the engine logs 2 "[warn] ...
+      # (skipping)" lines per revoked finding. Stats counters are NOT affected --
+      # trackError only counts sentinel timeout/rate-limit/server/network errors.
+      # Reducing the noise needs an engine change (skip remaining modifiers after
+      # a terminal set_score, or log evaluation errors below warn level).
       - name: revoked-key
         priority: 10
         http: *sendgrid_scopes

--- a/pkg/scoring/sendgrid_test.go
+++ b/pkg/scoring/sendgrid_test.go
@@ -1,0 +1,79 @@
+package scoring
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// builtinScorerFor returns the built-in scorer covering ruleID.
+func builtinScorerFor(t *testing.T, ruleID string) *Scorer {
+	t.Helper()
+	scorers, err := NewLoader().LoadBuiltinScorers()
+	require.NoError(t, err)
+	for _, s := range scorers {
+		if s.canScore(ruleID) {
+			return s
+		}
+	}
+	t.Fatalf("no built-in scorer covers rule %q", ruleID)
+	return nil
+}
+
+// The shipped scorer must exist and be registered for the SendGrid rule. The
+// cmd/titus scope tests build their own YAML, so without this the production
+// file could be missing entirely and those tests would still pass.
+func TestBuiltinSendGridScorer_IsRegisteredForRule(t *testing.T) {
+	s := builtinScorerFor(t, "np.sendgrid.1")
+	assert.Equal(t, "sendgrid-key-scope", s.Name)
+
+	got := make(map[string]Modifier, len(s.Modifiers))
+	for _, m := range s.Modifiers {
+		got[m.Name] = m
+	}
+	for _, name := range []string{
+		"full-access-key", "domain-auth-access", "subuser-management",
+		"contact-pii-access", "narrow-scope-set", "billing-access", "revoked-key",
+	} {
+		assert.Contains(t, got, name)
+	}
+}
+
+// Every modifier must hit the real scopes endpoint with the rule's token group.
+// The engine caches on (method, url, secret), so identical URLs also mean one
+// network call per finding rather than seven.
+func TestBuiltinSendGridScorer_AllModifiersShareOneAuthedRequest(t *testing.T) {
+	s := builtinScorerFor(t, "np.sendgrid.1")
+	for _, m := range s.Modifiers {
+		cond, ok := m.Condition.(*httpCondition)
+		require.Truef(t, ok, "modifier %q should be http-backed", m.Name)
+		assert.Equal(t, "https://api.sendgrid.com/v3/scopes", cond.url, "modifier %q", m.Name)
+		assert.Equal(t, "GET", cond.method, "modifier %q", m.Name)
+		assert.Equal(t, "bearer", cond.auth.Type, "modifier %q", m.Name)
+		assert.Equal(t, "token", cond.auth.SecretGroup, "modifier %q", m.Name)
+	}
+}
+
+// Ordering is load-bearing, not cosmetic. Higher priority is evaluated first and
+// a later set_score replaces the running score, so billing-access must come
+// AFTER narrow-scope-set to override its downgrade, and revoked-key must be last
+// of all so a dead key scores 5 no matter what scopes it once held.
+func TestBuiltinSendGridScorer_SetScoreOrderingInvariants(t *testing.T) {
+	s := builtinScorerFor(t, "np.sendgrid.1")
+	prio := make(map[string]int, len(s.Modifiers))
+	for _, m := range s.Modifiers {
+		prio[m.Name] = m.Priority
+	}
+
+	assert.Less(t, prio["billing-access"], prio["narrow-scope-set"],
+		"billing-access must evaluate after narrow-scope-set to override its delta")
+
+	for name, p := range prio {
+		if name == "revoked-key" {
+			continue
+		}
+		assert.Less(t, prio["revoked-key"], p,
+			"revoked-key must evaluate last; %q has lower or equal priority", name)
+	}
+}

--- a/pkg/scoring/sendgrid_test.go
+++ b/pkg/scoring/sendgrid_test.go
@@ -77,3 +77,36 @@ func TestBuiltinSendGridScorer_SetScoreOrderingInvariants(t *testing.T) {
 			"revoked-key must evaluate last; %q has lower or equal priority", name)
 	}
 }
+
+// Scope strings are the highest-risk part of this scorer: a modifier keyed on a
+// string SendGrid never emits simply never fires, and nothing else in the test
+// suite would notice. These are the names documented under
+// https://www.twilio.com/docs/sendgrid/api-reference/api-key-permissions
+// -- note marketing.read, NOT marketing.contacts.read, and whitelabel.*, NOT
+// domain_auth.*.
+func TestBuiltinSendGridScorer_UsesDocumentedScopeStrings(t *testing.T) {
+	want := map[string]string{
+		"domain-auth-access": `"whitelabel.read"`,
+		"subuser-management": `"subusers.create"`,
+		"contact-pii-access": `"marketing.read"`,
+		"billing-access":     `"billing.read"`,
+	}
+
+	s := builtinScorerFor(t, "np.sendgrid.1")
+	seen := map[string]bool{}
+	for _, m := range s.Modifiers {
+		expected, ok := want[m.Name]
+		if !ok {
+			continue
+		}
+		cond, ok := m.Condition.(*httpCondition)
+		require.Truef(t, ok, "modifier %q should be http-backed", m.Name)
+		leaf, ok := cond.firesWhen.(*responseBodyContainsLeaf)
+		require.Truef(t, ok, "modifier %q should match on response body", m.Name)
+		assert.Equal(t, expected, leaf.Value, "modifier %q scope string", m.Name)
+		seen[m.Name] = true
+	}
+	for name := range want {
+		assert.Truef(t, seen[name], "modifier %q not found in the shipped scorer", name)
+	}
+}

--- a/pkg/scoring/sendgrid_test.go
+++ b/pkg/scoring/sendgrid_test.go
@@ -110,3 +110,20 @@ func TestBuiltinSendGridScorer_UsesDocumentedScopeStrings(t *testing.T) {
 		assert.Truef(t, seen[name], "modifier %q not found in the shipped scorer", name)
 	}
 }
+
+// set_score is a verdict, not a contribution: it overwrites the running score,
+// so using it for a non-terminal signal makes the final value depend on
+// evaluation order rather than on capability. Only genuinely terminal states --
+// a billing-only key and a dead key -- may use it. Breadth is a contributing
+// factor and must be a delta, or a Full Access key can score BELOW a key
+// holding a subset of its scopes.
+func TestBuiltinSendGridScorer_OnlyTerminalStatesUseSetScore(t *testing.T) {
+	s := builtinScorerFor(t, "np.sendgrid.1")
+	terminal := map[string]bool{"billing-access": true, "revoked-key": true}
+	for _, m := range s.Modifiers {
+		if m.Kind == ModifierKindSetScore {
+			assert.Truef(t, terminal[m.Name],
+				"modifier %q uses set_score but is not a terminal state", m.Name)
+		}
+	}
+}

--- a/pkg/scoring/yaml.go
+++ b/pkg/scoring/yaml.go
@@ -67,6 +67,9 @@ type yamlHeader struct {
 
 // yamlFiresWhen holds exactly one fires_when leaf (validated at load time).
 type yamlFiresWhen struct {
+	// Negative inverts the leaf below it. It is not itself a leaf.
+	Negative bool `yaml:"negative,omitempty"`
+
 	StatusCode           *int                    `yaml:"status_code,omitempty"`
 	StatusCodeIn         []int                   `yaml:"status_code_in,omitempty"`
 	ResponseBodyContains string                  `yaml:"response_body_contains,omitempty"`


### PR DESCRIPTION
Closes LAB-3371.

SendGrid keys (`np.sendgrid.1`, base_score 65) range from Full Access — which can send mail, manage domain authentication, create subusers and read contact lists — down to a restricted key that can only send. `GET /v3/scopes` returns the calling key's own permission list with no side effects, so the real blast radius is measurable from the credential alone.

Four commits, deliberately separable: if the DSL primitive is contentious, the scorer rebases onto whatever replaces it.

## Reviewers: two things need a human decision

**1. This deviates from the ticket's scoring model.** The ticket specified Full Access → `set_score 85`. That turned out to be unworkable: `set_score` overwrites the running score, so with three sensitive-scope deltas stacking on top, a real Full Access key scored 100 anyway — and worse, a Full Access key could score *below* a key holding a subset of its scopes. Breadth is now `delta +30` and `set_score` is reserved for terminal states. A realistic Full Access key scores **100**, not 85. Prioritising accuracy over the ticket's number was a deliberate call and is open to challenge.

**2. `negative:` is a new public YAML surface.** It's documented in `docs/scoring.md`, so whoever owns the scoring DSL should say yes to it deliberately. It's isolated in commit 1 precisely so it can be rejected without dragging the scorer down.

## 1. `negative:` on `fires_when`

The DSL was positive-only, so scorers had no way to express the "Score DOWN" half of their tickets. `negative: true` wraps a leaf and inverts it; with `json_array_length_gte` it supplies the "fewer than N" test the condition list lacks. The name matches the `negative:` flag the rule-validation DSL already uses for `WordMatch`.

**Errors propagate rather than invert.** `jsonGet` errors on a missing path instead of returning false, so inverting errors would make a negated `json_path_*` fire on any response lacking the field — including a revoked key's error body. `TestSendGridScorer_RevokedKey_SetScore5` exercises this.

Nearly every remaining `feat(scoring)` ticket under LAB-3356 has "Score DOWN" clauses, so this unblocks more than SendGrid.

## 2. SendGrid scorer

Seven modifiers, one cached GET. The engine caches on `(method, url, sha256(secret))`, so a finding costs one network call rather than seven; a YAML anchor keeps URL and auth identical by construction.

| Case | Score |
| -- | -- |
| Realistic Full Access | 100 |
| Breadth only | 95 |
| Billing key | 85 |
| Narrow + `whitelabel.read` | 65 |
| Narrow + `marketing.read` | 60 |
| `mail.send` only | 45 |
| Revoked (401) | 5 |

Scoring is monotonic: a Full Access key can never score below a key holding a subset of its scopes.

## 3–4. Review fixes

- `contact-pii-access` was keyed on `marketing.contacts.read`, which is not a SendGrid scope (it's `marketing.read`). The modifier could never fire.
- `full-access-key` used `set_score`, producing the ordering bug above.
- `buildFiresWhenLeafInner` returned on the first matching leaf, silently discarding extras. The doc comment claimed this was already rejected. It now is.

## Corrections to the ticket

The ticket's scope strings were wrong, and this class of error fails silently — a scorer keyed on a string SendGrid never emits simply never fires:

- `mail.send`, not `mail_send`
- `whitelabel.*`, not `domain_auth.*`
- `marketing.read`, not `marketing.contacts.*`

A key also carries **either** billing permissions **or** any other set, never both, and Full Access excludes billing — so billing keys are a narrow-but-valuable class, not an escalation on top of Full Access.

## Documentation

`docs/scoring.md` documented a scorer API that does not exist; the worked example **would not load**. Corrected and verified against the real loader: `auth.bearer` → `auth.type`/`auth.secret_group`, `status_code_is` → `status_code`, `match_length.min` → `op`/`value`, `surrounding_context_contains.pattern` → `value`/`within`, plus the template syntax (`{{ .Groups.name }}` was sent literally) and the caching note.

## Known issues, tracked not fixed

| Issue | Ticket |
| -- | -- |
| EU regional keys scored as revoked (needs DSL conjunction; validator has the same gap) | LAB-6047 |
| 2 `[warn]` lines per revoked finding (log noise only — stats counters verified unaffected) | LAB-6050 |
| Cache key ignores template substitution (latent; no scorer triggers it today) | LAB-6051 |

## Testing

`go build ./...`, `go test ./...`, `go vet ./...`, `make score-lint`, **`make test-race` (full suite, CGO)**, `make test-validators`, `make scan-fixtures` — all green.

Not run locally: the `-tags vectorscan` build (needs `libvectorscan`). That tag only gates `pkg/matcher/*`, and no package in this diff contains a build tag.

## A caveat worth reading

Three of the defects found in review were **test fixtures that made broken behaviour look correct** — most notably a "Full Access" fixture holding none of the scopes Full Access implies. That was a pattern in how these tests were written, not three coincidences. The remaining fixtures deserve a sceptical look.

---

*Review threads have been replied to and resolved. The three deferred items (LAB-6047, LAB-6050, LAB-6051) each carry a reply explaining why they were not fixed here — they are deferred on the record, not hidden. Two GitHub Advanced Security alerts (1316, 1317) are false positives on a rule example and a docs table respectively; both still need dismissing in the Security tab, which needs `security_events` scope.*
