### PR TITLE
fix(scoring): key the response cache on the rendered request (LAB-6051)

### DIFF
--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -277,9 +277,11 @@ Note the secret itself is normally injected via `auth.secret_group` rather than 
 
 **Response caching:**
 
-Within a single scan, responses are cached on (method, URL, secret). If several modifiers for the same finding issue the same request, only one network call is made -- so a scorer can split its logic across many modifiers without multiplying traffic.
+Within a single scan, responses are cached on the **rendered** request: method, URL, headers, body and secret, after template substitution. If several modifiers for the same finding issue the same request, only one network call is made -- so a scorer can split its logic across many modifiers without multiplying traffic.
 
-The URL is keyed **before** template substitution, so plaintext secrets never appear in cache keys. That has a consequence worth knowing: two requests whose URL templates are identical but which render differently -- because a non-secret variable such as a region or account identifier differs -- currently share a cache entry, and the second silently receives the first response. No built-in scorer triggers this today (the only templated URL substitutes its own secret), but do not rely on a non-secret template variable to distinguish two requests until this is fixed. Tracked as LAB-6051.
+Because the key is a hash of all of those together, credentials never appear in cache keys even though a rendered URL or body may contain them. Requests that differ in any component -- including a non-secret template variable such as a region or account identifier -- get separate entries, so a template variable is a safe way to distinguish two requests.
+
+Header order is significant: two modifiers declaring the same headers in a different order miss the shared entry and issue separate requests. That costs an extra call, never a wrong response.
 
 ---
 

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -277,7 +277,7 @@ Note the secret itself is normally injected via `auth.secret_group` rather than 
 
 **Response caching:**
 
-Within a single scan, responses are cached on the **rendered** request: method, URL, headers, body and secret, after template substitution. If several modifiers for the same finding issue the same request, only one network call is made -- so a scorer can split its logic across many modifiers without multiplying traffic.
+Within a single scan, responses are cached on the **rendered** request: method, URL, headers, body, auth scheme and secret, after template substitution. If several modifiers for the same finding issue the same request, only one network call is made -- so a scorer can split its logic across many modifiers without multiplying traffic.
 
 Because the key is a hash of all of those together, credentials never appear in cache keys even though a rendered URL or body may contain them. Requests that differ in any component -- including a non-secret template variable such as a region or account identifier -- get separate entries, so a template variable is a safe way to distinguish two requests.
 

--- a/pkg/scoring/condition_http.go
+++ b/pkg/scoring/condition_http.go
@@ -60,29 +60,20 @@ func (c *httpCondition) evaluateWithCache(ctx context.Context, m *types.Match, c
 	// response to the second. httpCacheKey hashes the whole key, so rendering
 	// here does not put credentials into map keys.
 	//
-	// Substitution is idempotent — no {{...}} placeholders survive the first
-	// pass — so makeHTTPRequest rendering these again below is harmless.
+	// The SAME rendered values are sent below. Rendering a second time would not
+	// be reliably identical: substituteVarsInURL iterates NamedGroups in map
+	// order, so a captured value that itself looks like a placeholder could
+	// resolve differently between passes, and the key would then describe a
+	// request that was never sent.
 	secretBytes := m.NamedGroups[c.auth.SecretGroup]
-	renderedHeaders := make([]scorerHeader, len(c.headers))
-	for i, hdr := range c.headers {
-		renderedHeaders[i] = scorerHeader{
-			Name:  hdr.Name,
-			Value: substituteVarsInURL(hdr.Value, m.NamedGroups),
-		}
-	}
-	key := httpCacheKey(
-		c.method,
-		substituteVarsInURL(c.url, m.NamedGroups),
-		renderedHeaders,
-		substituteVarsInURL(c.body, m.NamedGroups),
-		secretBytes,
-	)
+	rendered := renderRequest(c.method, c.url, c.headers, c.body, m.NamedGroups)
+	key := httpCacheKey(rendered, c.auth, secretBytes)
 
 	resp, found := cache.get(key)
 	if !found {
 		var err error
 		resp, err = withRetry(ctx, func() (*cachedHTTPResponse, error) {
-			return makeHTTPRequest(ctx, c.method, c.url, c.headers, c.body, c.auth, m.NamedGroups)
+			return sendRenderedRequest(ctx, rendered, c.auth, string(secretBytes))
 		})
 		if err != nil {
 			return false, fmt.Errorf("http condition request: %w", err)

--- a/pkg/scoring/condition_http.go
+++ b/pkg/scoring/condition_http.go
@@ -54,11 +54,29 @@ func (c *httpCondition) evaluateWithCache(ctx context.Context, m *types.Match, c
 		return false, nil
 	}
 
-	// Use the template URL (c.url) not the expanded URL as the cache key so
-	// plaintext secrets don't appear in in-memory cache keys. The secret bytes
-	// already provide per-secret uniqueness in the key hash.
+	// Key on the RENDERED request, not the template. Two requests differing only
+	// in a non-secret template variable render differently but share a template,
+	// so keying on the template made them collide and served the first one's
+	// response to the second. httpCacheKey hashes the whole key, so rendering
+	// here does not put credentials into map keys.
+	//
+	// Substitution is idempotent — no {{...}} placeholders survive the first
+	// pass — so makeHTTPRequest rendering these again below is harmless.
 	secretBytes := m.NamedGroups[c.auth.SecretGroup]
-	key := httpCacheKey(c.method, c.url, secretBytes)
+	renderedHeaders := make([]scorerHeader, len(c.headers))
+	for i, hdr := range c.headers {
+		renderedHeaders[i] = scorerHeader{
+			Name:  hdr.Name,
+			Value: substituteVarsInURL(hdr.Value, m.NamedGroups),
+		}
+	}
+	key := httpCacheKey(
+		c.method,
+		substituteVarsInURL(c.url, m.NamedGroups),
+		renderedHeaders,
+		substituteVarsInURL(c.body, m.NamedGroups),
+		secretBytes,
+	)
 
 	resp, found := cache.get(key)
 	if !found {

--- a/pkg/scoring/condition_http_test.go
+++ b/pkg/scoring/condition_http_test.go
@@ -228,11 +228,10 @@ func TestNegatedLeaf_ArrayLengthGte_GivesLessThan(t *testing.T) {
 // cache key must reflect the RENDERED request, not the template (LAB-6051)
 // ----------------------------------------------------------------
 
-// countingServer records every request path/header/body it receives.
+// countingServer records the request paths it receives.
 type countingServer struct {
-	calls   int
-	paths   []string
-	regions []string
+	calls int
+	paths []string
 }
 
 // Two findings sharing a secret but rendering a different non-secret template
@@ -348,4 +347,70 @@ func TestHTTPCondition_DifferentBodies_IssueSeparateRequests(t *testing.T) {
 		require.NoError(t, err)
 	}
 	assert.Equal(t, 2, calls, "different bodies must not share a cache entry")
+}
+
+// Auth is part of what makes a request distinct: the same URL and secret sent
+// as a bearer header, a custom header, or a query parameter are three different
+// requests. Omitting auth from the key let the second reuse the first's response.
+func TestHTTPCondition_DifferentAuthTypes_IssueSeparateRequests(t *testing.T) {
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	cache := newHTTPResponseCache()
+	m := matchWithGroups(map[string][]byte{"token": []byte("secret")})
+	auths := []scorerAuth{
+		{Type: "bearer", SecretGroup: "token"},
+		{Type: "header", SecretGroup: "token", HeaderName: "X-Token"},
+		{Type: "query", SecretGroup: "token", QueryParam: "token"},
+	}
+	for _, a := range auths {
+		c := &httpCondition{
+			method:    "GET",
+			url:       srv.URL + "/x",
+			auth:      a,
+			firesWhen: &statusCodeLeaf{Code: 200},
+		}
+		_, err := c.evaluateWithCache(context.Background(), m, cache)
+		require.NoError(t, err)
+	}
+	assert.Equal(t, len(auths), calls, "each auth scheme is a distinct request")
+}
+
+// The key encoding must be unambiguous. Delimiting fields with a NUL byte
+// collides for values that themselves contain NUL: no headers with a body of
+// "a\x00b\x00" produced the same bytes as one header {a: b} with an empty body.
+func TestHTTPCondition_AmbiguousFieldBoundaries_DoNotCollide(t *testing.T) {
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	cache := newHTTPResponseCache()
+	m := matchWithGroups(map[string][]byte{"token": []byte("secret")})
+	auth := scorerAuth{Type: "bearer", SecretGroup: "token"}
+
+	withBody := &httpCondition{
+		method: "POST", url: srv.URL + "/x", auth: auth,
+		body:      "a\x00b\x00",
+		firesWhen: &statusCodeLeaf{Code: 200},
+	}
+	withHeader := &httpCondition{
+		method: "POST", url: srv.URL + "/x", auth: auth,
+		headers:   []scorerHeader{{Name: "a", Value: "b"}},
+		firesWhen: &statusCodeLeaf{Code: 200},
+	}
+	_, err := withBody.evaluateWithCache(context.Background(), m, cache)
+	require.NoError(t, err)
+	_, err = withHeader.evaluateWithCache(context.Background(), m, cache)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, calls, "distinct requests must not hash to the same key")
 }

--- a/pkg/scoring/condition_http_test.go
+++ b/pkg/scoring/condition_http_test.go
@@ -223,3 +223,129 @@ func TestNegatedLeaf_ArrayLengthGte_GivesLessThan(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, fired, "2 scopes is fewer than 25, so the negated gte should fire")
 }
+
+// ----------------------------------------------------------------
+// cache key must reflect the RENDERED request, not the template (LAB-6051)
+// ----------------------------------------------------------------
+
+// countingServer records every request path/header/body it receives.
+type countingServer struct {
+	calls   int
+	paths   []string
+	regions []string
+}
+
+// Two findings sharing a secret but rendering a different non-secret template
+// variable are different requests. Keying on the un-rendered template made them
+// collide, so the second silently received the first one's response.
+func TestHTTPCondition_DifferentTemplateValues_IssueSeparateRequests(t *testing.T) {
+	var rec countingServer
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec.calls++
+		rec.paths = append(rec.paths, r.URL.Path)
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"region":"` + r.URL.Path + `"}`))
+	}))
+	defer srv.Close()
+
+	cache := newHTTPResponseCache()
+	cond := func() *httpCondition {
+		return &httpCondition{
+			method:    "GET",
+			url:       srv.URL + "/{{region}}/account",
+			auth:      scorerAuth{Type: "bearer", SecretGroup: "token"},
+			firesWhen: &statusCodeLeaf{Code: 200},
+		}
+	}
+	us := matchWithGroups(map[string][]byte{"token": []byte("same-secret"), "region": []byte("us")})
+	eu := matchWithGroups(map[string][]byte{"token": []byte("same-secret"), "region": []byte("eu")})
+
+	_, err := cond().evaluateWithCache(context.Background(), us, cache)
+	require.NoError(t, err)
+	_, err = cond().evaluateWithCache(context.Background(), eu, cache)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, rec.calls, "different rendered URLs must not share a cache entry")
+	assert.Equal(t, []string{"/us/account", "/eu/account"}, rec.paths)
+}
+
+// The flip side, and the property the SendGrid scorer depends on: modifiers
+// issuing an identical request must still share one network call.
+func TestHTTPCondition_IdenticalRequests_ShareOneCacheEntry(t *testing.T) {
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"scopes":["mail.send"]}`))
+	}))
+	defer srv.Close()
+
+	cache := newHTTPResponseCache()
+	cond := func() *httpCondition {
+		return &httpCondition{
+			method:    "GET",
+			url:       srv.URL + "/v3/scopes",
+			auth:      scorerAuth{Type: "bearer", SecretGroup: "token"},
+			firesWhen: &statusCodeLeaf{Code: 200},
+		}
+	}
+	m := matchWithGroups(map[string][]byte{"token": []byte("secret")})
+
+	for i := 0; i < 3; i++ {
+		_, err := cond().evaluateWithCache(context.Background(), m, cache)
+		require.NoError(t, err)
+	}
+	assert.Equal(t, 1, calls, "identical requests must share one cache entry")
+}
+
+// Headers are part of request identity too.
+func TestHTTPCondition_DifferentHeaders_IssueSeparateRequests(t *testing.T) {
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	cache := newHTTPResponseCache()
+	m := matchWithGroups(map[string][]byte{"token": []byte("secret")})
+	for _, v := range []string{"v1", "v2"} {
+		c := &httpCondition{
+			method:    "GET",
+			url:       srv.URL + "/x",
+			headers:   []scorerHeader{{Name: "X-Api-Version", Value: v}},
+			auth:      scorerAuth{Type: "bearer", SecretGroup: "token"},
+			firesWhen: &statusCodeLeaf{Code: 200},
+		}
+		_, err := c.evaluateWithCache(context.Background(), m, cache)
+		require.NoError(t, err)
+	}
+	assert.Equal(t, 2, calls, "different headers must not share a cache entry")
+}
+
+// So is the request body.
+func TestHTTPCondition_DifferentBodies_IssueSeparateRequests(t *testing.T) {
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	cache := newHTTPResponseCache()
+	m := matchWithGroups(map[string][]byte{"token": []byte("secret")})
+	for _, b := range []string{`{"q":"a"}`, `{"q":"b"}`} {
+		c := &httpCondition{
+			method:    "POST",
+			url:       srv.URL + "/search",
+			body:      b,
+			auth:      scorerAuth{Type: "bearer", SecretGroup: "token"},
+			firesWhen: &statusCodeLeaf{Code: 200},
+		}
+		_, err := c.evaluateWithCache(context.Background(), m, cache)
+		require.NoError(t, err)
+	}
+	assert.Equal(t, 2, calls, "different bodies must not share a cache entry")
+}

--- a/pkg/scoring/http_cache.go
+++ b/pkg/scoring/http_cache.go
@@ -2,7 +2,9 @@ package scoring
 
 import (
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
+	"strconv"
 	"sync"
 )
 
@@ -36,24 +38,48 @@ func newHTTPResponseCache() *httpResponseCache {
 // The whole key is a single hash, so credentials never appear in map keys even
 // though the rendered URL, headers and body may contain them.
 //
+// Auth is part of request identity too: the same URL and secret sent as a
+// bearer header, a custom header, or a query parameter are three different
+// requests.
+//
+// Fields are length-prefixed rather than delimited. A delimiter is ambiguous
+// for values that can contain it — with NUL separators, no headers and a body
+// of "a\x00b\x00" hashes identically to one header {a: b} with an empty body.
+// The header count is written too, so a header pair cannot be confused with the
+// body that follows it.
+//
 // Header order is significant. Headers come from the YAML in declaration order,
 // so this is deterministic for a given modifier; two modifiers declaring the
 // same headers in a different order simply miss the shared entry, costing an
 // extra request rather than returning a wrong one.
-func httpCacheKey(method, url string, headers []scorerHeader, body string, secretBytes []byte) string {
+func httpCacheKey(r renderedRequest, auth scorerAuth, secretBytes []byte) string {
 	h := sha256.New()
-	write := func(s string) {
-		_, _ = h.Write([]byte(s))
-		_, _ = h.Write([]byte{0})
+	write := func(b []byte) {
+		var n [8]byte
+		binary.BigEndian.PutUint64(n[:], uint64(len(b)))
+		_, _ = h.Write(n[:])
+		_, _ = h.Write(b)
 	}
-	write(method)
-	write(url)
-	for _, hdr := range headers {
-		write(hdr.Name)
-		write(hdr.Value)
+	writeStr := func(s string) { write([]byte(s)) }
+
+	writeStr(r.method)
+	writeStr(r.url)
+	writeStr(strconv.Itoa(len(r.headers)))
+	for _, hdr := range r.headers {
+		writeStr(hdr.Name)
+		writeStr(hdr.Value)
 	}
-	write(body)
-	_, _ = h.Write(secretBytes)
+	writeStr(r.body)
+
+	// Effective auth: the scheme and everything that shapes where the secret goes.
+	writeStr(auth.Type)
+	writeStr(auth.SecretGroup)
+	writeStr(auth.HeaderName)
+	writeStr(auth.QueryParam)
+	writeStr(auth.Username)
+	writeStr(auth.KeyPrefix)
+
+	write(secretBytes)
 	return hex.EncodeToString(h.Sum(nil))
 }
 

--- a/pkg/scoring/http_cache.go
+++ b/pkg/scoring/http_cache.go
@@ -13,8 +13,9 @@ type cachedHTTPResponse struct {
 	Headers    map[string]string // lower-cased header names
 }
 
-// httpResponseCache is a per-scan, thread-safe cache keyed by (method, url, secret_hash).
-// It is NOT shared across scans; the engine creates one per Score() invocation group.
+// httpResponseCache is a per-scan, thread-safe cache keyed by the rendered
+// request (see httpCacheKey). It is NOT shared across scans; the engine creates
+// one per Score() invocation group.
 type httpResponseCache struct {
 	mu      sync.RWMutex
 	entries map[string]*cachedHTTPResponse
@@ -24,11 +25,36 @@ func newHTTPResponseCache() *httpResponseCache {
 	return &httpResponseCache{entries: make(map[string]*cachedHTTPResponse)}
 }
 
-// httpCacheKey returns a deterministic key for (method, url, secretBytes).
-// secretBytes is hashed so credentials never appear in map keys.
-func httpCacheKey(method, url string, secretBytes []byte) string {
-	h := sha256.Sum256(secretBytes)
-	return method + "\x00" + url + "\x00" + hex.EncodeToString(h[:])
+// httpCacheKey returns a deterministic key identifying one rendered request.
+//
+// Every component must be the value actually sent, not the template it came
+// from. Keying on an un-rendered URL made two requests that differ only in a
+// non-secret template variable — a region, an account id — collide, so the
+// second silently received the first one's response. Headers and body are part
+// of request identity for the same reason.
+//
+// The whole key is a single hash, so credentials never appear in map keys even
+// though the rendered URL, headers and body may contain them.
+//
+// Header order is significant. Headers come from the YAML in declaration order,
+// so this is deterministic for a given modifier; two modifiers declaring the
+// same headers in a different order simply miss the shared entry, costing an
+// extra request rather than returning a wrong one.
+func httpCacheKey(method, url string, headers []scorerHeader, body string, secretBytes []byte) string {
+	h := sha256.New()
+	write := func(s string) {
+		_, _ = h.Write([]byte(s))
+		_, _ = h.Write([]byte{0})
+	}
+	write(method)
+	write(url)
+	for _, hdr := range headers {
+		write(hdr.Name)
+		write(hdr.Value)
+	}
+	write(body)
+	_, _ = h.Write(secretBytes)
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 func (c *httpResponseCache) get(key string) (*cachedHTTPResponse, bool) {

--- a/pkg/scoring/http_cache_test.go
+++ b/pkg/scoring/http_cache_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestHTTPResponseCache_StoresAndRetrievesResponse(t *testing.T) {
 	c := newHTTPResponseCache()
-	key := httpCacheKey("GET", "https://api.github.com/user", []byte("ghp_secret"))
+	key := httpCacheKey("GET", "https://api.github.com/user", nil, "", []byte("ghp_secret"))
 
 	_, found := c.get(key)
 	assert.False(t, found, "cache should be empty initially")
@@ -25,19 +25,19 @@ func TestHTTPResponseCache_StoresAndRetrievesResponse(t *testing.T) {
 }
 
 func TestHTTPCacheKey_DifferentSecretsGiveDifferentKeys(t *testing.T) {
-	k1 := httpCacheKey("GET", "https://api.github.com/user", []byte("token-A"))
-	k2 := httpCacheKey("GET", "https://api.github.com/user", []byte("token-B"))
+	k1 := httpCacheKey("GET", "https://api.github.com/user", nil, "", []byte("token-A"))
+	k2 := httpCacheKey("GET", "https://api.github.com/user", nil, "", []byte("token-B"))
 	assert.NotEqual(t, k1, k2)
 }
 
 func TestHTTPCacheKey_DifferentURLsGiveDifferentKeys(t *testing.T) {
-	k1 := httpCacheKey("GET", "https://api.github.com/user", []byte("tok"))
-	k2 := httpCacheKey("GET", "https://api.github.com/user/orgs", []byte("tok"))
+	k1 := httpCacheKey("GET", "https://api.github.com/user", nil, "", []byte("tok"))
+	k2 := httpCacheKey("GET", "https://api.github.com/user/orgs", nil, "", []byte("tok"))
 	assert.NotEqual(t, k1, k2)
 }
 
 func TestHTTPResponseCache_MissOnUnknownKey(t *testing.T) {
 	c := newHTTPResponseCache()
-	_, found := c.get(httpCacheKey("GET", "https://example.com", nil))
+	_, found := c.get(httpCacheKey("GET", "https://example.com", nil, "", nil))
 	assert.False(t, found)
 }

--- a/pkg/scoring/http_cache_test.go
+++ b/pkg/scoring/http_cache_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestHTTPResponseCache_StoresAndRetrievesResponse(t *testing.T) {
 	c := newHTTPResponseCache()
-	key := httpCacheKey("GET", "https://api.github.com/user", nil, "", []byte("ghp_secret"))
+	key := httpCacheKey(renderedRequest{method: "GET", url: "https://api.github.com/user"}, scorerAuth{}, []byte("ghp_secret"))
 
 	_, found := c.get(key)
 	assert.False(t, found, "cache should be empty initially")
@@ -25,19 +25,19 @@ func TestHTTPResponseCache_StoresAndRetrievesResponse(t *testing.T) {
 }
 
 func TestHTTPCacheKey_DifferentSecretsGiveDifferentKeys(t *testing.T) {
-	k1 := httpCacheKey("GET", "https://api.github.com/user", nil, "", []byte("token-A"))
-	k2 := httpCacheKey("GET", "https://api.github.com/user", nil, "", []byte("token-B"))
+	k1 := httpCacheKey(renderedRequest{method: "GET", url: "https://api.github.com/user"}, scorerAuth{}, []byte("token-A"))
+	k2 := httpCacheKey(renderedRequest{method: "GET", url: "https://api.github.com/user"}, scorerAuth{}, []byte("token-B"))
 	assert.NotEqual(t, k1, k2)
 }
 
 func TestHTTPCacheKey_DifferentURLsGiveDifferentKeys(t *testing.T) {
-	k1 := httpCacheKey("GET", "https://api.github.com/user", nil, "", []byte("tok"))
-	k2 := httpCacheKey("GET", "https://api.github.com/user/orgs", nil, "", []byte("tok"))
+	k1 := httpCacheKey(renderedRequest{method: "GET", url: "https://api.github.com/user"}, scorerAuth{}, []byte("tok"))
+	k2 := httpCacheKey(renderedRequest{method: "GET", url: "https://api.github.com/user/orgs"}, scorerAuth{}, []byte("tok"))
 	assert.NotEqual(t, k1, k2)
 }
 
 func TestHTTPResponseCache_MissOnUnknownKey(t *testing.T) {
 	c := newHTTPResponseCache()
-	_, found := c.get(httpCacheKey("GET", "https://example.com", nil, "", nil))
+	_, found := c.get(httpCacheKey(renderedRequest{method: "GET", url: "https://example.com"}, scorerAuth{}, nil))
 	assert.False(t, found)
 }

--- a/pkg/scoring/http_client.go
+++ b/pkg/scoring/http_client.go
@@ -29,8 +29,39 @@ type scorerHeader struct {
 
 var defaultHTTPClient = &http.Client{Timeout: 30 * time.Second}
 
-// makeHTTPRequest performs an HTTP request on behalf of an httpCondition.
-// namedGroups is used to substitute {{group}} template variables in URL and headers.
+// renderedRequest is a request whose {{group}} template variables have already
+// been substituted. Rendering once and using the same values for both the cache
+// key and the outgoing request keeps the two in lockstep.
+//
+// This matters because substituteVarsInURL iterates NamedGroups in Go's
+// unspecified map order. If one captured value happens to contain what looks
+// like another placeholder, substituting twice can produce two different
+// strings — so a key built by a second, independent substitution pass could
+// describe a request that was never sent.
+type renderedRequest struct {
+	method  string
+	url     string
+	headers []scorerHeader
+	body    string
+}
+
+// renderRequest substitutes template variables once, for every part of the request.
+func renderRequest(method, rawURL string, headers []scorerHeader, body string, namedGroups map[string][]byte) renderedRequest {
+	rendered := make([]scorerHeader, len(headers))
+	for i, h := range headers {
+		rendered[i] = scorerHeader{Name: h.Name, Value: substituteVarsInURL(h.Value, namedGroups)}
+	}
+	return renderedRequest{
+		method:  method,
+		url:     substituteVarsInURL(rawURL, namedGroups),
+		headers: rendered,
+		body:    substituteVarsInURL(body, namedGroups),
+	}
+}
+
+// makeHTTPRequest renders the request and sends it. Callers that need the
+// rendered values themselves — to build a cache key that matches what is
+// actually sent — should call renderRequest and sendRenderedRequest instead.
 // The context carries the per-modifier deadline; callers must set it.
 func makeHTTPRequest(
 	ctx context.Context,
@@ -40,26 +71,34 @@ func makeHTTPRequest(
 	auth scorerAuth,
 	namedGroups map[string][]byte,
 ) (*cachedHTTPResponse, error) {
-	url := substituteVarsInURL(rawURL, namedGroups)
+	r := renderRequest(method, rawURL, headers, body, namedGroups)
+	return sendRenderedRequest(ctx, r, auth, string(namedGroups[auth.SecretGroup]))
+}
 
+// sendRenderedRequest performs an already-rendered request. It does no further
+// template substitution.
+func sendRenderedRequest(
+	ctx context.Context,
+	r renderedRequest,
+	auth scorerAuth,
+	secret string,
+) (*cachedHTTPResponse, error) {
 	var bodyReader io.Reader
-	if body != "" {
-		bodyReader = strings.NewReader(substituteVarsInURL(body, namedGroups))
+	if r.body != "" {
+		bodyReader = strings.NewReader(r.body)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, method, url, bodyReader)
+	req, err := http.NewRequestWithContext(ctx, r.method, r.url, bodyReader)
 	if err != nil {
 		return nil, fmt.Errorf("building HTTP request: %w", err)
 	}
 
-	// Static headers (template vars substituted)
-	for _, h := range headers {
-		req.Header.Set(h.Name, substituteVarsInURL(h.Value, namedGroups))
+	for _, h := range r.headers {
+		req.Header.Set(h.Name, h.Value)
 	}
 
 	// Auth
 	if auth.Type != "" && auth.SecretGroup != "" {
-		secret := string(namedGroups[auth.SecretGroup])
 		if err := applyScorerAuth(req, auth, secret); err != nil {
 			return nil, fmt.Errorf("applying auth: %w", err)
 		}


### PR DESCRIPTION
Closes LAB-6051. Raised by CodeRabbit on #324.

## Problem

`httpCacheKey` was built from the **un-substituted** URL template plus the secret:

```go
key := httpCacheKey(c.method, c.url, secretBytes)   // c.url is the template
```

The reasoning — keep the template out of cleartext, and the secret hash provides uniqueness — holds only while **the secret is the sole template variable**. Two requests differing in a non-secret variable (a region, an account id) render differently but share a template, so they collided and the second silently received the first response.

Headers and body were not in the key at all, so the same collision existed on those axes too.

## Fix

The key is now a single hash over the **rendered** request: method, substituted URL, substituted headers, substituted body, secret. Hashing everything together means credentials still never appear in map keys, even though a rendered URL or body may contain them.

I fixed all three axes rather than only the URL the ticket named — body and headers are equally part of request identity and equally absent from the old key, and it is the same few lines.

## Current exposure: none

| Axis | Today |
| -- | -- |
| Templated URL | Only `google.yaml`, and its `{{key}}` **is** its `secret_group` — the secret hash already disambiguated it |
| Body | No scorer sets one |
| Headers | `slack.yaml` sets them, but its two modifiers sharing `auth.test` declare identical ones |

So this is a latent fix. Regional endpoints are what would first trigger it, and those are next up in LAB-6047.

## Behaviour notes

- **Header order is significant.** Headers come from the YAML in declaration order, so this is deterministic per modifier. Two modifiers declaring the same headers in a different order miss the shared entry — an extra request, never a wrong response.
- **Substitution runs twice.** `evaluateWithCache` renders to build the key, then `makeHTTPRequest` renders again. Substitution is idempotent (no `{{...}}` survive the first pass), and I preferred the duplicate call over restructuring the request path.
- **No change to hit/miss behaviour for any current scorer** — nothing varies on the new axes. The SendGrid scorer still makes one call for seven modifiers, covered by a test.

## Testing

Four tests, one per collision axis plus the property they must not break: identical requests still share one entry. The three collision tests failed before this change.

`go build ./...`, `go test ./...`, `go vet ./...`, `make test-race` (full suite, CGO), `make score-lint` — all green.

## Note for whoever merges second

This and #326 both touch `evaluateWithCache`. I ran a trial merge: **the production code auto-merges cleanly** (different regions of the function — key construction here, classification/sentinel there). The only conflict is in `pkg/scoring/condition_http_test.go`, where both branches append test functions at EOF. Resolution is to keep both blocks; no logic is in tension.