### PR TITLE
feat(rules): add Cloudinary URL credential detection rule

### DIFF
--- a/pkg/rule/cloudinary_test.go
+++ b/pkg/rule/cloudinary_test.go
@@ -1,0 +1,86 @@
+package rule
+
+import (
+	"testing"
+
+	"github.com/praetorian-inc/titus/pkg/matcher"
+	"github.com/praetorian-inc/titus/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCloudinaryURL_Detection verifies the kingfisher.cloudinary.1 rule detects
+// Cloudinary environment URLs (cloudinary://<api_key>:<api_secret>@<cloud_name>)
+// and ignores public delivery URLs and placeholder values.
+func TestCloudinaryURL_Detection(t *testing.T) {
+	loader := NewLoader()
+	rules, err := loader.LoadBuiltinRules()
+	require.NoError(t, err)
+
+	var cloudinaryRule *types.Rule
+	for _, r := range rules {
+		if r.ID == "kingfisher.cloudinary.1" {
+			cloudinaryRule = r
+			break
+		}
+	}
+	require.NotNil(t, cloudinaryRule, "kingfisher.cloudinary.1 rule should exist")
+
+	m, err := matcher.NewPortableRegexp([]*types.Rule{cloudinaryRule}, 0, nil)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name        string
+		input       string
+		shouldMatch bool
+	}{
+		{
+			name:        "valid CLOUDINARY_URL env assignment",
+			input:       `CLOUDINARY_URL=cloudinary://874837483274837:abcd1234EFGH5678ijkl9012MNO@demo-media`,
+			shouldMatch: true,
+		},
+		{
+			name:        "valid quoted URL",
+			input:       `CLOUDINARY_URL="cloudinary://123456789012345:Xy7Kp2Lm9Qr4Vn1Bc6Dg3Fh8Js0@my-company"`,
+			shouldMatch: true,
+		},
+		{
+			name:        "valid JSON value",
+			input:       `{"cloudinary_url":"cloudinary://509182734650918:9zAq2Wsx3Edc4Rfv5Tgb6Yhn7Uj@prod-assets"}`,
+			shouldMatch: true,
+		},
+		{
+			name:        "invalid - secret too short",
+			input:       `cloudinary://874837483274837:tooShortSecret@demo-media`,
+			shouldMatch: false,
+		},
+		{
+			name:        "invalid - api key not 15 digits",
+			input:       `cloudinary://12345:abcd1234EFGH5678ijkl9012MNO@demo-media`,
+			shouldMatch: false,
+		},
+		{
+			name:        "invalid - public delivery URL",
+			input:       `https://res.cloudinary.com/demo/image/upload/v1234567890/sample.jpg`,
+			shouldMatch: false,
+		},
+		{
+			name:        "invalid - placeholder value",
+			input:       `CLOUDINARY_URL=cloudinary://<your_api_key>:<your_api_secret>@<cloud_name>`,
+			shouldMatch: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			matches, err := m.Match([]byte(tc.input))
+			require.NoError(t, err)
+
+			if tc.shouldMatch {
+				assert.NotEmpty(t, matches, "expected match for: %s", tc.input)
+			} else {
+				assert.Empty(t, matches, "expected no match for: %s", tc.input)
+			}
+		})
+	}
+}

--- a/pkg/rule/rules/cloudinary.yml
+++ b/pkg/rule/rules/cloudinary.yml
@@ -1,0 +1,47 @@
+rules:
+
+- name: Cloudinary URL Credential
+  id: kingfisher.cloudinary.1
+  base_score: 85
+
+  pattern: |
+    (?x)
+    (?P<token>
+      cloudinary://
+      \d{15}
+      :
+      [A-Za-z0-9_-]{27}
+      @
+      [a-zA-Z][a-zA-Z0-9-]{2,49}
+    )
+
+  min_entropy: 3.0
+
+  confidence: high
+
+  categories:
+  - api
+  - secret
+
+  description: |
+    A Cloudinary API environment URL was found. The CLOUDINARY_URL value packs
+    the cloud name, API key, and API secret into a single connection string of
+    the form cloudinary://<api_key>:<api_secret>@<cloud_name>. An attacker with
+    this credential can call the Cloudinary Admin API to list, upload, overwrite,
+    and delete media assets, rotate delivery settings, and run transformations
+    that consume paid quota, giving them full control over the account's media.
+
+  references:
+  - https://cloudinary.com/documentation/finding_your_credentials
+  - https://cloudinary.com/documentation/node_integration#setting_the_cloudinary_url_environment_variable
+
+  examples:
+  - 'CLOUDINARY_URL=cloudinary://874837483274837:abcd1234EFGH5678ijkl9012MNO@demo-media'
+  - 'CLOUDINARY_URL="cloudinary://123456789012345:Xy7Kp2Lm9Qr4Vn1Bc6Dg3Fh8Js0@my-company"'
+  - '{"cloudinary_url":"cloudinary://509182734650918:9zAq2Wsx3Edc4Rfv5Tgb6Yhn7Uj@prod-assets"}'
+
+  negative_examples:
+  - 'CLOUDINARY_URL=cloudinary://874837483274837:tooShortSecret@demo-media'
+  - 'cloudinary://12345:abcd1234EFGH5678ijkl9012MNO@demo-media'
+  - 'https://res.cloudinary.com/demo/image/upload/v1234567890/sample.jpg'
+  - 'CLOUDINARY_URL=cloudinary://<your_api_key>:<your_api_secret>@<cloud_name>'

--- a/pkg/rule/rules/cloudinary.yml
+++ b/pkg/rule/rules/cloudinary.yml
@@ -6,14 +6,12 @@ rules:
 
   pattern: |
     (?x)
-    (?P<token>
-      cloudinary://
-      \d{15}
-      :
-      [A-Za-z0-9_-]{27}
-      @
-      [a-zA-Z][a-zA-Z0-9-]{2,49}
-    )
+    cloudinary://
+    (?P<key>\d{15})
+    :
+    (?P<token>[A-Za-z0-9_-]{27})
+    @
+    (?P<cloud>[a-zA-Z][a-zA-Z0-9-]{2,49})
 
   min_entropy: 3.0
 
@@ -32,7 +30,7 @@ rules:
     that consume paid quota, giving them full control over the account's media.
 
   references:
-  - https://cloudinary.com/documentation/finding_your_credentials
+  - https://cloudinary.com/documentation/developer_onboarding_faq
   - https://cloudinary.com/documentation/node_integration#setting_the_cloudinary_url_environment_variable
 
   examples:

--- a/pkg/rule/rulesets/default.yml
+++ b/pkg/rule/rulesets/default.yml
@@ -277,6 +277,7 @@ rulesets:
   - kingfisher.clojars.2                # Clojars API Token
   - kingfisher.cloudflare.1             # Cloudflare API Token
   - kingfisher.cloudflare.2             # Cloudflare CA Key
+  - kingfisher.cloudinary.1             # Cloudinary URL Credential
   - kingfisher.cloudsight.1             # CloudSight API Key
   - kingfisher.codacy.1                 # Codacy API Key
   - kingfisher.codecov.1                # Codecov Access Token


### PR DESCRIPTION
Adds a rule for Cloudinary environment URLs, which pack the cloud name, API key, and API secret into a single cloudinary://<api_key>:<api_secret>@<cloud_name> string that grants full control of the account's media. It matches the canonical CLOUDINARY_URL format and skips public res.cloudinary.com delivery URLs and placeholder values, with a test covering both.