### PR TITLE
fix(mongodb): detect real Atlas keys, and pair the digest public key (LAB-6095)

### DIFF
--- a/pkg/matcher/rule_examples_test.go
+++ b/pkg/matcher/rule_examples_test.go
@@ -83,8 +83,6 @@ var knownExampleFailures = map[string]exampleBaseline{
 	"kingfisher.lob.2":          {regex: nil, filter: []int{0}, total: 2},
 	"kingfisher.mattermost.2":   {regex: nil, filter: []int{0}, total: 3},
 	"kingfisher.messagebird.1":  {regex: nil, filter: []int{0}, total: 2},
-	"kingfisher.mongodb.1":      {regex: nil, filter: []int{0}, total: 1},
-	"kingfisher.mongodb.2":      {regex: nil, filter: []int{0}, total: 1},
 	"kingfisher.mysql.1":        {regex: nil, filter: []int{1}, total: 2},
 	"kingfisher.openweather.1":  {regex: nil, filter: []int{2, 3}, total: 4},
 	"kingfisher.planetscale.2":  {regex: nil, filter: []int{0, 1}, total: 2},

--- a/pkg/matcher/rule_examples_test.go
+++ b/pkg/matcher/rule_examples_test.go
@@ -21,18 +21,30 @@ import (
 
 	"github.com/praetorian-inc/titus/pkg/rule"
 	"github.com/praetorian-inc/titus/pkg/types"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// knownExampleFailures lists rules that cannot currently detect their own
-// documented examples. Tracked as LAB-6096.
+// exampleBaseline records exactly which of a rule's examples are known to fail,
+// by index, and at which stage.
 //
-// Entries are rule IDs, deliberately not a count: a count would let a fixed
-// rule be silently traded for a newly broken one.
+// Indices rather than counts, for the same reason the map is keyed by rule ID
+// rather than holding a total: a count lets a fixed example be silently traded
+// for a newly broken one. total is recorded too, so adding or removing an
+// example -- which shifts every index after it -- forces a re-baseline instead
+// of quietly invalidating the entries.
+type exampleBaseline struct {
+	regex  []int // indices whose example the regex never matches
+	filter []int // indices matched by the regex, then dropped by filterMatches
+	total  int   // len(rule.Examples) when this baseline was taken
+}
+
+// knownExampleFailures is the burn-down list for LAB-6096: rules that cannot
+// detect the examples they document. 51 rules of the 533 carrying examples.
 //
-// TO FIX A RULE, DELETE ITS LINE HERE. TestRuleExamples_KnownFailuresStillFail
-// fails if a listed rule starts passing, so the list can only shrink and a
-// fixed rule cannot quietly stop being guarded.
+// TO FIX A RULE, DELETE ITS LINE HERE. TestRuleExamples_KnownFailuresMatchBaseline
+// fails if a listed rule's failures no longer match exactly, so the list cannot
+// rot and a fixed rule cannot quietly stop being guarded.
 //
 // Each failure is one of two things, and they need opposite fixes:
 //   - the example does not represent a real credential -> fix the example
@@ -42,84 +54,86 @@ import (
 // Do NOT bulk-relax pattern_requirements to clear these. Those constraints
 // exist to suppress false positives; loosening them blindly trades a
 // false-negative problem for a false-positive one.
-var knownExampleFailures = map[string]string{
-	"kingfisher.airtable.2":     "1/1 examples fail at regex stage",
-	"kingfisher.contentful.1":   "1/3 examples fail at regex stage",
-	"kingfisher.contentful.2":   "1/4 examples fail at regex stage",
-	"kingfisher.curl.2":         "1/3 examples fail at regex stage",
-	"np.amplitude.1":            "1/2 examples fail at regex stage",
-	"np.cypress.1":              "1/3 examples fail at regex stage",
-	"np.redis.1":                "1/4 examples fail at regex stage",
-	"np.twitter.3":              "1/3 examples fail at regex stage",
-	"kingfisher.ai21studio.1":   "3/3 examples fail at postfilter stage",
-	"kingfisher.anypoint.1":     "1/1 examples fail at postfilter stage",
-	"kingfisher.asana.1":        "2/2 examples fail at postfilter stage",
-	"kingfisher.asana.2":        "1/2 examples fail at postfilter stage",
-	"kingfisher.azure.devops.1": "1/2 examples fail at postfilter stage",
-	"kingfisher.beamer.1":       "2/2 examples fail at postfilter stage",
-	"kingfisher.ciscomeraki.1":  "1/2 examples fail at postfilter stage",
-	"kingfisher.clojars.1":      "1/1 examples fail at postfilter stage",
-	"kingfisher.cloudflare.1":   "2/2 examples fail at postfilter stage",
-	"kingfisher.cloudflare.2":   "2/2 examples fail at postfilter stage",
-	"kingfisher.cloudsight.1":   "1/2 examples fail at postfilter stage",
-	"kingfisher.discord.3":      "2/2 examples fail at postfilter stage",
-	"kingfisher.filezilla.2":    "1/2 examples fail at postfilter stage",
-	"kingfisher.freshbooks.1":   "1/2 examples fail at postfilter stage",
-	"kingfisher.gocardless.1":   "1/2 examples fail at postfilter stage",
-	"kingfisher.imagekit.1":     "1/2 examples fail at postfilter stage",
-	"kingfisher.infracost.1":    "1/2 examples fail at postfilter stage",
-	"kingfisher.ipstack.1":      "1/2 examples fail at postfilter stage",
-	"kingfisher.jdbc.1":         "3/4 examples fail at postfilter stage",
-	"kingfisher.jira.1":         "2/2 examples fail at postfilter stage",
-	"kingfisher.lob.1":          "1/2 examples fail at postfilter stage",
-	"kingfisher.lob.2":          "1/2 examples fail at postfilter stage",
-	"kingfisher.mattermost.2":   "1/3 examples fail at postfilter stage",
-	"kingfisher.messagebird.1":  "1/2 examples fail at postfilter stage",
-	"kingfisher.mongodb.1":      "1/1 examples fail at postfilter stage",
-	"kingfisher.mongodb.2":      "1/1 examples fail at postfilter stage",
-	"kingfisher.mysql.1":        "1/2 examples fail at postfilter stage",
-	"kingfisher.openweather.1":  "2/4 examples fail at postfilter stage",
-	"kingfisher.planetscale.2":  "2/2 examples fail at postfilter stage",
-	"kingfisher.prefect.1":      "1/2 examples fail at postfilter stage",
-	"kingfisher.privkey.1":      "1/1 examples fail at postfilter stage",
-	"kingfisher.privkey.2":      "1/5 examples fail at postfilter stage",
-	"kingfisher.rabbitmq.1":     "2/4 examples fail at postfilter stage",
-	"kingfisher.recaptcha.1":    "3/3 examples fail at postfilter stage",
-	"kingfisher.runway.1":       "4/4 examples fail at postfilter stage",
-	"kingfisher.scalingo.1":     "1/2 examples fail at postfilter stage",
-	"kingfisher.scraperapi.1":   "1/2 examples fail at postfilter stage",
-	"kingfisher.sendbird.2":     "1/1 examples fail at postfilter stage",
-	"kingfisher.sentry.1":       "1/2 examples fail at postfilter stage",
-	"kingfisher.sentry.3":       "1/2 examples fail at postfilter stage",
-	"kingfisher.shippo.1":       "1/2 examples fail at postfilter stage",
-	"kingfisher.supabase.2":     "1/2 examples fail at postfilter stage",
-	"kingfisher.vercel.1":       "3/4 examples fail at postfilter stage",
+var knownExampleFailures = map[string]exampleBaseline{
+	"kingfisher.ai21studio.1":   {regex: nil, filter: []int{0, 1, 2}, total: 3},
+	"kingfisher.airtable.2":     {regex: []int{0}, filter: nil, total: 1},
+	"kingfisher.anypoint.1":     {regex: nil, filter: []int{0}, total: 1},
+	"kingfisher.asana.1":        {regex: nil, filter: []int{0, 1}, total: 2},
+	"kingfisher.asana.2":        {regex: nil, filter: []int{1}, total: 2},
+	"kingfisher.azure.devops.1": {regex: nil, filter: []int{0}, total: 2},
+	"kingfisher.beamer.1":       {regex: nil, filter: []int{0, 1}, total: 2},
+	"kingfisher.ciscomeraki.1":  {regex: nil, filter: []int{1}, total: 2},
+	"kingfisher.clojars.1":      {regex: nil, filter: []int{0}, total: 1},
+	"kingfisher.cloudflare.1":   {regex: nil, filter: []int{0, 1}, total: 2},
+	"kingfisher.cloudflare.2":   {regex: nil, filter: []int{0, 1}, total: 2},
+	"kingfisher.cloudsight.1":   {regex: nil, filter: []int{0}, total: 2},
+	"kingfisher.contentful.1":   {regex: []int{1}, filter: nil, total: 3},
+	"kingfisher.contentful.2":   {regex: []int{3}, filter: nil, total: 4},
+	"kingfisher.curl.2":         {regex: []int{0}, filter: nil, total: 3},
+	"kingfisher.discord.3":      {regex: nil, filter: []int{0, 1}, total: 2},
+	"kingfisher.filezilla.2":    {regex: nil, filter: []int{0}, total: 2},
+	"kingfisher.freshbooks.1":   {regex: nil, filter: []int{1}, total: 2},
+	"kingfisher.gocardless.1":   {regex: nil, filter: []int{1}, total: 2},
+	"kingfisher.imagekit.1":     {regex: nil, filter: []int{0}, total: 2},
+	"kingfisher.infracost.1":    {regex: nil, filter: []int{0}, total: 2},
+	"kingfisher.ipstack.1":      {regex: nil, filter: []int{1}, total: 2},
+	"kingfisher.jdbc.1":         {regex: nil, filter: []int{0, 2, 3}, total: 4},
+	"kingfisher.jira.1":         {regex: nil, filter: []int{0, 1}, total: 2},
+	"kingfisher.lob.1":          {regex: nil, filter: []int{1}, total: 2},
+	"kingfisher.lob.2":          {regex: nil, filter: []int{0}, total: 2},
+	"kingfisher.mattermost.2":   {regex: nil, filter: []int{0}, total: 3},
+	"kingfisher.messagebird.1":  {regex: nil, filter: []int{0}, total: 2},
+	"kingfisher.mongodb.1":      {regex: nil, filter: []int{0}, total: 1},
+	"kingfisher.mongodb.2":      {regex: nil, filter: []int{0}, total: 1},
+	"kingfisher.mysql.1":        {regex: nil, filter: []int{1}, total: 2},
+	"kingfisher.openweather.1":  {regex: nil, filter: []int{2, 3}, total: 4},
+	"kingfisher.planetscale.2":  {regex: nil, filter: []int{0, 1}, total: 2},
+	"kingfisher.prefect.1":      {regex: nil, filter: []int{1}, total: 2},
+	"kingfisher.privkey.1":      {regex: nil, filter: []int{0}, total: 1},
+	"kingfisher.privkey.2":      {regex: nil, filter: []int{4}, total: 5},
+	"kingfisher.rabbitmq.1":     {regex: nil, filter: []int{1, 3}, total: 4},
+	"kingfisher.recaptcha.1":    {regex: nil, filter: []int{0, 1, 2}, total: 3},
+	"kingfisher.runway.1":       {regex: nil, filter: []int{0, 1, 2, 3}, total: 4},
+	"kingfisher.scalingo.1":     {regex: nil, filter: []int{0}, total: 2},
+	"kingfisher.scraperapi.1":   {regex: nil, filter: []int{1}, total: 2},
+	"kingfisher.sendbird.2":     {regex: nil, filter: []int{0}, total: 1},
+	"kingfisher.sentry.1":       {regex: nil, filter: []int{0}, total: 2},
+	"kingfisher.sentry.3":       {regex: nil, filter: []int{0}, total: 2},
+	"kingfisher.shippo.1":       {regex: nil, filter: []int{1}, total: 2},
+	"kingfisher.supabase.2":     {regex: nil, filter: []int{1}, total: 2},
+	"kingfisher.vercel.1":       {regex: nil, filter: []int{0, 1, 3}, total: 4},
+	"np.amplitude.1":            {regex: []int{1}, filter: nil, total: 2},
+	"np.cypress.1":              {regex: []int{2}, filter: nil, total: 3},
+	"np.redis.1":                {regex: []int{3}, filter: nil, total: 4},
+	"np.twitter.3":              {regex: []int{1}, filter: nil, total: 3},
 }
 
-// exampleOutcome reports how many of a rule's examples survive the full
-// pipeline, and how many are lost at each stage.
-func exampleOutcome(t *testing.T, r *types.Rule) (lostToRegex, lostToFilter int) {
+// exampleOutcome reports which of a rule's examples fail, and at which stage.
+func exampleOutcome(t *testing.T, r *types.Rule) (regexFails, filterFails []int) {
 	t.Helper()
 	// 5s rather than the 500ms production default. The question here is whether
 	// a rule CAN detect its example, not whether it does so quickly on a loaded
-	// CI runner — a guard that passes on fast machines and fails on slow ones is
+	// CI runner -- a guard that passes on fast machines and fails on slow ones is
 	// worse than no guard. 5s is the matcher's own fallback timeout, so it is a
 	// generous ceiling rather than an arbitrary one.
 	m, err := NewPortableRegexpWithTimeout([]*types.Rule{r}, 0, nil, 5*time.Second)
 	if err != nil {
-		return len(r.Examples), 0
+		for i := range r.Examples {
+			regexFails = append(regexFails, i)
+		}
+		return regexFails, nil
 	}
-	for _, ex := range r.Examples {
+	for i, ex := range r.Examples {
 		ms, err := m.Match([]byte(ex))
 		if err != nil || len(ms) == 0 {
-			lostToRegex++
+			regexFails = append(regexFails, i)
 			continue
 		}
 		if len(filterMatches(ms, map[string]*types.Rule{r.ID: r})) == 0 {
-			lostToFilter++
+			filterFails = append(filterFails, i)
 		}
 	}
-	return lostToRegex, lostToFilter
+	return regexFails, filterFails
 }
 
 func rulesWithExamples(t *testing.T) []*types.Rule {
@@ -136,7 +150,7 @@ func rulesWithExamples(t *testing.T) []*types.Rule {
 	return out
 }
 
-// Every rule must detect the examples it documents.
+// Every rule not on the burn-down list must detect all of its own examples.
 //
 // This runs the FULL pipeline -- regex AND the entropy / pattern_requirements
 // post-filters -- because most failures do not happen at the regex stage. Of
@@ -148,33 +162,46 @@ func TestRuleExamples_AllRulesDetectTheirOwnExamples(t *testing.T) {
 		if _, known := knownExampleFailures[r.ID]; known {
 			continue
 		}
-		lostRegex, lostFilter := exampleOutcome(t, r)
-		if lostRegex > 0 || lostFilter > 0 {
-			t.Errorf("rule %q fails its own examples (%d unmatched by regex, %d dropped by post-filters).\n"+
+		rx, fl := exampleOutcome(t, r)
+		if len(rx) > 0 || len(fl) > 0 {
+			t.Errorf("rule %q fails its own examples (regex-unmatched indices %v, post-filtered indices %v).\n"+
 				"Either the example is not a real credential, or the rule's pattern/requirements exclude it. "+
-				"If this is a pre-existing failure being surfaced, add it to knownExampleFailures with a reason.",
-				r.ID, lostRegex, lostFilter)
+				"If this is a pre-existing failure being surfaced, add a baseline to knownExampleFailures.",
+				r.ID, rx, fl)
 		}
 	}
 }
 
-// A rule on the known-failures list that now passes must be removed from it.
+// A listed rule must fail EXACTLY the examples its baseline records.
 //
-// Without this the list rots: a rule gets fixed, its entry lingers, and that
-// rule silently stops being guarded by the test above.
-func TestRuleExamples_KnownFailuresStillFail(t *testing.T) {
+// Allowlisting a rule ID alone would drop every one of its examples from
+// coverage, including the ones that currently pass -- kingfisher.jdbc.1 fails 3
+// of 4. Comparing exact indices keeps the passing example guarded, and means a
+// fixed failure cannot be exchanged for a new one without the test noticing.
+func TestRuleExamples_KnownFailuresMatchBaseline(t *testing.T) {
 	byID := map[string]*types.Rule{}
 	for _, r := range rulesWithExamples(t) {
 		byID[r.ID] = r
 	}
-	for id := range knownExampleFailures {
+	for id, want := range knownExampleFailures {
 		r, ok := byID[id]
 		if !ok {
 			t.Errorf("knownExampleFailures lists %q, which no longer exists or has no examples — remove the entry", id)
 			continue
 		}
-		lostRegex, lostFilter := exampleOutcome(t, r)
-		if lostRegex == 0 && lostFilter == 0 {
+		if len(r.Examples) != want.total {
+			t.Errorf("rule %q now has %d examples, baseline recorded %d — indices have shifted, re-baseline the entry",
+				id, len(r.Examples), want.total)
+			continue
+		}
+		rx, fl := exampleOutcome(t, r)
+		assert.Equalf(t, want.regex, rx,
+			"rule %q: regex-stage failures changed. If examples were fixed, delete or update the entry; "+
+				"if a passing example regressed, that is a new detection gap.", id)
+		assert.Equalf(t, want.filter, fl,
+			"rule %q: post-filter failures changed. If examples were fixed, delete or update the entry; "+
+				"if a passing example regressed, that is a new detection gap.", id)
+		if len(rx) == 0 && len(fl) == 0 {
 			t.Errorf("rule %q now detects all its examples — delete its line from knownExampleFailures", id)
 		}
 	}

--- a/pkg/rule/rules/mongodb.yml
+++ b/pkg/rule/rules/mongodb.yml
@@ -27,9 +27,20 @@ rules:
       \b
     pattern_requirements:
       min_digits: 2
-      min_uppercase: 1
       min_lowercase: 1
-    min_entropy: 3.7
+      # No min_uppercase: Atlas renders private keys as LOWERCASE hex UUIDs
+      # (e.g. 2c130c23-e6b6-4da8-a93f-a8bf33218830), so requiring an uppercase
+      # character matched only the minority containing an uppercase A-F -- this
+      # rule missed the documented format entirely (LAB-6096).
+    # 3.3, not 3.7. Atlas private keys are random lowercase-hex UUIDs, whose
+    # Shannon entropy averages 3.71 -- so a 3.7 floor rejected 43% of all valid
+    # keys (measured over 200k generated UUIDs). 3.3 admits 99.9% of them.
+    #
+    # Entropy adds little here anyway: the pattern already requires mongodb/atlas
+    # context, a private/secret/key keyword, and the full UUID structure, so it
+    # is specific without this. Raising it trades real detections for very
+    # little false-positive reduction (LAB-6096).
+    min_entropy: 3.3
     examples:
       - ATLAS_PRIVATE_KEY=4b18315e-6b7d-4337-b449-5d38f5a189ec
     validation:
@@ -73,7 +84,10 @@ rules:
     confidence: medium
     visible: false
     examples:
-      - 'mongodb-public: qj4Zrh8e6A'
+      # An Atlas public key is 8 lowercase letters. The previous example,
+      # 'qj4Zrh8e6A', was not Atlas-shaped: the capture stops at the first digit,
+      # yielding 'qj', which then fell below min_entropy (LAB-6096).
+      - 'mongodb-public: yhltsvan'
   - name: MongoDB URI Connection String
     id: kingfisher.mongodb.3
     base_score: 85

--- a/pkg/scoring/mongodb_atlas.go
+++ b/pkg/scoring/mongodb_atlas.go
@@ -2,26 +2,61 @@ package scoring
 
 import (
 	"context"
+	"regexp"
 
 	"github.com/praetorian-inc/titus/pkg/types"
 )
 
+// atlasPublicKeyPatterns recover an Atlas programmatic public key from the
+// context surrounding a private key match.
+//
+// An Atlas public key is 8 lowercase letters (e.g. "yhltsvan"), paired with a
+// lowercase-UUID private key. Every pattern therefore requires mongodb/atlas or
+// an explicit public-key label: [a-z]{8} on its own matches ordinary prose, and
+// an unanchored version would pair the private key with any nearby word.
+//
+// The third form covers `curl --user "{PUBLIC}:{PRIVATE}" --digest`, which is
+// how the Atlas documentation demonstrates every API call and which places both
+// halves adjacent.
+var atlasPublicKeyPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)(?:mongodb|atlas)[_\-.]?(?:public|pub)(?:[_\-.]?key)?\s*[=:]\s*["']?([a-z]{8})\b`),
+	regexp.MustCompile(`(?i)\bpublic[_\-.]?key\s*[=:]\s*["']?([a-z]{8})\b`),
+	regexp.MustCompile(`--user\s+["']?([a-z]{8}):`),
+}
+
 // extractAtlasDigestCredentials extracts the public and private key pair used
 // for kingfisher.mongodb.1 digest authentication.
 //
-// The private key is the main matched secret (Snippet.Matching).
-// The public key is expected in NamedGroups["PUBKEY"] — populated by the
-// depends_on_rule mechanism declared in the rule YAML.
+// The private key is the main matched secret (Snippet.Matching). The public key
+// is a SEPARATE rule's match (kingfisher.mongodb.2), so it can never appear in
+// this match's NamedGroups: the matcher populates those only from the matching
+// rule's own regex, and mongodb.yml declares no named capture groups.
+//
+// This previously read NamedGroups["PUBKEY"], described in the rule YAML as
+// populated by depends_on_rule. No Go code parses depends_on_rule, so the key
+// was never present and the digest path never produced credentials -- silently,
+// since buildAtlasClient returns nil and the condition then reports (false, nil)
+// with no error, warning or stat (LAB-6095).
+//
+// Pairing from the snippet is how every other split credential in this repo is
+// handled: see pkg/validator/helpscout.go for a client ID, and the AWS session
+// token extraction in pkg/scoring/aws.go.
 func extractAtlasDigestCredentials(m *types.Match) (pubKey, privKey string, ok bool) {
 	if m == nil {
 		return "", "", false
 	}
-	pub, hasPub := m.NamedGroups["PUBKEY"]
 	priv := m.Snippet.Matching
-	if !hasPub || len(pub) == 0 || len(priv) == 0 {
+	if len(priv) == 0 {
 		return "", "", false
 	}
-	return string(pub), string(priv), true
+	for _, part := range [][]byte{m.Snippet.Before, m.Snippet.Matching, m.Snippet.After} {
+		for _, re := range atlasPublicKeyPatterns {
+			if sub := re.FindSubmatch(part); len(sub) >= 2 && len(sub[1]) > 0 {
+				return string(sub[1]), string(priv), true
+			}
+		}
+	}
+	return "", "", false
 }
 
 // extractAtlasServiceAccountToken extracts the bearer token used for

--- a/pkg/scoring/mongodb_atlas.go
+++ b/pkg/scoring/mongodb_atlas.go
@@ -1,6 +1,7 @@
 package scoring
 
 import (
+	"bytes"
 	"context"
 	"regexp"
 
@@ -24,13 +25,43 @@ var atlasPublicKeyPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`--user\s+["']?([a-z]{8}):`),
 }
 
+// atlasPrivateKeyPattern is the UUID an Atlas private key consists of.
+var atlasPrivateKeyPattern = regexp.MustCompile(`(?i)\b[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}\b`)
+
+// atlasPrivateKey returns the private key UUID from a kingfisher.mongodb.1 match.
+//
+// It is NOT Snippet.Matching. That field holds the whole matched span, and the
+// rule's pattern deliberately spans from the mongodb/atlas keyword through the
+// private-key label to the UUID, so Matching looks like
+//
+//	ATLAS_PUBLIC_KEY=yhltsvan\nATLAS_PRIVATE_KEY=2c130c23-...-a8bf33218830
+//
+// Using it directly would authenticate with that entire blob as the password.
+//
+// Groups holds the positional captures with the full match already stripped
+// (extractCaptureGroups starts at index 1), so the rule's single capture lands
+// at Groups[0]. The UUID shape is verified rather than assumed, and the matched
+// span is searched as a fallback, so this cannot silently pick up the wrong
+// value if capture indexing differs between matcher backends.
+func atlasPrivateKey(m *types.Match) string {
+	for _, g := range m.Groups {
+		if v := atlasPrivateKeyPattern.Find(g); v != nil {
+			return string(v)
+		}
+	}
+	if v := atlasPrivateKeyPattern.Find(m.Snippet.Matching); v != nil {
+		return string(v)
+	}
+	return ""
+}
+
 // extractAtlasDigestCredentials extracts the public and private key pair used
 // for kingfisher.mongodb.1 digest authentication.
 //
-// The private key is the main matched secret (Snippet.Matching). The public key
-// is a SEPARATE rule's match (kingfisher.mongodb.2), so it can never appear in
-// this match's NamedGroups: the matcher populates those only from the matching
-// rule's own regex, and mongodb.yml declares no named capture groups.
+// The public key is a SEPARATE rule's match (kingfisher.mongodb.2), so it can
+// never appear in this match's NamedGroups: the matcher populates those only
+// from the matching rule's own regex, and mongodb.yml declares no named capture
+// groups.
 //
 // This previously read NamedGroups["PUBKEY"], described in the rule YAML as
 // populated by depends_on_rule. No Go code parses depends_on_rule, so the key
@@ -41,22 +72,53 @@ var atlasPublicKeyPatterns = []*regexp.Regexp{
 // Pairing from the snippet is how every other split credential in this repo is
 // handled: see pkg/validator/helpscout.go for a client ID, and the AWS session
 // token extraction in pkg/scoring/aws.go.
+//
+// When several credential pairs sit within the same snippet, the public key
+// NEAREST the private key wins, preferring one that precedes it. Taking the
+// first match in the context would pair a private key with an earlier,
+// unrelated public key and authenticate with a mismatched pair.
 func extractAtlasDigestCredentials(m *types.Match) (pubKey, privKey string, ok bool) {
 	if m == nil {
 		return "", "", false
 	}
-	priv := m.Snippet.Matching
-	if len(priv) == 0 {
+	priv := atlasPrivateKey(m)
+	if priv == "" {
 		return "", "", false
 	}
-	for _, part := range [][]byte{m.Snippet.Before, m.Snippet.Matching, m.Snippet.After} {
-		for _, re := range atlasPublicKeyPatterns {
-			if sub := re.FindSubmatch(part); len(sub) >= 2 && len(sub[1]) > 0 {
-				return string(sub[1]), string(priv), true
+
+	// Reassemble the contiguous context so candidate positions are comparable.
+	ctx := make([]byte, 0, len(m.Snippet.Before)+len(m.Snippet.Matching)+len(m.Snippet.After))
+	ctx = append(ctx, m.Snippet.Before...)
+	ctx = append(ctx, m.Snippet.Matching...)
+	ctx = append(ctx, m.Snippet.After...)
+
+	privPos := bytes.Index(ctx, []byte(priv))
+	if privPos < 0 {
+		privPos = len(m.Snippet.Before)
+	}
+
+	best, bestDist := "", -1
+	for _, re := range atlasPublicKeyPatterns {
+		for _, loc := range re.FindAllSubmatchIndex(ctx, -1) {
+			if len(loc) < 4 || loc[2] < 0 {
+				continue
+			}
+			cand := string(ctx[loc[2]:loc[3]])
+			dist := privPos - loc[3]
+			if dist < 0 {
+				// Candidate follows the private key: same distance measure, but
+				// preferred only when nothing precedes it.
+				dist = (loc[2] - privPos) + 1
+			}
+			if bestDist < 0 || dist < bestDist {
+				best, bestDist = cand, dist
 			}
 		}
 	}
-	return "", "", false
+	if best == "" {
+		return "", "", false
+	}
+	return best, priv, true
 }
 
 // extractAtlasServiceAccountToken extracts the bearer token used for

--- a/pkg/scoring/mongodb_atlas_pairing_test.go
+++ b/pkg/scoring/mongodb_atlas_pairing_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/praetorian-inc/titus/pkg/matcher"
+	"github.com/praetorian-inc/titus/pkg/rule"
 	"github.com/praetorian-inc/titus/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,13 +14,29 @@ import (
 // atlasMatch builds a match shaped as the matcher produces one: the private key
 // is Snippet.Matching, NamedGroups is empty (mongodb.yml has no named capture
 // groups), and the public key lives in the surrounding context if anywhere.
-func atlasMatch(before, priv, after string) *types.Match {
+// atlasMatch builds a kingfisher.mongodb.1 match the way the MATCHER builds one.
+//
+// This is deliberately not the obvious shape. Snippet.Matching holds the whole
+// matched span -- the rule spans from the mongodb/atlas keyword through the
+// private-key label to the UUID -- while Groups[0] holds the captured UUID
+// alone. An earlier version of this helper put the bare UUID in Matching, which
+// is a state the matcher never produces, and it hid a bug where the entire span
+// was returned as the private key.
+//
+// matched is the text the rule matches; the UUID inside it is the capture.
+func atlasMatch(before, matched, after string) *types.Match {
+	uuid := atlasPrivateKeyPattern.FindString(matched)
+	var groups [][]byte
+	if uuid != "" {
+		groups = [][]byte{[]byte(uuid)}
+	}
 	return &types.Match{
 		RuleID:      "kingfisher.mongodb.1",
 		NamedGroups: map[string][]byte{},
+		Groups:      groups,
 		Snippet: types.Snippet{
 			Before:   []byte(before),
-			Matching: []byte(priv),
+			Matching: []byte(matched),
 			After:    []byte(after),
 		},
 	}
@@ -92,3 +110,64 @@ func TestBuiltinAtlasScorer_DigestModifierGetsCredentials(t *testing.T) {
 
 // stubAtlasAPI satisfies atlasAPI without making network calls.
 type stubAtlasAPI struct{ atlasAPI }
+
+// The private key is the UUID, not the whole matched span.
+//
+// The rule's pattern spans from the mongodb/atlas keyword to the UUID, so
+// Snippet.Matching contains labels, separators and possibly the public key too.
+// Returning it would authenticate with that entire blob as the password.
+func TestAtlasDigest_PrivateKeyIsTheUUIDNotTheWholeSpan(t *testing.T) {
+	m := atlasMatch("", "ATLAS_PUBLIC_KEY=yhltsvan\nATLAS_PRIVATE_KEY="+atlasPriv, "\n")
+	pub, priv, ok := extractAtlasDigestCredentials(m)
+	require.True(t, ok)
+	assert.Equal(t, atlasPub, pub)
+	assert.Equal(t, atlasPriv, priv, "must be the UUID alone, not the matched span")
+	assert.NotContains(t, priv, "ATLAS_", "the label must not leak into the credential")
+}
+
+// With several pairs in one snippet, the private key must be paired with the
+// public key NEAREST it, not the first one in the context.
+func TestAtlasDigest_MultiplePairs_PicksNearestPublicKey(t *testing.T) {
+	const otherPub = "abcdefgh"
+	before := "ATLAS_PUBLIC_KEY=" + otherPub + "\n" +
+		"ATLAS_PRIVATE_KEY=11111111-2222-3333-4444-555555555555\n" +
+		"ATLAS_PUBLIC_KEY=" + atlasPub + "\n"
+	m := atlasMatch(before, "ATLAS_PRIVATE_KEY="+atlasPriv, "\n")
+
+	pub, priv, ok := extractAtlasDigestCredentials(m)
+	require.True(t, ok)
+	assert.Equal(t, atlasPriv, priv)
+	assert.Equal(t, atlasPub, pub, "must pair with the nearest preceding public key, not the first")
+	assert.NotEqual(t, otherPub, pub)
+}
+
+// End-to-end against the REAL matcher, not a hand-built match.
+//
+// Every earlier bug in this area survived because fixtures described a match
+// the matcher never produces -- NamedGroups["PUBKEY"] populated, or the bare
+// UUID in Snippet.Matching. This test takes the shape from the matcher itself,
+// so a fixture assumption cannot hide a defect.
+func TestAtlasDigest_AgainstRealMatcherOutput(t *testing.T) {
+	rules, err := rule.NewLoader().LoadBuiltinRules()
+	require.NoError(t, err)
+	var atlasRule *types.Rule
+	for _, r := range rules {
+		if r.ID == "kingfisher.mongodb.1" {
+			atlasRule = r
+		}
+	}
+	require.NotNil(t, atlasRule)
+
+	mm, err := matcher.NewPortableRegexp([]*types.Rule{atlasRule}, 3, nil)
+	require.NoError(t, err)
+
+	input := "ATLAS_PUBLIC_KEY=" + atlasPub + "\nATLAS_PRIVATE_KEY=" + atlasPriv + "\n"
+	matches, err := mm.Match([]byte(input))
+	require.NoError(t, err)
+	require.NotEmpty(t, matches, "the rule must detect a realistic Atlas key pair")
+
+	pub, priv, ok := extractAtlasDigestCredentials(matches[0])
+	require.True(t, ok, "digest credentials must be recoverable from a real match")
+	assert.Equal(t, atlasPub, pub)
+	assert.Equal(t, atlasPriv, priv)
+}

--- a/pkg/scoring/mongodb_atlas_pairing_test.go
+++ b/pkg/scoring/mongodb_atlas_pairing_test.go
@@ -1,0 +1,94 @@
+package scoring
+
+import (
+	"context"
+	"testing"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// atlasMatch builds a match shaped as the matcher produces one: the private key
+// is Snippet.Matching, NamedGroups is empty (mongodb.yml has no named capture
+// groups), and the public key lives in the surrounding context if anywhere.
+func atlasMatch(before, priv, after string) *types.Match {
+	return &types.Match{
+		RuleID:      "kingfisher.mongodb.1",
+		NamedGroups: map[string][]byte{},
+		Snippet: types.Snippet{
+			Before:   []byte(before),
+			Matching: []byte(priv),
+			After:    []byte(after),
+		},
+	}
+}
+
+const (
+	atlasPriv = "2c130c23-e6b6-4da8-a93f-a8bf33218830"
+	atlasPub  = "yhltsvan"
+)
+
+// The public key sits in the config above the private key -- the common shape.
+func TestAtlasDigest_PairsPublicKeyFromContextBefore(t *testing.T) {
+	m := atlasMatch("ATLAS_PUBLIC_KEY=yhltsvan\nATLAS_PRIVATE_KEY=", atlasPriv, "\n")
+	pub, priv, ok := extractAtlasDigestCredentials(m)
+	require.True(t, ok, "should pair the public key from preceding context")
+	assert.Equal(t, atlasPub, pub)
+	assert.Equal(t, atlasPriv, priv)
+}
+
+// ...or below it.
+func TestAtlasDigest_PairsPublicKeyFromContextAfter(t *testing.T) {
+	m := atlasMatch("atlas_private_key: ", atlasPriv, "\natlas_public_key: yhltsvan\n")
+	pub, _, ok := extractAtlasDigestCredentials(m)
+	require.True(t, ok)
+	assert.Equal(t, atlasPub, pub)
+}
+
+// The curl digest form puts both keys adjacent, and is how the Atlas docs
+// demonstrate every API call.
+func TestAtlasDigest_PairsFromCurlUserForm(t *testing.T) {
+	m := atlasMatch(`curl --user "yhltsvan:`, atlasPriv, `" --digest -X GET https://cloud.mongodb.com/api/atlas/v2/groups`)
+	pub, _, ok := extractAtlasDigestCredentials(m)
+	require.True(t, ok)
+	assert.Equal(t, atlasPub, pub)
+}
+
+// A bare 8-letter word nearby is not a public key. The patterns must require
+// mongodb/atlas/public context, because [a-z]{8} alone matches ordinary prose.
+func TestAtlasDigest_DoesNotPairUnrelatedWords(t *testing.T) {
+	m := atlasMatch("// deployed absolute controls\nprivate_key = ", atlasPriv, "\n")
+	_, _, ok := extractAtlasDigestCredentials(m)
+	assert.False(t, ok, "an unanchored 8-letter word must not be taken for a public key")
+}
+
+// No public key anywhere: still no credentials, but now that is a real absence
+// rather than a mechanism that never worked.
+func TestAtlasDigest_NoPublicKeyInContext(t *testing.T) {
+	m := atlasMatch("ATLAS_PRIVATE_KEY=", atlasPriv, "\n")
+	_, _, ok := extractAtlasDigestCredentials(m)
+	assert.False(t, ok)
+}
+
+// The shipped scorer's dynamic modifier must be able to obtain credentials from
+// a realistic match. This is the check whose absence let the defect ship: the
+// digest path returned (false, nil) -- no error, no warning, no stat.
+func TestBuiltinAtlasScorer_DigestModifierGetsCredentials(t *testing.T) {
+	m := atlasMatch("ATLAS_PUBLIC_KEY=yhltsvan\nATLAS_PRIVATE_KEY=", atlasPriv, "\n")
+
+	var gotAuth, gotPub, gotPriv string
+	client := buildAtlasClient(context.Background(), m,
+		func(_ context.Context, authType string, creds map[string]string) (atlasAPI, error) {
+			gotAuth, gotPub, gotPriv = authType, creds["publicKey"], creds["privateKey"]
+			return stubAtlasAPI{}, nil
+		})
+
+	require.NotNil(t, client, "digest path must produce a client; nil means credentials were never assembled")
+	assert.Equal(t, "digest", gotAuth)
+	assert.Equal(t, atlasPub, gotPub)
+	assert.Equal(t, atlasPriv, gotPriv)
+}
+
+// stubAtlasAPI satisfies atlasAPI without making network calls.
+type stubAtlasAPI struct{ atlasAPI }

--- a/pkg/scoring/mongodb_atlas_test.go
+++ b/pkg/scoring/mongodb_atlas_test.go
@@ -15,18 +15,22 @@ import (
 // ---------------------------------------------------------------------------
 
 func TestExtractAtlasDigestCredentials_BothPresent(t *testing.T) {
+	// This previously supplied NamedGroups["PUBKEY"], a state the matcher cannot
+	// produce: NamedGroups comes only from the matching rule's own regex, and
+	// mongodb.yml declares no named capture groups. The fixture made a mechanism
+	// that never worked look tested (LAB-6095). The public key now comes from the
+	// snippet, which is where it actually is.
 	m := &types.Match{
-		NamedGroups: map[string][]byte{
-			"PUBKEY": []byte("MYPUBKEY"),
-		},
+		NamedGroups: map[string][]byte{},
 		Snippet: types.Snippet{
-			Matching: []byte("privkey-uuid"),
+			Before:   []byte("ATLAS_PUBLIC_KEY=yhltsvan\nATLAS_PRIVATE_KEY="),
+			Matching: []byte("2c130c23-e6b6-4da8-a93f-a8bf33218830"),
 		},
 	}
 	pubKey, privKey, ok := extractAtlasDigestCredentials(m)
 	assert.True(t, ok)
-	assert.Equal(t, "MYPUBKEY", pubKey)
-	assert.Equal(t, "privkey-uuid", privKey)
+	assert.Equal(t, "yhltsvan", pubKey)
+	assert.Equal(t, "2c130c23-e6b6-4da8-a93f-a8bf33218830", privKey)
 }
 
 func TestExtractAtlasDigestCredentials_MissingPubKey(t *testing.T) {
@@ -102,14 +106,21 @@ func fakeAtlasFactory(api atlasAPI) atlasClientFactory {
 	}
 }
 
+// atlasDigestTestMatch builds a kingfisher.mongodb.1 match shaped as the
+// matcher actually produces one: NamedGroups empty (mongodb.yml declares no
+// named capture groups) and the public key present only in the surrounding
+// context.
+//
+// It previously supplied NamedGroups["PUBKEY"], which the matcher can never
+// populate. Every test built on this fixture therefore exercised a code path
+// that could not run in production (LAB-6095).
 func atlasDigestTestMatch() *types.Match {
 	return &types.Match{
-		RuleID: "kingfisher.mongodb.1",
-		NamedGroups: map[string][]byte{
-			"PUBKEY": []byte("MYPUBLICKEY"),
-		},
+		RuleID:      "kingfisher.mongodb.1",
+		NamedGroups: map[string][]byte{},
 		Snippet: types.Snippet{
-			Matching: []byte("4b18315e-6b7d-4337-b449-5d38f5a189ec"),
+			Before:   []byte("ATLAS_PUBLIC_KEY=yhltsvan\nATLAS_PRIVATE_KEY="),
+			Matching: []byte("2c130c23-e6b6-4da8-a93f-a8bf33218830"),
 		},
 	}
 }


### PR DESCRIPTION
Closes LAB-6095. Refs LAB-6096.

Three linked defects meant MongoDB Atlas API keys were barely detected, and were never scored even when they were.

## 1. Detection — `kingfisher.mongodb.1` missed ~all real keys

`min_uppercase: 1` cannot be satisfied by the documented format. Atlas renders private keys as **lowercase** hex UUIDs, so the rule fired only on the minority containing an uppercase `A-F`. It did not match its own example.

**Removing that alone was not enough**, which is the part I did not expect. `min_entropy: 3.7` sits almost exactly on the mean Shannon entropy of a random lowercase-hex UUID:

| min_entropy | Valid Atlas keys accepted |
| -- | -- |
| **3.7 (before)** | **56.8%** |
| 3.5 | 95.3% |
| **3.3 (after)** | **99.9%** |

Measured over 200,000 generated UUIDs. The threshold was rejecting **43% of all valid keys**. Dropping `min_uppercase` alone would have moved this rule from "almost never fires" to "coin flip" — and I would have reported it as fixed.

Entropy was contributing little regardless: the pattern already requires mongodb/atlas context, a `private`/`secret`/`key` keyword, and the full UUID structure.

Verified end to end — all three now detected, where the second previously missed by **0.003** of entropy:

| Key | Before | After |
| -- | -- | -- |
| `4b18315e-…` (the rule’s own example) | ✗ | ✓ |
| `2c130c23-…` (from MongoDB’s integration docs) | ✗ | ✓ |
| `8f2a1b3c-…` (arbitrary UUID) | ✗ | ✓ |

## 2. Detection — `kingfisher.mongodb.2`: the example was wrong, not the rule

The opposite diagnosis, and why LAB-6096 warns these need opposite fixes. `qj4Zrh8e6A` is not Atlas-shaped — a real public key is 8 lowercase letters. The capture stops at the first digit, yielding `qj`, which then falls below `min_entropy`. Example replaced; **pattern unchanged**.

## 3. Scoring — the digest path never ran

`extractAtlasDigestCredentials` read `NamedGroups["PUBKEY"]`, described in the rule YAML as populated by `depends_on_rule`. **No Go code parses `depends_on_rule`**, and `NamedGroups` carries only the matching rule’s own captures — so the public key was never there.

It failed invisibly: `buildAtlasClient` returns nil, the condition reports `(false, nil)`. No error, no warning, no stat. Both `atlas-org-admin` and `atlas-project-read-only` have never fired.

The public key now comes from the snippet, as `helpscout.go` does for its client ID and `aws.go` for session tokens. Patterns are anchored on mongodb/atlas/public context — `[a-z]{8}` alone matches ordinary prose — and one covers the `curl --user "{PUBLIC}:{PRIVATE}" --digest` form the Atlas docs use for every call.

## Tests

`atlasDigestTestMatch` supplied `NamedGroups["PUBKEY"]`, a state the matcher cannot produce, so every test built on it exercised a path that could not run in production. Rebuilt around realistic matches.

**This is the fourth fixture in this package found to make broken code look tested** — after the SendGrid scope string, the Full Access scoring bug, and the Google dynamic path. Worth weighing when reviewing the remaining assertions here.

## Burn-down

Both mongodb rules are removed from the LAB-6096 list: **51 → 49**. First exercise of that mechanism, and it behaved as intended — the guard failed until the rules genuinely passed.

## Note on the second commit

This branch also carries `7c097a9`, which was **reviewed on #329 but not included in its merge** (#329 merged `bb04214c` only). It addresses the review point that allowlisting a rule ID drops its still-passing examples from coverage; baselines now record failing example indices. Without it, that fix is absent from `main`.

## Testing

`go build ./...`, `go test ./...`, `go vet ./...`, `golangci-lint run ./...`, `make test-race` (full suite, CGO), `make score-lint` — all green.