### PR TITLE
fix(rules): remove catastrophic backtracking from np.phpmailer.1 (LAB-6097)

### DIFF
--- a/pkg/matcher/rule_examples_test.go
+++ b/pkg/matcher/rule_examples_test.go
@@ -1,17 +1,14 @@
-//go:build !race
-
-// This guard is excluded from -race builds on purpose.
+// This guard deliberately runs under -race as well as normally.
 //
-// It measures rule semantics -- can a rule detect the example it documents --
-// and contains no concurrency, so the race detector has nothing to find here.
-// What it does do is slow execution by roughly an order of magnitude, which
-// pushes patterns that nest quantifiers over .* past any sane match timeout.
-// np.phpmailer.1 exceeds even 30s under -race while passing comfortably in a
-// normal run. Left in, this guard would fail the Race Detector job for reasons
-// unrelated to correctness.
+// It carried //go:build !race until LAB-6097. np.phpmailer.1 nested quantifiers
+// over .*, which cost ~3s per match normally and exceeded 30s under -race,
+// where instrumentation is roughly an order of magnitude slower. Excluding the
+// guard was the wrong way round: the slowness was the bug, not the test.
 //
-// np.phpmailer.1's backtracking cost deserves attention in its own right; it is
-// not something this test should paper over, nor be blocked by.
+// Running under -race now earns something specific. A pattern that reintroduces
+// catastrophic backtracking will blow the match timeout there long before it
+// does in a normal run, so the Race Detector job doubles as a cheap budget
+// check on rule patterns -- no brittle timing assertion required.
 
 package matcher
 

--- a/pkg/rule/rules/phpmailer.yml
+++ b/pkg/rule/rules/phpmailer.yml
@@ -4,12 +4,24 @@ rules:
   id: np.phpmailer.1
   base_score: 60
 
+  # The filler between fields is "up to 3 whole lines", written so there is
+  # exactly ONE way to divide any given span.
+  #
+  # It was previously `(?: \s* .* \s* ){0,3}`. \s* and .* overlap, so a bounded
+  # repetition of them gives the engine a combinatorial number of equivalent
+  # ways to split the same text, and two such groups multiply. Matching one
+  # 774-byte example took 2.94s under the production 500ms timeout -- succeeding
+  # only via the retry path -- and exceeded 30s under -race.
+  #
+  # [^\S\n] is horizontal whitespace only and [^\n]*\n consumes exactly one line
+  # per iteration, so no two parses of the same span are possible. Same example:
+  # 5.80s -> 23us across both examples (LAB-6097).
   pattern: |
     (?x)
     \$mail->Host     \s* = \s* '([^'\n]{5,})'; \s* (?: //.* )?
-    (?: \s* .* \s* ){0,3}
+    [^\S\n]* \n? (?: [^\n]*\n ){0,3} [^\S\n]*
     \$mail->Username \s* = \s* '([^'\n]{5,})'; \s* (?: //.* )?
-    (?: \s* .* \s* ){0,3}
+    [^\S\n]* \n? (?: [^\n]*\n ){0,3} [^\S\n]*
     \$mail->Password \s* = \s* '([^'\n]{5,})';
 
   categories: [fuzzy, secret]

--- a/pkg/rule/rules/phpmailer.yml
+++ b/pkg/rule/rules/phpmailer.yml
@@ -18,9 +18,9 @@ rules:
   # 5.80s -> 23us across both examples (LAB-6097).
   pattern: |
     (?x)
-    \$mail->Host     \s* = \s* '([^'\n]{5,})'; \s* (?: //.* )?
+    \$mail->Host     \s* = \s* '([^'\n]{5,})'; [^\S\n]* (?: //.* )?
     [^\S\n]* \n? (?: [^\n]*\n ){0,3} [^\S\n]*
-    \$mail->Username \s* = \s* '([^'\n]{5,})'; \s* (?: //.* )?
+    \$mail->Username \s* = \s* '([^'\n]{5,})'; [^\S\n]* (?: //.* )?
     [^\S\n]* \n? (?: [^\n]*\n ){0,3} [^\S\n]*
     \$mail->Password \s* = \s* '([^'\n]{5,})';
 


### PR DESCRIPTION
Closes LAB-6097. Found while adding the rule-examples guard in #329, where this was the only rule that could not run under `-race`.

## The cost

The filler between fields was `(?: \s* .* \s* ){0,3}`, twice. `\s*` and `.*` overlap, so a bounded repetition of them gives the engine a combinatorial number of equivalent ways to divide the same span — and two such groups multiply.

Measured through the **production** constructor (`NewPortableRegexp`, 500ms initial timeout):

| Input | Before | After |
| -- | -- | -- |
| Example 0 (774 bytes) | **2.94s** | **45µs** |
| Example 1 (689 bytes) | **1.55s** | **9µs** |

The cost fell on the **matching** path, not the failing one — so it was paid on real findings, exactly when the scan is doing useful work.

**2.94s is not merely slow.** The production match timeout has been 500ms since #318, so every PHPMailer match blew that budget and succeeded only via the retry path (10× the timeout, capped at 30s). A slightly larger block would have exceeded even that cap and been **dropped** — a false negative appearing only under load or on big files, and near-impossible to reproduce.

## The fix

```
[^\S\n]* \n? (?: [^\n]*\n ){0,3} [^\S\n]*
```

Same "up to 3 lines" intent, but with exactly **one** possible parse of any span: `[^\S\n]` is horizontal whitespace only, and `[^\n]*\n` consumes exactly one line per iteration.

I also measured `\s* (?: [^\n]*\n \s* ){0,3}`, which is similarly fast today (33µs) — but it keeps `\s*` inside the repetition, retaining the ambiguity that caused this in the first place. Determinism was the point, not the benchmark.

## The part worth reviewing

This removes `//go:build !race` from the rule-examples guard, which existed solely because of this rule. That exclusion was the wrong way round — **the slowness was the bug, not the test**.

Running the guard under `-race` now earns something concrete: instrumentation is ~10× slower, so a pattern that reintroduces catastrophic backtracking blows the match timeout there long before it does in a normal run.

**Verified rather than asserted.** Reverting this pattern with the guard un-excluded:

```
--- FAIL: TestRuleExamples_AllRulesDetectTheirOwnExamples (10.29s)
    rule "np.phpmailer.1" fails its own examples (regex-unmatched indices [0 1], ...)
```

and green again when restored (1.46s). **The Race Detector job is now a backtracking budget check** — no brittle timing assertion needed.

## Testing

`go build ./...`, `go test ./...`, `go vet ./...`, `golangci-lint run ./...`, `make test-race` (full suite, CGO), `make score-lint` — all green. Guard under `-race` went from *excluded* to passing in 0.27s.

End-to-end: a realistic PHPMailer config block is still detected by the CLI.

## Follow-up worth considering

Other rules may share this shape. A sweep for `.*` or `\s*` inside a bounded repetition across the ruleset would find them — and with the guard now running under `-race`, any that are pathological should surface there.