### PR TITLE
fix(scoring): support auth type "none" and reject unknown types at load (LAB-6049)

### DIFF
--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -235,6 +235,11 @@ group holding the secret:
 | `header` | Sends the secret in `header_name` |
 | `query` | Sends the secret in the `query_param` query parameter |
 | `api_key` | `Authorization: <key_prefix><secret>` (`key_prefix` defaults to `key=`) |
+| `none` | No auth header — for APIs that take the credential in the URL or body via a `{{template}}` variable |
+
+An unsupported `auth.type` is rejected at load time rather than failing per-request.
+Keep `secret_group` set even with `none`: the response cache keys on it, so omitting
+it makes every finding sharing a URL template collide on one cache entry.
 
 **Firing conditions (`fires_when`):**
 

--- a/pkg/scoring/google_test.go
+++ b/pkg/scoring/google_test.go
@@ -1,0 +1,67 @@
+package scoring
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The shipped Google scorer's dynamic modifiers must actually be able to issue
+// their request. They could not: auth.type "none" was unsupported, so both
+// modifiers errored before sending anything and the scorer silently did nothing
+// from the day it shipped. Nothing caught it because the dynamic path was never
+// exercised against the built-in file.
+func TestBuiltinGoogleScorer_DynamicModifiersCanIssueTheirRequest(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"models":[{"name":"models/gemini-1.5-pro"}]}`))
+	}))
+	defer srv.Close()
+
+	s := builtinScorerFor(t, "np.google.5")
+
+	var dynamic int
+	for _, m := range s.Modifiers {
+		cond, ok := m.Condition.(*httpCondition)
+		if !ok {
+			continue
+		}
+		dynamic++
+		// Point the real modifier at the stub, leaving auth untouched.
+		probe := &httpCondition{
+			method:    cond.method,
+			url:       srv.URL + "/v1/models?key={{key}}",
+			headers:   cond.headers,
+			body:      cond.body,
+			auth:      cond.auth,
+			firesWhen: cond.firesWhen,
+		}
+		m := &types.Match{NamedGroups: map[string][]byte{"key": []byte("AIzaSyEXAMPLE")}}
+		_, err := probe.Evaluate(context.Background(), m)
+		require.NoErrorf(t, err, "modifier %q could not issue its request", s.Modifiers[dynamic-1].Name)
+	}
+	require.Positive(t, dynamic, "expected the Google scorer to have dynamic modifiers")
+}
+
+// type: none still needs secret_group. evaluateWithCache builds the cache key
+// from NamedGroups[auth.SecretGroup]; without it secretBytes is nil and every
+// finding sharing this URL template collides on one cache entry, so the second
+// key silently receives the first key's response. It looks redundant next to
+// type: none -- it is not.
+func TestBuiltinGoogleScorer_KeepsSecretGroupForCacheKeying(t *testing.T) {
+	s := builtinScorerFor(t, "np.google.5")
+	for _, m := range s.Modifiers {
+		cond, ok := m.Condition.(*httpCondition)
+		if !ok {
+			continue
+		}
+		assert.NotEmptyf(t, cond.auth.SecretGroup,
+			"modifier %q must keep secret_group so cache keys stay per-secret", m.Name)
+	}
+}

--- a/pkg/scoring/google_test.go
+++ b/pkg/scoring/google_test.go
@@ -45,9 +45,12 @@ func TestBuiltinGoogleScorer_DynamicModifiersCanIssueTheirRequest(t *testing.T) 
 			auth:      cond.auth,
 			firesWhen: cond.firesWhen,
 		}
-		m := &types.Match{NamedGroups: map[string][]byte{"key": []byte("AIzaSyEXAMPLE")}}
-		name := s.Modifiers[dynamic-1].Name
-		_, err := probe.Evaluate(context.Background(), m)
+		// Named `match` rather than `m` so the modifier stays in scope: taking the
+		// name from s.Modifiers[dynamic-1] would misattribute failures, since
+		// dynamic counts only HTTP modifiers while the slice holds all of them.
+		match := &types.Match{NamedGroups: map[string][]byte{"key": []byte("AIzaSyEXAMPLE")}}
+		name := m.Name
+		_, err := probe.Evaluate(context.Background(), match)
 		require.NoErrorf(t, err, "modifier %q could not issue its request", name)
 
 		// The full auth contract for type: none -- the secret must reach the API

--- a/pkg/scoring/google_test.go
+++ b/pkg/scoring/google_test.go
@@ -17,7 +17,10 @@ import (
 // from the day it shipped. Nothing caught it because the dynamic path was never
 // exercised against the built-in file.
 func TestBuiltinGoogleScorer_DynamicModifiersCanIssueTheirRequest(t *testing.T) {
+	var gotAuthHeader, gotQuery string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuthHeader = r.Header.Get("Authorization")
+		gotQuery = r.URL.RawQuery
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
 		_, _ = w.Write([]byte(`{"models":[{"name":"models/gemini-1.5-pro"}]}`))
@@ -43,8 +46,16 @@ func TestBuiltinGoogleScorer_DynamicModifiersCanIssueTheirRequest(t *testing.T) 
 			firesWhen: cond.firesWhen,
 		}
 		m := &types.Match{NamedGroups: map[string][]byte{"key": []byte("AIzaSyEXAMPLE")}}
+		name := s.Modifiers[dynamic-1].Name
 		_, err := probe.Evaluate(context.Background(), m)
-		require.NoErrorf(t, err, "modifier %q could not issue its request", s.Modifiers[dynamic-1].Name)
+		require.NoErrorf(t, err, "modifier %q could not issue its request", name)
+
+		// The full auth contract for type: none -- the secret must reach the API
+		// through the URL template, and no Authorization header may be set.
+		assert.Containsf(t, gotQuery, "key=AIzaSyEXAMPLE",
+			"modifier %q must pass the secret as a query parameter", name)
+		assert.Emptyf(t, gotAuthHeader,
+			"modifier %q uses auth.type none and must not set an Authorization header", name)
 	}
 	require.Positive(t, dynamic, "expected the Google scorer to have dynamic modifiers")
 }

--- a/pkg/scoring/http_client.go
+++ b/pkg/scoring/http_client.go
@@ -111,6 +111,11 @@ func applyScorerAuth(req *http.Request, auth scorerAuth, secret string) error {
 		q := req.URL.Query()
 		q.Set(auth.QueryParam, secret)
 		req.URL.RawQuery = q.Encode()
+	case "none":
+		// The credential travels in the URL or body via a {{template}} variable
+		// rather than a header. secret_group must still be set: the response cache
+		// keys on it, and without it every finding sharing a URL template collides.
+		return nil
 	case "api_key":
 		prefix := auth.KeyPrefix
 		if prefix == "" {
@@ -131,4 +136,18 @@ func substituteVarsInURL(s string, groups map[string][]byte) string {
 		s = strings.ReplaceAll(s, "{{ "+k+" }}", string(v))
 	}
 	return s
+}
+
+// supportedAuthTypes is the set applyScorerAuth accepts, kept next to that
+// switch so the loader's validation cannot drift from what the request layer
+// actually handles. An unsupported type used to load fine and fail at request
+// time, where the engine logged it and skipped the modifier -- the scorer ran
+// and silently did nothing (LAB-6049).
+var supportedAuthTypes = map[string]bool{
+	"bearer":  true,
+	"basic":   true,
+	"header":  true,
+	"query":   true,
+	"api_key": true,
+	"none":    true,
 }

--- a/pkg/scoring/http_client_test.go
+++ b/pkg/scoring/http_client_test.go
@@ -46,3 +46,50 @@ func TestMakeHTTPRequest_CancelsOnContextDone(t *testing.T) {
 	_, err := makeHTTPRequest(ctx, "GET", srv.URL, nil, "", scorerAuth{}, nil)
 	assert.Error(t, err, "expected error from cancelled context")
 }
+
+// ----------------------------------------------------------------
+// auth type "none" (LAB-6049)
+// ----------------------------------------------------------------
+
+// Some APIs take the credential in the URL rather than a header -- Google's
+// Generative Language API uses ?key=<secret>. Those scorers declare
+// auth.type: none, which was not a supported case: the guard in
+// makeHTTPRequest only skips auth when the type is EMPTY, so "none" fell
+// through to applyScorerAuth's default branch and failed the whole request.
+func TestMakeHTTPRequest_AuthTypeNone_SendsRequest(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"models":[{"name":"gemini-1.5-pro"}]}`))
+	}))
+	defer srv.Close()
+
+	auth := scorerAuth{Type: "none", SecretGroup: "key"}
+	groups := map[string][]byte{"key": []byte("AIzaSyEXAMPLE")}
+
+	resp, err := makeHTTPRequest(context.Background(), "GET", srv.URL+"/v1/models?key={{key}}", nil, "", auth, groups)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+	assert.Contains(t, string(resp.Body), "gemini-1.5-pro")
+}
+
+// The whole point of type: none is that no Authorization header is set.
+func TestMakeHTTPRequest_AuthTypeNone_SetsNoAuthorizationHeader(t *testing.T) {
+	var gotAuth string
+	var gotURL string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotURL = r.URL.String()
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	auth := scorerAuth{Type: "none", SecretGroup: "key"}
+	groups := map[string][]byte{"key": []byte("AIzaSyEXAMPLE")}
+
+	_, err := makeHTTPRequest(context.Background(), "GET", srv.URL+"/v1/models?key={{key}}", nil, "", auth, groups)
+	require.NoError(t, err)
+	assert.Empty(t, gotAuth, "type: none must not set an Authorization header")
+	assert.Contains(t, gotURL, "key=AIzaSyEXAMPLE", "the secret still reaches the API via the URL template")
+}

--- a/pkg/scoring/loader.go
+++ b/pkg/scoring/loader.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -203,6 +204,9 @@ func convertYAMLModifier(ym yamlModifier) (Modifier, error) {
 	}
 	if ym.HTTP != nil && ym.FiresWhen != nil {
 		condCount++
+		if t := strings.ToLower(ym.HTTP.Auth.Type); t != "" && !supportedAuthTypes[t] {
+			return Modifier{}, fmt.Errorf("http.auth.type %q is not supported (want one of: api_key, basic, bearer, header, none, query)", ym.HTTP.Auth.Type)
+		}
 		leaf, err := buildFiresWhenLeaf(ym.FiresWhen)
 		if err != nil {
 			return Modifier{}, fmt.Errorf("modifier %q fires_when: %w", ym.Name, err)

--- a/pkg/scoring/loader_test.go
+++ b/pkg/scoring/loader_test.go
@@ -424,3 +424,52 @@ func TestLoadScorers_MultipleFiresWhenLeaves_Errors(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "exactly one")
 }
+
+// An unsupported auth type used to load fine and fail at request time, where
+// the engine logged it and skipped the modifier -- the scorer ran and silently
+// did nothing (LAB-6049). Reject it at load instead.
+func TestLoadScorers_UnknownAuthType_Errors(t *testing.T) {
+	yamlBytes := []byte(`scorers:
+  - name: bad-auth
+    rule_ids: [np.google.1]
+    modifiers:
+      - name: m
+        http:
+          method: GET
+          url: https://example.com/v1/models
+          auth:
+            type: oauth2
+            secret_group: "key"
+        fires_when:
+          status_code: 200
+        delta: 5
+`)
+	_, err := NewLoader().LoadScorers(yamlBytes)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "oauth2")
+}
+
+// Every auth type the request layer supports must load.
+func TestLoadScorers_SupportedAuthTypes_Load(t *testing.T) {
+	for _, at := range []string{"bearer", "basic", "header", "query", "api_key", "none"} {
+		yamlBytes := []byte(`scorers:
+  - name: ok-auth
+    rule_ids: [np.google.1]
+    modifiers:
+      - name: m
+        http:
+          method: GET
+          url: https://example.com/v1/models
+          auth:
+            type: ` + at + `
+            secret_group: "key"
+            header_name: "X-Key"
+            query_param: "key"
+        fires_when:
+          status_code: 200
+        delta: 5
+`)
+		_, err := NewLoader().LoadScorers(yamlBytes)
+		require.NoErrorf(t, err, "auth type %q should load", at)
+	}
+}

--- a/pkg/scoring/scorers/google.yaml
+++ b/pkg/scoring/scorers/google.yaml
@@ -29,6 +29,8 @@ scorers:
           url: "https://generativelanguage.googleapis.com/v1/models?key={{key}}"
           auth:
             type: none
+            # Required even with type: none -- the response cache keys on this
+            # group, so dropping it makes every Google finding collide.
             secret_group: key
         fires_when:
           status_code: 200
@@ -44,6 +46,8 @@ scorers:
           url: "https://generativelanguage.googleapis.com/v1/models?key={{key}}"
           auth:
             type: none
+            # Required even with type: none -- the response cache keys on this
+            # group, so dropping it makes every Google finding collide.
             secret_group: key
         fires_when:
           response_body_contains: "gemini-1.5-pro"


### PR DESCRIPTION
Closes LAB-6049. Found while reviewing #324.

## The bug

The Google scorer's two dynamic modifiers — `gemini-api-access` (+15) and `gemini-advanced-models` (+10) — **have never fired**.

`google.yaml` declares `auth.type: none` because the key travels in the URL as `?key={{key}}`. But `none` was not a case in `applyScorerAuth`, and the guard in `makeHTTPRequest` only skips auth when the type is **empty**:

```go
if auth.Type != "" && auth.SecretGroup != "" {
```

`"none"` is not empty, so it reached the switch's `default:` branch and failed the request before it was sent.

The engine logs a modifier error and skips the modifier, so this failed silently — the scorer loads, runs, and does nothing. Google API keys have been scored on static signals alone since LAB-4000 (#247).

Reproduced against the real `google.yaml` shape:

```
fired=false err=http condition request: applying auth: unknown auth type "none"
```

## The fix

Adds `case "none"`, and **rejects unsupported auth types at load time** rather than per-request. The supported set lives beside `applyScorerAuth`'s switch so the loader's validation cannot drift from what the request layer actually handles.

An audit of every YAML scorer found `google.yaml` was the only offender — the other four all use `bearer`.

## One thing deliberately left alone

`google.yaml` keeps `secret_group: key` even with `type: none`. It reads as redundant; it is not. `evaluateWithCache` builds the cache key from `NamedGroups[auth.SecretGroup]`, so dropping it leaves `secretBytes` nil and collides **every** Google finding onto one cache entry — serving the first key's response to all the rest. Now pinned by a comment and a test, because it is an inviting cleanup.

## Why it survived

The `cmd/titus` scope tests build their own YAML against a mock server, so nothing ever exercised the **shipped** file's dynamic path. `pkg/scoring/google_test.go` now does, mirroring the guard added for SendGrid in #324. This is the third instance of the same pattern (see also `depends_on_rule`/`PUBKEY` in `mongodb_atlas.go`, still unfixed).

## Testing

6 new tests. `go build ./...`, `go test ./...`, `go vet ./...`, `make test-race` (full suite, CGO), `make score-lint` — all green.

Note `security / Gosec` and `security / Govulncheck` fail on every branch right now (gosec crashes on Go 1.25.8 with `internal error: package "fmt" without types`); #322 fixes that.