### PR TITLE
fix(scoring): stop warning when a condition cannot apply to an error response (LAB-6050)

### DIFF
--- a/pkg/scoring/condition_http.go
+++ b/pkg/scoring/condition_http.go
@@ -79,7 +79,13 @@ func (c *httpCondition) evaluateWithCache(ctx context.Context, m *types.Match, c
 		}
 	}
 
-	return c.firesWhen.evaluate(resp)
+	fired, err := c.firesWhen.evaluate(resp)
+	if err != nil && resp.StatusCode >= 400 {
+		// The condition was written for a successful response; an error body
+		// simply does not carry the field. Expected, not a misconfiguration.
+		return false, fmt.Errorf("%w (HTTP %d): %v", ErrConditionNotApplicable, resp.StatusCode, err)
+	}
+	return fired, err
 }
 
 // ----------------------------------------------------------------

--- a/pkg/scoring/condition_http.go
+++ b/pkg/scoring/condition_http.go
@@ -71,12 +71,19 @@ func (c *httpCondition) evaluateWithCache(ctx context.Context, m *types.Match, c
 		}
 		// Always cache the response — including 429/5xx — so that subsequent
 		// calls for the same secret/URL fast-fail without hitting the network
-		// again.  Classify persistent 429/5xx as sentinel errors so trackError
-		// can increment the correct stats counter.
+		// again.
 		cache.put(key, resp)
-		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500 {
-			return false, classifyHTTPError(resp.StatusCode, nil)
-		}
+	}
+
+	// Classify persistent 429/5xx as sentinel errors so trackError increments the
+	// correct stats counter. This runs for cached responses too, not just fresh
+	// ones: a later modifier sharing the URL and secret must see the same
+	// rate-limit/server error. Otherwise it falls through to its leaf, whose
+	// failure is then reported as ErrConditionNotApplicable — which the engine
+	// deliberately does not warn about — turning a throttled or broken API into
+	// silence for every modifier after the first.
+	if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500 {
+		return false, classifyHTTPError(resp.StatusCode, nil)
 	}
 
 	fired, err := c.firesWhen.evaluate(resp)

--- a/pkg/scoring/condition_http_test.go
+++ b/pkg/scoring/condition_http_test.go
@@ -223,3 +223,43 @@ func TestNegatedLeaf_ArrayLengthGte_GivesLessThan(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, fired, "2 scopes is fewer than 25, so the negated gte should fire")
 }
+
+// A 429/5xx must stay classified as a rate-limit/server error even when the
+// response comes from the cache. The classification lived inside the cache-miss
+// branch, so a second modifier sharing the URL and secret skipped it, and its
+// leaf error was then reported as ErrConditionNotApplicable -- which the engine
+// deliberately does not warn about. That turned a throttled or broken API into
+// silence for every modifier after the first (LAB-6050 review).
+func TestHTTPCondition_CachedRateLimit_StaysClassified(t *testing.T) {
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"message":"slow down"}`))
+	}))
+	defer srv.Close()
+
+	cache := newHTTPResponseCache()
+	newCond := func() *httpCondition {
+		return &httpCondition{
+			method:    "GET",
+			url:       srv.URL + "/v3/scopes",
+			auth:      scorerAuth{Type: "bearer", SecretGroup: "token"},
+			firesWhen: &jsonArrayLengthGteLeaf{Path: ".scopes", Value: 25},
+		}
+	}
+	match := matchWithGroups(map[string][]byte{"token": []byte("secret")})
+
+	_, err1 := newCond().evaluateWithCache(context.Background(), match, cache)
+	require.Error(t, err1)
+	assert.ErrorIs(t, err1, ErrModifierRateLimit, "first modifier (cache miss)")
+
+	callsAfterFirst := calls
+	_, err2 := newCond().evaluateWithCache(context.Background(), match, cache)
+	require.Error(t, err2)
+	assert.Equal(t, callsAfterFirst, calls, "second modifier must be served from cache")
+	assert.ErrorIs(t, err2, ErrModifierRateLimit,
+		"a cached 429 must stay a rate-limit error, not become not-applicable")
+	assert.NotErrorIs(t, err2, ErrConditionNotApplicable,
+		"a throttled API must never be silently skipped")
+}

--- a/pkg/scoring/engine.go
+++ b/pkg/scoring/engine.go
@@ -127,7 +127,13 @@ func (e *Engine) Score(ctx context.Context, f *types.Finding, matches []*types.M
 		modCancel()
 
 		if err != nil {
-			e.warnf("[warn] scorer %q modifier %q: %v (skipping)\n", scorer.Name, m.Name, err)
+			// A condition that cannot apply to an error response is routine --
+			// every scorer with a revoked-credential case produces one per dead
+			// key. Everything else still warns, including the same failure
+			// against a 2xx response, which usually means a bad field name.
+			if !errors.Is(err, ErrConditionNotApplicable) {
+				e.warnf("[warn] scorer %q modifier %q: %v (skipping)\n", scorer.Name, m.Name, err)
+			}
 			e.trackError(err)
 			continue
 		}

--- a/pkg/scoring/engine_warnings_test.go
+++ b/pkg/scoring/engine_warnings_test.go
@@ -1,0 +1,108 @@
+package scoring
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// scoreWithWarnings runs one finding through a scorer built from yamlSrc and
+// returns the score plus every warning the engine emitted.
+func scoreWithWarnings(t *testing.T, yamlSrc string, ruleID string) (*types.Score, []string) {
+	t.Helper()
+	scorers, err := NewLoader().LoadScorers([]byte(yamlSrc))
+	require.NoError(t, err)
+
+	var warnings []string
+	engine := NewEngine(scorers, EngineConfig{
+		ScopeEnabled: true,
+		Timeout:      5 * time.Second,
+		WarnF:        func(f string, a ...any) { warnings = append(warnings, fmt.Sprintf(f, a...)) },
+	})
+	rule := &types.Rule{ID: ruleID, BaseScore: 65}
+	finding := &types.Finding{ID: "f1", RuleID: ruleID}
+	match := &types.Match{RuleID: ruleID, NamedGroups: map[string][]byte{"token": []byte("secret")}}
+	return engine.Score(context.Background(), finding, []*types.Match{match}, rule), warnings
+}
+
+// A revoked credential is the common case in a scan, not an anomaly. The
+// modifiers that inspect the response body cannot find their fields in a 401
+// error body and error, which previously produced a warning each -- scaling
+// with every dead key found.
+func TestEngine_NotApplicableOnErrorResponse_DoesNotWarn(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"errors":[{"message":"authorization required"}]}`))
+	}))
+	defer srv.Close()
+
+	score, warnings := scoreWithWarnings(t, `
+scorers:
+  - name: probe
+    rule_ids: [np.sendgrid.1]
+    modifiers:
+      - name: breadth
+        priority: 90
+        http: &h
+          method: GET
+          url: `+srv.URL+`/v3/scopes
+          auth: {type: bearer, secret_group: "token"}
+        fires_when:
+          json_array_length_gte: {path: ".scopes", value: 100}
+        delta: 30
+      - name: narrow
+        priority: 40
+        http: *h
+        fires_when:
+          negative: true
+          json_array_length_gte: {path: ".scopes", value: 25}
+        delta: -20
+      - name: revoked
+        priority: 10
+        http: *h
+        fires_when:
+          status_code: 401
+        set_score: 5
+`, "np.sendgrid.1")
+
+	assert.Equal(t, 5, score.Final, "the revoked verdict must still apply")
+	assert.Empty(t, warnings, "a condition that cannot apply to an error response is routine, not warnworthy")
+}
+
+// The demotion must NOT be unconditional. A condition that cannot find its
+// field in a healthy 200 response is probably a typo in the scorer, and losing
+// that signal would trade log noise for a silent-misconfiguration hole.
+func TestEngine_NotApplicableOnSuccessResponse_StillWarns(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"scopes":["mail.send"]}`))
+	}))
+	defer srv.Close()
+
+	_, warnings := scoreWithWarnings(t, `
+scorers:
+  - name: probe
+    rule_ids: [np.sendgrid.1]
+    modifiers:
+      - name: typo-path
+        priority: 90
+        http:
+          method: GET
+          url: `+srv.URL+`/v3/scopes
+          auth: {type: bearer, secret_group: "token"}
+        fires_when:
+          json_array_length_gte: {path: ".scoeps", value: 5}
+        delta: 10
+`, "np.sendgrid.1")
+
+	require.Len(t, warnings, 1, "a bad path against a healthy response must still be reported")
+	assert.Contains(t, warnings[0], "typo-path")
+}

--- a/pkg/scoring/http_error.go
+++ b/pkg/scoring/http_error.go
@@ -15,6 +15,16 @@ var (
 	ErrModifierServerError = errors.New("modifier http: server error (5xx)")
 	ErrModifierNetwork     = errors.New("modifier http: network error")
 	ErrModifierParseError  = errors.New("modifier http: response parse error")
+
+	// ErrConditionNotApplicable marks a fires_when condition that could not be
+	// evaluated against the response it received -- typically a json_path leaf
+	// looking for a field that an error body does not carry. It is only used for
+	// non-success responses, where it is expected rather than noteworthy: a dead
+	// credential returns an error body no scope condition was ever going to match.
+	// The engine skips the warning for this error alone. The same failure against
+	// a 2xx response stays a warning, because there it usually means the scorer
+	// names a field that does not exist.
+	ErrConditionNotApplicable = errors.New("modifier condition not applicable to response")
 )
 
 // classifyHTTPError maps an HTTP status code (or nil for network err) to a

--- a/pkg/scoring/scorers/sendgrid.yaml
+++ b/pkg/scoring/scorers/sendgrid.yaml
@@ -126,12 +126,12 @@ scorers:
         set_score: 85
 
       # --- Dead key: evaluated last, wins outright ---
-      # Side effect: on a 401 the two json_array_length_gte modifiers above cannot
-      # find .scopes and return an error, so the engine logs 2 "[warn] ...
-      # (skipping)" lines per revoked finding. Stats counters are NOT affected --
-      # trackError only counts sentinel timeout/rate-limit/server/network errors.
-      # Reducing the noise needs an engine change (skip remaining modifiers after
-      # a terminal set_score, or log evaluation errors below warn level).
+      # On a 401 the two json_array_length_gte modifiers above cannot find
+      # .scopes and return an error. The engine recognises that as
+      # ErrConditionNotApplicable and does not warn: a dead credential returns an
+      # error body no scope condition was ever going to match (LAB-6050). The
+      # same failure against a 2xx response still warns, since there it usually
+      # means the scorer names a field that does not exist.
       - name: revoked-key
         priority: 10
         http: *sendgrid_scopes


### PR DESCRIPTION
Closes LAB-6050. Found while reviewing #324.

## Problem

`engine.go` funnelled two unrelated failures into one `warnf`:

1. **The request failed** — network, timeout, 5xx. Worth a warning.
2. **A `fires_when` condition could not be evaluated against the response it got** — a `json_path` leaf looking for `.scopes` in a 401 error body. Routine, and unavoidable for any scorer with a revoked-credential case.

SendGrid emitted **exactly 2** `[warn]` lines per revoked finding (measured), and revoked keys are common in a scan.

## Fix

`ErrConditionNotApplicable`, returned when a `fires_when` leaf errors against a **non-success** response. The engine skips the warning for that error alone.

**The status check is the whole point.** The same failure against a **2xx** response keeps warning, because there it usually means the scorer names a field that does not exist. Demoting unconditionally would trade log noise for a silent-misconfiguration hole — the exact failure class behind LAB-6049 and the SendGrid scope-string bug.

| | Before | After |
| -- | -- | -- |
| Revoked key (401) | 2 warnings | **0** |
| Bad JSON path on a 200 | 1 warning | 1 warning |
| Network failure / timeout | warning + stats | unchanged |

**No score can move.** Modifiers that error are still skipped, and `trackError` still runs, so timeout/rate-limit/server/network accounting is untouched.

## Why not the short-circuit

The ticket also proposed skipping remaining modifiers once a terminal `set_score` fires. Rejected: that changes evaluation semantics rather than logging. Deltas ordered below a `set_score` would stop applying, so real scores could shift. Today’s scorers happen to be safe, but it sets a trap for the next one — too much blast radius for a logging problem.

A third option, a not-applicable state on the leaf interface, is the cleanest model but touches every implementation. Worth revisiting if this recurs.

## Note on the metrics claim

An earlier review of #324 said this noise inflated failure metrics. It does not, and this PR does not change that: `trackError` only counts sentinel timeout/rate-limit/server/network errors, and a `jsonGet` path-missing error matches none of them. Measured on a revoked key: `stats={Timeouts:0 RateLimited:0 NetworkErrors:0 ServerErrors:0}`. It was log noise only.

## Testing

Two tests, one for each direction — silence on an error response, and a preserved warning on a healthy one. The second passed before this change and is a guard, not a driver: it pins the behaviour that must survive.

`go build ./...`, `go test ./...`, `go vet ./...`, `make test-race` (full suite, CGO), `make score-lint` — all green.

`security / Gosec` and `security / Govulncheck` fail on every branch right now (gosec crashes on Go 1.25.8); #322 fixes that.