### PR TITLE
fix(rules): name secret capture in 3 multi-capture rules

### DIFF
--- a/pkg/matcher/postfilter.go
+++ b/pkg/matcher/postfilter.go
@@ -14,9 +14,14 @@ const defaultSpecialChars = "!@#$%^&*()_+-=[]{}|;:'\",.<>?/\\`~"
 // findSecretCapture selects which capture group represents the secret value.
 // Priority (matching Kingfisher):
 //  1. Named capture called "TOKEN" (case-insensitive)
-//  2. First named capture in NamedGroups
-//  3. Groups[1] (first positional capture)
-//  4. Groups[0] (full match)
+//  2. Highest-entropy named capture in NamedGroups
+//  3. Groups[1] (second positional capture — index 0 is the first capture,
+//     NOT the full match; both backends strip the full match at index 0)
+//  4. Groups[0] (first positional capture)
+//
+// For rules with 3+ captures that lack named groups, step 3 picks the SECOND
+// capture, which is often a username or context field rather than the secret.
+// Fix: name the secret capture "token" so step 1 selects it. See LAB-6101.
 func findSecretCapture(m *types.Match) []byte {
 	// 1. Named capture called "TOKEN" (case-insensitive)
 	for k, v := range m.NamedGroups {

--- a/pkg/matcher/postfilter.go
+++ b/pkg/matcher/postfilter.go
@@ -48,12 +48,12 @@ func findSecretCapture(m *types.Match) []byte {
 		}
 	}
 
-	// 3. Groups[1] (first positional capture)
+	// 3. Groups[1] (second positional capture)
 	if len(m.Groups) > 1 {
 		return m.Groups[1]
 	}
 
-	// 4. Groups[0] (full match)
+	// 4. Groups[0] (first positional capture)
 	if len(m.Groups) > 0 {
 		return m.Groups[0]
 	}

--- a/pkg/matcher/postfilter_test.go
+++ b/pkg/matcher/postfilter_test.go
@@ -2,9 +2,12 @@ package matcher
 
 import (
 	"testing"
+	"time"
 
+	"github.com/praetorian-inc/titus/pkg/rule"
 	"github.com/praetorian-inc/titus/pkg/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // --- findSecretCapture tests ---
@@ -358,5 +361,63 @@ func TestFilterMatches_PatternRequirementsFiltering(t *testing.T) {
 	}
 	if string(result[0].NamedGroups["token"]) != "sk_live_realkey12345" {
 		t.Errorf("unexpected match content: %q", result[0].NamedGroups["token"])
+	}
+}
+
+// TestFindSecretCapture_MultiCaptureRulesSelectPassword verifies that rules
+// with 3+ captures select the password (via the named "token" group), not a
+// middle field like the login or username.
+//
+// Before LAB-6101, these rules had no named groups, so findSecretCapture fell
+// through to Groups[1] — the second capture — which was a username or path.
+// Entropy and pattern_requirements checks ran against that field instead of
+// the actual credential.
+func TestFindSecretCapture_MultiCaptureRulesSelectPassword(t *testing.T) {
+	allRules, err := rule.NewLoader().LoadBuiltinRules()
+	require.NoError(t, err)
+
+	byID := map[string]*types.Rule{}
+	for _, r := range allRules {
+		byID[r.ID] = r
+	}
+
+	tests := []struct {
+		ruleID   string
+		input    string
+		wantSecret string
+	}{
+		{
+			ruleID:     "np.netrc.1",
+			input:      "machine api.github.com login ziggy^stardust password 012345abcdef",
+			wantSecret: "012345abcdef",
+		},
+		{
+			ruleID:     "np.phpmailer.1",
+			input:      "$mail->Host = 'smtp.example.com';\n$mail->Username = 'user@example.com';\n$mail->Password = 'un!techwhooah';",
+			wantSecret: "un!techwhooah",
+		},
+		{
+			ruleID:     "np.generic.8",
+			input:      `$domain = New-Object DirectoryServices.DirectoryEntry("LDAP://10.10.10.1","domain\user", "secret")`,
+			wantSecret: "secret",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.ruleID, func(t *testing.T) {
+			r, ok := byID[tt.ruleID]
+			require.True(t, ok, "rule %s not found", tt.ruleID)
+
+			m, err := NewPortableRegexpWithTimeout([]*types.Rule{r}, 0, nil, 5*time.Second)
+			require.NoError(t, err)
+
+			matches, err := m.Match([]byte(tt.input))
+			require.NoError(t, err)
+			require.NotEmpty(t, matches, "rule %s did not match its input", tt.ruleID)
+
+			secret := findSecretCapture(matches[0])
+			assert.Equal(t, tt.wantSecret, string(secret),
+				"findSecretCapture should select the password, not another capture")
+		})
 	}
 }

--- a/pkg/rule/rules/generic.yml
+++ b/pkg/rule/rules/generic.yml
@@ -343,7 +343,7 @@ rules:
       \s* , \s*
       " ( [^"\n]{3,50} ) "                (?# username )
       \s* , \s*
-      " ( [^"\n]{3,50} ) "                (?# password )
+      " (?P<token>[^"\n]{3,50}) "          (?# password )
       (?: \s* , \s* [^)]{3,50} )?         (?# authentication type )
     \s* \)
 

--- a/pkg/rule/rules/generic.yml
+++ b/pkg/rule/rules/generic.yml
@@ -343,7 +343,7 @@ rules:
       \s* , \s*
       " ( [^"\n]{3,50} ) "                (?# username )
       \s* , \s*
-      " (?P<token>[^"\n]{3,50}) "          (?# password )
+      " (?P<token> [^"\n]{3,50} ) "                (?# password )
       (?: \s* , \s* [^)]{3,50} )?         (?# authentication type )
     \s* \)
 

--- a/pkg/rule/rules/netrc.yml
+++ b/pkg/rule/rules/netrc.yml
@@ -10,7 +10,7 @@ rules:
     \s+
     login \s+ ([^\s]+)
     \s+
-    password \s+ ([^\s]+)
+    password \s+ (?P<token>[^\s]+)
 
   categories: [secret]
 

--- a/pkg/rule/rules/phpmailer.yml
+++ b/pkg/rule/rules/phpmailer.yml
@@ -10,7 +10,7 @@ rules:
     (?: \s* .* \s* ){0,3}
     \$mail->Username \s* = \s* '([^'\n]{5,})'; \s* (?: //.* )?
     (?: \s* .* \s* ){0,3}
-    \$mail->Password \s* = \s* '([^'\n]{5,})';
+    \$mail->Password \s* = \s* '(?P<token>[^'\n]{5,})';
 
   categories: [fuzzy, secret]
 


### PR DESCRIPTION
## Summary

- **Fixed doc comment** in `findSecretCapture` (`pkg/matcher/postfilter.go`): comment claimed `Groups[0]` is the full match, but both backends strip it — `Groups[0]` is the first capture. The comment now accurately describes the indexing and warns about the multi-capture pitfall.
- **Named the password capture `(?P<token>...)`** in 3 rules where `findSecretCapture` was selecting the wrong field:
  - `np.netrc.1`: was selecting **login** (`ziggy^stardust`) instead of **password** (`012345abcdef`)
  - `np.phpmailer.1`: was selecting **username** (`user@example.com`) instead of **password** (`secret`)
  - `np.generic.8`: was selecting **username** (`domain\user`) instead of **password** (`secret`)
- The remaining 12 positional-fallback rules with 2+ captures are left for individual triage (most select the final capture, which is often accidentally correct)

## Impact

Entropy and `pattern_requirements` checks now run against the actual secret rather than a username/context field. This can only improve detection — passwords are higher entropy than usernames.

## Test plan

- [x] `TestRuleExamples` passes — no baseline shifts
- [x] Full `pkg/matcher`, `pkg/scoring`, `pkg/rule` test suites green
- [x] Verified via script that `NamedGroups["token"]` is populated correctly for all 3 rules

Closes LAB-6101

🤖 Generated with [Claude Code](https://claude.com/claude-code)