### PR TITLE
feat(scoring): Plaid environment-aware scorer (LAB-3383)

### DIFF
--- a/pkg/rule/rules/plaid.yml
+++ b/pkg/rule/rules/plaid.yml
@@ -12,7 +12,7 @@ rules:
       (?:\s*[:=]\s*|["']\s*:\s*["']|=\s*["'])
       \s*
       \b
-      (
+      (?P<client_id>
         [a-z0-9]{24}
       )
       \b
@@ -35,7 +35,7 @@ rules:
       (?:SECRET|PRIVATE|ACCESS|KEY|TOKEN|ACCESS_KEY)
       (?:.|[\n\r]){0,32}?
       \b
-      (
+      (?P<token>
         [a-z0-9]{30}
       )
       \b
@@ -96,7 +96,7 @@ rules:
       (?:SECRET|PRIVATE|ACCESS|KEY|TOKEN|ACCESS_KEY)
       (?:.|[\n\r]){0,32}?
       \b
-      (
+      (?P<token>
         [a-z0-9]{30}
       )
       \b
@@ -156,7 +156,7 @@ rules:
     pattern: |
       (?xi)
       \b
-      (
+      (?P<token>
         access-production-
         [0-9a-f]{8}-
         [0-9a-f]{4}-
@@ -215,7 +215,7 @@ rules:
     pattern: |
       (?xi)
       \b
-      (
+      (?P<token>
         access-sandbox-
         [0-9a-f]{8}-
         [0-9a-f]{4}-

--- a/pkg/scoring/go_scorers.go
+++ b/pkg/scoring/go_scorers.go
@@ -15,6 +15,7 @@ func BuiltinGoScorers() []*Scorer {
 		GitLabGoScorer(),
 		GCPGoScorer(),
 		AzureGoScorer(),
+		PlaidGoScorer(),
 	}
 }
 

--- a/pkg/scoring/plaid.go
+++ b/pkg/scoring/plaid.go
@@ -1,0 +1,262 @@
+package scoring
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+)
+
+type plaidHTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// extractPlaidSecret extracts the Plaid secret from the match.
+// Tries named group "token" first, falls back to positional group 0.
+func extractPlaidSecret(m *types.Match) (string, bool) {
+	if m == nil {
+		return "", false
+	}
+	if v, ok := m.NamedGroups["token"]; ok && len(v) > 0 {
+		return string(v), true
+	}
+	if len(m.Groups) > 0 && len(m.Groups[0]) > 0 {
+		return string(m.Groups[0]), true
+	}
+	return "", false
+}
+
+var plaidClientIDRe = regexp.MustCompile(`(?i)(?:plaid[_-]?)?client[_-]?id\s*[:=]\s*["']?([a-z0-9]{24})\b`)
+
+// extractPlaidClientID scans surrounding context for a co-located Plaid client ID.
+func extractPlaidClientID(m *types.Match) (string, bool) {
+	if m == nil {
+		return "", false
+	}
+	for _, ctx := range [][]byte{m.Snippet.Before, m.Snippet.After} {
+		if sub := plaidClientIDRe.FindSubmatch(ctx); len(sub) > 1 {
+			return string(sub[1]), true
+		}
+	}
+	return "", false
+}
+
+type plaidInstitutionsReq struct {
+	ClientID     string   `json:"client_id"`
+	Secret       string   `json:"secret"`
+	Count        int      `json:"count"`
+	Offset       int      `json:"offset"`
+	CountryCodes []string `json:"country_codes"`
+}
+
+// plaidEnvCheckCondition fires when the Plaid secret + client_id pair is valid
+// for a specific environment (production, development, or sandbox).
+type plaidEnvCheckCondition struct {
+	envURL string // e.g. "https://production.plaid.com/institutions/get"
+	client plaidHTTPClient
+}
+
+func (c *plaidEnvCheckCondition) markDynamic() {}
+
+func (c *plaidEnvCheckCondition) Evaluate(ctx context.Context, m *types.Match) (bool, error) {
+	secret, ok := extractPlaidSecret(m)
+	if !ok {
+		return false, nil
+	}
+	clientID, ok := extractPlaidClientID(m)
+	if !ok {
+		return false, nil
+	}
+
+	body, err := json.Marshal(plaidInstitutionsReq{
+		ClientID:     clientID,
+		Secret:       secret,
+		Count:        1,
+		Offset:       0,
+		CountryCodes: []string{"US"},
+	})
+	if err != nil {
+		return false, nil
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", c.envURL, bytes.NewReader(body))
+	if err != nil {
+		return false, nil
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient().Do(req)
+	if err != nil {
+		return false, nil
+	}
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return false, nil
+	}
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false, nil
+	}
+	return !bytes.Contains(respBody, []byte("INVALID_API_KEYS")), nil
+}
+
+func (c *plaidEnvCheckCondition) httpClient() plaidHTTPClient {
+	if c.client != nil {
+		return c.client
+	}
+	return defaultHTTPClient
+}
+
+// plaidRevokedCondition fires when a client_id is available in the surrounding
+// context but the secret is rejected by all three Plaid environments.
+type plaidRevokedCondition struct {
+	client plaidHTTPClient
+}
+
+func (c *plaidRevokedCondition) markDynamic() {}
+
+func (c *plaidRevokedCondition) Evaluate(ctx context.Context, m *types.Match) (bool, error) {
+	secret, ok := extractPlaidSecret(m)
+	if !ok {
+		return false, nil
+	}
+	clientID, ok := extractPlaidClientID(m)
+	if !ok {
+		return false, nil
+	}
+
+	body, err := json.Marshal(plaidInstitutionsReq{
+		ClientID:     clientID,
+		Secret:       secret,
+		Count:        1,
+		Offset:       0,
+		CountryCodes: []string{"US"},
+	})
+	if err != nil {
+		return false, nil
+	}
+
+	for _, env := range []string{
+		"https://production.plaid.com/institutions/get",
+		"https://development.plaid.com/institutions/get",
+		"https://sandbox.plaid.com/institutions/get",
+	} {
+		req, err := http.NewRequestWithContext(ctx, "POST", env, bytes.NewReader(body))
+		if err != nil {
+			continue
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := c.httpClient().Do(req)
+		if err != nil {
+			continue
+		}
+		respBody, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+
+		if resp.StatusCode == http.StatusOK && !bytes.Contains(respBody, []byte("INVALID_API_KEYS")) {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func (c *plaidRevokedCondition) httpClient() plaidHTTPClient {
+	if c.client != nil {
+		return c.client
+	}
+	return defaultHTTPClient
+}
+
+// plaidSandboxContextCondition fires when the surrounding context contains
+// "sandbox" (case-insensitive), suggesting the secret belongs to a sandbox
+// environment even when no client_id is available for dynamic verification.
+type plaidSandboxContextCondition struct{}
+
+func (c *plaidSandboxContextCondition) Evaluate(_ context.Context, m *types.Match) (bool, error) {
+	if m == nil {
+		return false, nil
+	}
+	low := func(b []byte) string { return strings.ToLower(string(b)) }
+	return strings.Contains(low(m.Snippet.Before), "sandbox") ||
+		strings.Contains(low(m.Snippet.After), "sandbox"), nil
+}
+
+// PlaidGoScorer returns the environment-aware Plaid secret scorer.
+//
+// Targets kingfisher.plaid.2 (Production Secret, base 90) and
+// kingfisher.plaid.3 (Sandbox Secret, base 40). Access tokens (plaid.4/5)
+// already carry their environment in the prefix and are not scored here.
+//
+// Dynamic modifiers (require a co-located client_id in surrounding context)
+// probe POST /institutions/get against each Plaid environment.
+// Static modifiers fall back to keyword detection when no client_id is found.
+//
+// Product-aware scoring (auth, identity, assets) is deferred — it requires an
+// access_token which is not reliably co-located with the secret.
+func PlaidGoScorer() *Scorer {
+	return &Scorer{
+		Name:    "plaid-secret-environment",
+		RuleIDs: []string{"kingfisher.plaid.2", "kingfisher.plaid.3"},
+		Modifiers: []Modifier{
+			// --- Static fallbacks (evaluated first, overridden by dynamic) ---
+
+			// Context contains "sandbox" — likely a sandbox key.
+			{
+				Name:      "sandbox-context",
+				Priority:  90,
+				Kind:      ModifierKindSetScore,
+				Value:     10,
+				Condition: &plaidSandboxContextCondition{},
+			},
+
+			// --- Dynamic (evaluated later, override static) ---
+
+			// Confirmed production → highest severity.
+			{
+				Name:     "production-verified",
+				Priority: 30,
+				Kind:     ModifierKindSetScore,
+				Value:    95,
+				Condition: &plaidEnvCheckCondition{
+					envURL: "https://production.plaid.com/institutions/get",
+				},
+			},
+			// Confirmed development → moderate severity (real data, limited scale).
+			{
+				Name:     "development-verified",
+				Priority: 25,
+				Kind:     ModifierKindSetScore,
+				Value:    60,
+				Condition: &plaidEnvCheckCondition{
+					envURL: "https://development.plaid.com/institutions/get",
+				},
+			},
+			// Confirmed sandbox → minimal severity (entirely fake data).
+			{
+				Name:     "sandbox-verified",
+				Priority: 20,
+				Kind:     ModifierKindSetScore,
+				Value:    5,
+				Condition: &plaidEnvCheckCondition{
+					envURL: "https://sandbox.plaid.com/institutions/get",
+				},
+			},
+			// All environments reject → revoked / dead key.
+			{
+				Name:      "revoked-key",
+				Priority:  10,
+				Kind:      ModifierKindSetScore,
+				Value:     5,
+				Condition: &plaidRevokedCondition{},
+			},
+		},
+	}
+}

--- a/pkg/scoring/plaid.go
+++ b/pkg/scoring/plaid.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"regexp"
-	"strings"
 
 	"github.com/praetorian-inc/titus/pkg/types"
 )
@@ -31,14 +30,14 @@ func extractPlaidSecret(m *types.Match) (string, bool) {
 	return "", false
 }
 
-var plaidClientIDRe = regexp.MustCompile(`(?i)(?:plaid[_-]?)?client[_-]?id\s*[:=]\s*["']?([a-z0-9]{24})\b`)
+var plaidClientIDRe = regexp.MustCompile(`(?i)["']?(?:plaid[_-]?)?client[_-]?id["']?\s*[:=]\s*["']?([a-z0-9]{24})\b`)
 
 // extractPlaidClientID scans surrounding context for a co-located Plaid client ID.
 func extractPlaidClientID(m *types.Match) (string, bool) {
 	if m == nil {
 		return "", false
 	}
-	for _, ctx := range [][]byte{m.Snippet.Before, m.Snippet.After} {
+	for _, ctx := range [][]byte{m.Snippet.Before, m.Snippet.Matching, m.Snippet.After} {
 		if sub := plaidClientIDRe.FindSubmatch(ctx); len(sub) > 1 {
 			return string(sub[1]), true
 		}
@@ -48,7 +47,7 @@ func extractPlaidClientID(m *types.Match) (string, bool) {
 
 type plaidInstitutionsReq struct {
 	ClientID     string   `json:"client_id"`
-	Secret       string   `json:"secret"`
+	Secret       string   `json:"secret"` // #nosec G101 -- API request field, not a hardcoded credential
 	Count        int      `json:"count"`
 	Offset       int      `json:"offset"`
 	CountryCodes []string `json:"country_codes"`
@@ -115,7 +114,10 @@ func (c *plaidEnvCheckCondition) httpClient() plaidHTTPClient {
 }
 
 // plaidRevokedCondition fires when a client_id is available in the surrounding
-// context but the secret is rejected by all three Plaid environments.
+// context and every Plaid environment explicitly rejects the credentials with
+// INVALID_API_KEYS. Transport errors, timeouts, rate limits, and server errors
+// are treated as inconclusive — the condition does NOT fire, leaving the base
+// score intact rather than incorrectly marking a live key as dead.
 type plaidRevokedCondition struct {
 	client plaidHTTPClient
 }
@@ -143,20 +145,22 @@ func (c *plaidRevokedCondition) Evaluate(ctx context.Context, m *types.Match) (b
 		return false, nil
 	}
 
-	for _, env := range []string{
+	rejections := 0
+	envs := []string{
 		"https://production.plaid.com/institutions/get",
 		"https://development.plaid.com/institutions/get",
 		"https://sandbox.plaid.com/institutions/get",
-	} {
+	}
+	for _, env := range envs {
 		req, err := http.NewRequestWithContext(ctx, "POST", env, bytes.NewReader(body))
 		if err != nil {
-			continue
+			return false, nil
 		}
 		req.Header.Set("Content-Type", "application/json")
 
 		resp, err := c.httpClient().Do(req)
 		if err != nil {
-			continue
+			return false, nil
 		}
 		respBody, _ := io.ReadAll(resp.Body)
 		_ = resp.Body.Close()
@@ -164,8 +168,13 @@ func (c *plaidRevokedCondition) Evaluate(ctx context.Context, m *types.Match) (b
 		if resp.StatusCode == http.StatusOK && !bytes.Contains(respBody, []byte("INVALID_API_KEYS")) {
 			return false, nil
 		}
+		if bytes.Contains(respBody, []byte("INVALID_API_KEYS")) {
+			rejections++
+			continue
+		}
+		return false, nil
 	}
-	return true, nil
+	return rejections == len(envs), nil
 }
 
 func (c *plaidRevokedCondition) httpClient() plaidHTTPClient {
@@ -175,18 +184,24 @@ func (c *plaidRevokedCondition) httpClient() plaidHTTPClient {
 	return defaultHTTPClient
 }
 
-// plaidSandboxContextCondition fires when the surrounding context contains
-// "sandbox" (case-insensitive), suggesting the secret belongs to a sandbox
-// environment even when no client_id is available for dynamic verification.
+// plaidSandboxContextCondition fires when the surrounding context or matched
+// text contains "sandbox" (case-insensitive), suggesting the secret belongs to
+// a sandbox environment even when no client_id is available for dynamic
+// verification.
 type plaidSandboxContextCondition struct{}
+
+var sandboxLower = []byte("sandbox")
 
 func (c *plaidSandboxContextCondition) Evaluate(_ context.Context, m *types.Match) (bool, error) {
 	if m == nil {
 		return false, nil
 	}
-	low := func(b []byte) string { return strings.ToLower(string(b)) }
-	return strings.Contains(low(m.Snippet.Before), "sandbox") ||
-		strings.Contains(low(m.Snippet.After), "sandbox"), nil
+	for _, seg := range [][]byte{m.Snippet.Before, m.Snippet.Matching, m.Snippet.After} {
+		if bytes.Contains(bytes.ToLower(seg), sandboxLower) {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // PlaidGoScorer returns the environment-aware Plaid secret scorer.
@@ -213,7 +228,7 @@ func PlaidGoScorer() *Scorer {
 				Name:      "sandbox-context",
 				Priority:  90,
 				Kind:      ModifierKindSetScore,
-				Value:     10,
+				Value:     5,
 				Condition: &plaidSandboxContextCondition{},
 			},
 

--- a/pkg/scoring/plaid.go
+++ b/pkg/scoring/plaid.go
@@ -3,10 +3,16 @@ package scoring
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"regexp"
+	"sync"
+
+	"golang.org/x/sync/singleflight"
 
 	"github.com/praetorian-inc/titus/pkg/types"
 )
@@ -37,6 +43,12 @@ func extractPlaidClientID(m *types.Match) (string, bool) {
 	if m == nil {
 		return "", false
 	}
+	// kingfisher.plaid.1 captures the client_id as a named group. Prefer it:
+	// the group is the value the rule actually matched, whereas the context
+	// scan below re-derives it with a second regex.
+	if v, ok := m.NamedGroups["client_id"]; ok && len(v) > 0 {
+		return string(v), true
+	}
 	for _, ctx := range [][]byte{m.Snippet.Before, m.Snippet.Matching, m.Snippet.After} {
 		if sub := plaidClientIDRe.FindSubmatch(ctx); len(sub) > 1 {
 			return string(sub[1]), true
@@ -53,11 +65,154 @@ type plaidInstitutionsReq struct {
 	CountryCodes []string `json:"country_codes"`
 }
 
+var plaidInvalidAPIKeys = []byte("INVALID_API_KEYS")
+
+// The three Plaid hosts a secret can belong to. Named constants because the
+// per-environment conditions and the revoked check must probe the SAME URLs:
+// if they drifted apart, revoked-key would miss the cache and issue three
+// extra requests per finding.
+const (
+	plaidEnvProduction  = "https://production.plaid.com/institutions/get"
+	plaidEnvDevelopment = "https://development.plaid.com/institutions/get"
+	plaidEnvSandbox     = "https://sandbox.plaid.com/institutions/get"
+)
+
+var plaidEnvironments = []string{plaidEnvProduction, plaidEnvDevelopment, plaidEnvSandbox}
+
+// plaidEnvOutcome is the result of probing ONE environment with ONE credential
+// pair. Exactly one of the three states holds: the environment accepted the
+// credentials, explicitly rejected them with INVALID_API_KEYS, or could not be
+// reached for a verdict.
+type plaidEnvOutcome struct {
+	valid    bool
+	rejected bool
+	err      error
+}
+
+// plaidProbeCache coalesces /institutions/get probes so that each
+// (environment, credential) pair costs at most one request per scan.
+//
+// Without it a single finding costs up to six live authentication attempts:
+// one per environment condition, plus three more inside revoked-key, which
+// re-probes every environment. production.plaid.com would see the same
+// credential twice. These are real auth attempts against the customer's Plaid
+// account and appear in its audit log, so the duplication is not merely slow.
+//
+// Unreachable-environment outcomes are cached alongside verdicts -- the same
+// choice condition_http.go makes for 429/5xx -- so a broken environment is not
+// re-probed once per modifier. The error reaches the engine only on its first
+// consumer: four modifiers each reporting one outage would be four warnings
+// for a single failure.
+type plaidProbeCache struct {
+	mu      sync.Mutex
+	entries map[string]*plaidCacheEntry
+	group   singleflight.Group
+}
+
+type plaidCacheEntry struct {
+	outcome  plaidEnvOutcome
+	reported bool
+}
+
+func newPlaidProbeCache() *plaidProbeCache {
+	return &plaidProbeCache{entries: make(map[string]*plaidCacheEntry)}
+}
+
+// plaidCacheKey hashes the credential pair so plaintext secrets never appear
+// in map keys. The environment URL carries no secret and stays readable.
+func plaidCacheKey(envURL, clientID, secret string) string {
+	sum := sha256.Sum256([]byte(clientID + "\x00" + secret))
+	return envURL + "\x00" + hex.EncodeToString(sum[:])
+}
+
+// probe returns the outcome for one environment, issuing at most one request
+// per (environment, credential) pair. A nil cache probes directly, which is
+// what unit tests constructing bare conditions rely on.
+func (c *plaidProbeCache) probe(ctx context.Context, client plaidHTTPClient, envURL, clientID, secret string) plaidEnvOutcome {
+	if c == nil {
+		return plaidProbeEnv(ctx, client, envURL, clientID, secret)
+	}
+	key := plaidCacheKey(envURL, clientID, secret)
+
+	c.mu.Lock()
+	if entry, ok := c.entries[key]; ok {
+		out := entry.outcome
+		if out.err != nil {
+			if entry.reported {
+				out.err = nil // already surfaced once; do not warn again
+			}
+			entry.reported = true
+		}
+		c.mu.Unlock()
+		return out
+	}
+	c.mu.Unlock()
+
+	v, _, _ := c.group.Do(key, func() (any, error) {
+		out := plaidProbeEnv(ctx, client, envURL, clientID, secret)
+		c.mu.Lock()
+		c.entries[key] = &plaidCacheEntry{outcome: out, reported: out.err != nil}
+		c.mu.Unlock()
+		return out, nil
+	})
+	outcome, _ := v.(plaidEnvOutcome)
+	return outcome
+}
+
+// plaidProbeEnv issues one /institutions/get request and classifies it.
+//
+// A rate limit, server error, transport failure or unreadable body is
+// INCONCLUSIVE, not a rejection: reporting a live key as dead because Plaid was
+// briefly unreachable is the worst outcome available here, so those return an
+// error and leave the score alone.
+func plaidProbeEnv(ctx context.Context, client plaidHTTPClient, envURL, clientID, secret string) plaidEnvOutcome {
+	body, err := json.Marshal(plaidInstitutionsReq{
+		ClientID:     clientID,
+		Secret:       secret,
+		Count:        1,
+		Offset:       0,
+		CountryCodes: []string{"US"},
+	})
+	if err != nil {
+		return plaidEnvOutcome{err: fmt.Errorf("plaid: encode request: %w", err)}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", envURL, bytes.NewReader(body))
+	if err != nil {
+		return plaidEnvOutcome{err: fmt.Errorf("plaid: build request: %w", err)}
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return plaidEnvOutcome{err: fmt.Errorf("plaid %s: %w", envURL, classifyHTTPError(0, err))}
+	}
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return plaidEnvOutcome{err: fmt.Errorf("plaid %s: read response: %w", envURL, err)}
+	}
+
+	// An explicit INVALID_API_KEYS is a verdict at any status code.
+	if bytes.Contains(respBody, plaidInvalidAPIKeys) {
+		return plaidEnvOutcome{rejected: true}
+	}
+	if resp.StatusCode == http.StatusOK {
+		return plaidEnvOutcome{valid: true}
+	}
+	if classified := classifyHTTPError(resp.StatusCode, nil); classified != nil {
+		return plaidEnvOutcome{err: fmt.Errorf("plaid %s: %w", envURL, classified)}
+	}
+	return plaidEnvOutcome{err: fmt.Errorf("plaid %s: inconclusive HTTP %d", envURL, resp.StatusCode)}
+}
+
 // plaidEnvCheckCondition fires when the Plaid secret + client_id pair is valid
 // for a specific environment (production, development, or sandbox).
 type plaidEnvCheckCondition struct {
-	envURL string // e.g. "https://production.plaid.com/institutions/get"
+	envURL string
 	client plaidHTTPClient
+	cache  *plaidProbeCache
 }
 
 func (c *plaidEnvCheckCondition) markDynamic() {}
@@ -71,39 +226,11 @@ func (c *plaidEnvCheckCondition) Evaluate(ctx context.Context, m *types.Match) (
 	if !ok {
 		return false, nil
 	}
-
-	body, err := json.Marshal(plaidInstitutionsReq{
-		ClientID:     clientID,
-		Secret:       secret,
-		Count:        1,
-		Offset:       0,
-		CountryCodes: []string{"US"},
-	})
-	if err != nil {
-		return false, nil
+	out := c.cache.probe(ctx, c.httpClient(), c.envURL, clientID, secret)
+	if out.err != nil {
+		return false, out.err
 	}
-
-	req, err := http.NewRequestWithContext(ctx, "POST", c.envURL, bytes.NewReader(body))
-	if err != nil {
-		return false, nil
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := c.httpClient().Do(req)
-	if err != nil {
-		return false, nil
-	}
-	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		return false, nil
-	}
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return false, nil
-	}
-	return !bytes.Contains(respBody, []byte("INVALID_API_KEYS")), nil
+	return out.valid, nil
 }
 
 func (c *plaidEnvCheckCondition) httpClient() plaidHTTPClient {
@@ -113,13 +240,17 @@ func (c *plaidEnvCheckCondition) httpClient() plaidHTTPClient {
 	return defaultHTTPClient
 }
 
-// plaidRevokedCondition fires when a client_id is available in the surrounding
-// context and every Plaid environment explicitly rejects the credentials with
-// INVALID_API_KEYS. Transport errors, timeouts, rate limits, and server errors
-// are treated as inconclusive — the condition does NOT fire, leaving the base
-// score intact rather than incorrectly marking a live key as dead.
+// plaidRevokedCondition fires when a client_id is available and EVERY Plaid
+// environment explicitly rejects the credentials with INVALID_API_KEYS.
+// Transport errors, timeouts, rate limits and server errors are inconclusive --
+// the condition does not fire, leaving the base score intact rather than
+// marking a live key dead.
+//
+// Its probes share the cache with the per-environment conditions above, so on
+// a finding those have already scored this costs no additional requests.
 type plaidRevokedCondition struct {
 	client plaidHTTPClient
+	cache  *plaidProbeCache
 }
 
 func (c *plaidRevokedCondition) markDynamic() {}
@@ -134,47 +265,16 @@ func (c *plaidRevokedCondition) Evaluate(ctx context.Context, m *types.Match) (b
 		return false, nil
 	}
 
-	body, err := json.Marshal(plaidInstitutionsReq{
-		ClientID:     clientID,
-		Secret:       secret,
-		Count:        1,
-		Offset:       0,
-		CountryCodes: []string{"US"},
-	})
-	if err != nil {
-		return false, nil
-	}
-
-	rejections := 0
-	envs := []string{
-		"https://production.plaid.com/institutions/get",
-		"https://development.plaid.com/institutions/get",
-		"https://sandbox.plaid.com/institutions/get",
-	}
-	for _, env := range envs {
-		req, err := http.NewRequestWithContext(ctx, "POST", env, bytes.NewReader(body))
-		if err != nil {
+	for _, env := range plaidEnvironments {
+		out := c.cache.probe(ctx, c.httpClient(), env, clientID, secret)
+		if out.err != nil {
+			return false, out.err
+		}
+		if !out.rejected {
 			return false, nil
 		}
-		req.Header.Set("Content-Type", "application/json")
-
-		resp, err := c.httpClient().Do(req)
-		if err != nil {
-			return false, nil
-		}
-		respBody, _ := io.ReadAll(resp.Body)
-		_ = resp.Body.Close()
-
-		if resp.StatusCode == http.StatusOK && !bytes.Contains(respBody, []byte("INVALID_API_KEYS")) {
-			return false, nil
-		}
-		if bytes.Contains(respBody, []byte("INVALID_API_KEYS")) {
-			rejections++
-			continue
-		}
-		return false, nil
 	}
-	return rejections == len(envs), nil
+	return true, nil
 }
 
 func (c *plaidRevokedCondition) httpClient() plaidHTTPClient {
@@ -217,6 +317,9 @@ func (c *plaidSandboxContextCondition) Evaluate(_ context.Context, m *types.Matc
 // Product-aware scoring (auth, identity, assets) is deferred — it requires an
 // access_token which is not reliably co-located with the secret.
 func PlaidGoScorer() *Scorer {
+	// One cache per scorer instance, shared by every modifier below, so the
+	// four dynamic modifiers probe each environment once rather than six times.
+	cache := newPlaidProbeCache()
 	return &Scorer{
 		Name:    "plaid-secret-environment",
 		RuleIDs: []string{"kingfisher.plaid.2", "kingfisher.plaid.3"},
@@ -241,7 +344,8 @@ func PlaidGoScorer() *Scorer {
 				Kind:     ModifierKindSetScore,
 				Value:    95,
 				Condition: &plaidEnvCheckCondition{
-					envURL: "https://production.plaid.com/institutions/get",
+					envURL: plaidEnvProduction,
+					cache:  cache,
 				},
 			},
 			// Confirmed development → moderate severity (real data, limited scale).
@@ -251,7 +355,8 @@ func PlaidGoScorer() *Scorer {
 				Kind:     ModifierKindSetScore,
 				Value:    60,
 				Condition: &plaidEnvCheckCondition{
-					envURL: "https://development.plaid.com/institutions/get",
+					envURL: plaidEnvDevelopment,
+					cache:  cache,
 				},
 			},
 			// Confirmed sandbox → minimal severity (entirely fake data).
@@ -261,7 +366,8 @@ func PlaidGoScorer() *Scorer {
 				Kind:     ModifierKindSetScore,
 				Value:    5,
 				Condition: &plaidEnvCheckCondition{
-					envURL: "https://sandbox.plaid.com/institutions/get",
+					envURL: plaidEnvSandbox,
+					cache:  cache,
 				},
 			},
 			// All environments reject → revoked / dead key.
@@ -270,7 +376,7 @@ func PlaidGoScorer() *Scorer {
 				Priority:  10,
 				Kind:      ModifierKindSetScore,
 				Value:     5,
-				Condition: &plaidRevokedCondition{},
+				Condition: &plaidRevokedCondition{cache: cache},
 			},
 		},
 	}

--- a/pkg/scoring/plaid_test.go
+++ b/pkg/scoring/plaid_test.go
@@ -2,9 +2,14 @@ package scoring
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/praetorian-inc/titus/pkg/types"
 	"github.com/stretchr/testify/assert"
@@ -249,12 +254,18 @@ func TestPlaidRevoked_OneAccepts(t *testing.T) {
 	assert.False(t, fired)
 }
 
+// A transport failure must not read as "revoked" -- but it must not be silent
+// either. The condition returns the error so the engine warns and trackError
+// counts it in the scan stats; previously every error was swallowed as
+// (false, nil), so an unreachable Plaid degraded every finding to its base
+// score with no signal that scoring had not actually run.
 func TestPlaidRevoked_TransportError(t *testing.T) {
 	c := &plaidRevokedCondition{
 		client: &plaidFailingClient{},
 	}
 	fired, err := c.Evaluate(context.Background(), plaidSecretMatch("kingfisher.plaid.2"))
-	assert.NoError(t, err)
+	require.Error(t, err, "an unreachable environment must be reported, not swallowed")
+	assert.ErrorIs(t, err, ErrModifierNetwork, "must land in the network-error stats bucket")
 	assert.False(t, fired, "transport errors must not be treated as revoked")
 }
 
@@ -269,7 +280,8 @@ func TestPlaidRevoked_ServerError(t *testing.T) {
 		client: &plaidRedirectingClient{target: server.URL},
 	}
 	fired, err := c.Evaluate(context.Background(), plaidSecretMatch("kingfisher.plaid.2"))
-	assert.NoError(t, err)
+	require.Error(t, err, "a 5xx must be reported, not swallowed")
+	assert.ErrorIs(t, err, ErrModifierServerError, "must land in the server-error stats bucket")
 	assert.False(t, fired, "5xx errors must not be treated as revoked")
 }
 
@@ -457,4 +469,140 @@ type plaidFailingClient struct{}
 
 func (c *plaidFailingClient) Do(_ *http.Request) (*http.Response, error) {
 	return nil, http.ErrServerClosed
+}
+
+// countingPlaidClient records every request the scorer issues.
+type countingPlaidClient struct {
+	mu       sync.Mutex
+	requests []string
+	respond  func(url string) (int, string)
+}
+
+func (c *countingPlaidClient) Do(req *http.Request) (*http.Response, error) {
+	c.mu.Lock()
+	c.requests = append(c.requests, req.URL.String())
+	c.mu.Unlock()
+	code, body := c.respond(req.URL.String())
+	return &http.Response{
+		StatusCode: code,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func (c *countingPlaidClient) calls() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.requests)
+}
+
+// plaidScorerWithClient injects a client into every dynamic modifier while
+// leaving the shared probe cache from PlaidGoScorer() in place.
+func plaidScorerWithClient(c plaidHTTPClient) *Scorer {
+	s := PlaidGoScorer()
+	for i := range s.Modifiers {
+		switch cond := s.Modifiers[i].Condition.(type) {
+		case *plaidEnvCheckCondition:
+			cond.client = c
+		case *plaidRevokedCondition:
+			cond.client = c
+		}
+	}
+	return s
+}
+
+// Scoring one finding must probe each environment at most ONCE. Before the
+// shared cache, revoked-key re-probed all three environments after the
+// per-environment modifiers had already done so -- up to six live
+// authentication attempts per finding, with production hit twice. Each is a
+// real auth attempt in the customer's Plaid audit log.
+func TestPlaidScorer_ProbesEachEnvironmentOnce(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		valid string // environment host that accepts, "" for none
+		want  int
+	}{
+		{"production key", "production.plaid.com", 95},
+		{"development key", "development.plaid.com", 60},
+		{"sandbox key", "sandbox.plaid.com", 5},
+		{"revoked key", "", 5},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &countingPlaidClient{respond: func(url string) (int, string) {
+				if tc.valid != "" && strings.Contains(url, tc.valid) {
+					return 200, `{"institutions":[{"institution_id":"ins_1"}]}`
+				}
+				return 400, `{"error_code":"INVALID_API_KEYS"}`
+			}}
+			engine := NewEngine([]*Scorer{plaidScorerWithClient(client)}, EngineConfig{
+				ScopeEnabled: true,
+				Timeout:      5 * time.Second,
+				WarnF:        func(string, ...any) {},
+			})
+			rule := &types.Rule{ID: "kingfisher.plaid.2", BaseScore: 70}
+			score := engine.Score(context.Background(),
+				&types.Finding{ID: "f", RuleID: "kingfisher.plaid.2"},
+				[]*types.Match{plaidSecretMatch("kingfisher.plaid.2")}, rule)
+
+			assert.Equal(t, tc.want, score.Final)
+			assert.LessOrEqual(t, client.calls(), len(plaidEnvironments),
+				"each environment must be probed at most once per finding")
+
+			seen := map[string]int{}
+			client.mu.Lock()
+			for _, u := range client.requests {
+				seen[u]++
+			}
+			client.mu.Unlock()
+			for u, n := range seen {
+				assert.Equalf(t, 1, n, "%s was probed %d times; it must be cached", u, n)
+			}
+		})
+	}
+}
+
+// A finding with no co-located client_id cannot be verified dynamically and
+// must make no network calls at all.
+func TestPlaidScorer_NoClientID_MakesNoRequests(t *testing.T) {
+	client := &countingPlaidClient{respond: func(string) (int, string) {
+		return 200, `{"institutions":[]}`
+	}}
+	engine := NewEngine([]*Scorer{plaidScorerWithClient(client)}, EngineConfig{
+		ScopeEnabled: true,
+		Timeout:      5 * time.Second,
+		WarnF:        func(string, ...any) {},
+	})
+	m := &types.Match{
+		RuleID:      "kingfisher.plaid.2",
+		NamedGroups: map[string][]byte{"token": []byte("abcdefghij0123456789klmnopqrst")},
+	}
+	rule := &types.Rule{ID: "kingfisher.plaid.2", BaseScore: 70}
+	score := engine.Score(context.Background(),
+		&types.Finding{ID: "f", RuleID: "kingfisher.plaid.2"}, []*types.Match{m}, rule)
+
+	assert.Equal(t, 70, score.Final, "no verification possible: base score stands")
+	assert.Zero(t, client.calls(), "no client_id means nothing to verify")
+}
+
+// An unreachable Plaid must leave the score alone AND be visible: one warning
+// and one tracked network error per environment, not silence and not one
+// warning per modifier.
+func TestPlaidScorer_UnreachableIsVisibleAndBounded(t *testing.T) {
+	var warnings []string
+	engine := NewEngine([]*Scorer{plaidScorerWithClient(&plaidFailingClient{})}, EngineConfig{
+		ScopeEnabled: true,
+		Timeout:      5 * time.Second,
+		WarnF:        func(f string, a ...any) { warnings = append(warnings, fmt.Sprintf(f, a...)) },
+	})
+	rule := &types.Rule{ID: "kingfisher.plaid.2", BaseScore: 70}
+	score := engine.Score(context.Background(),
+		&types.Finding{ID: "f", RuleID: "kingfisher.plaid.2"},
+		[]*types.Match{plaidSecretMatch("kingfisher.plaid.2")}, rule)
+
+	assert.Equal(t, 70, score.Final, "an outage must not move the score")
+	assert.NotEmpty(t, warnings, "an outage must not be silent")
+	assert.LessOrEqual(t, len(warnings), len(plaidEnvironments),
+		"one outage must not warn once per modifier")
+	assert.Equal(t, len(plaidEnvironments), engine.Stats().NetworkErrors,
+		"each unreachable environment must be counted exactly once")
 }

--- a/pkg/scoring/plaid_test.go
+++ b/pkg/scoring/plaid_test.go
@@ -113,6 +113,34 @@ func TestExtractPlaidClientID_CaseInsensitive(t *testing.T) {
 	assert.Equal(t, fakePlaidClientID, id)
 }
 
+func TestExtractPlaidClientID_JSONStyle(t *testing.T) {
+	m := &types.Match{
+		RuleID:      "kingfisher.plaid.2",
+		NamedGroups: map[string][]byte{"token": []byte(fakePlaidSecret)},
+		Snippet: types.Snippet{
+			Before: []byte(`"client_id": "` + fakePlaidClientID + `"` + "\n"),
+		},
+	}
+	id, ok := extractPlaidClientID(m)
+	assert.True(t, ok)
+	assert.Equal(t, fakePlaidClientID, id)
+}
+
+func TestExtractPlaidClientID_InMatching(t *testing.T) {
+	m := &types.Match{
+		RuleID:      "kingfisher.plaid.2",
+		NamedGroups: map[string][]byte{"token": []byte(fakePlaidSecret)},
+		Snippet: types.Snippet{
+			Before:   []byte(""),
+			Matching: []byte(`client_id=` + fakePlaidClientID + ` secret=` + fakePlaidSecret),
+			After:    []byte(""),
+		},
+	}
+	id, ok := extractPlaidClientID(m)
+	assert.True(t, ok)
+	assert.Equal(t, fakePlaidClientID, id)
+}
+
 func TestExtractPlaidClientID_NotFound(t *testing.T) {
 	m := plaidSecretMatchNoClientID("kingfisher.plaid.2")
 	_, ok := extractPlaidClientID(m)
@@ -221,6 +249,30 @@ func TestPlaidRevoked_OneAccepts(t *testing.T) {
 	assert.False(t, fired)
 }
 
+func TestPlaidRevoked_TransportError(t *testing.T) {
+	c := &plaidRevokedCondition{
+		client: &plaidFailingClient{},
+	}
+	fired, err := c.Evaluate(context.Background(), plaidSecretMatch("kingfisher.plaid.2"))
+	assert.NoError(t, err)
+	assert.False(t, fired, "transport errors must not be treated as revoked")
+}
+
+func TestPlaidRevoked_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`internal error`))
+	}))
+	defer server.Close()
+
+	c := &plaidRevokedCondition{
+		client: &plaidRedirectingClient{target: server.URL},
+	}
+	fired, err := c.Evaluate(context.Background(), plaidSecretMatch("kingfisher.plaid.2"))
+	assert.NoError(t, err)
+	assert.False(t, fired, "5xx errors must not be treated as revoked")
+}
+
 func TestPlaidRevoked_NoClientID(t *testing.T) {
 	c := &plaidRevokedCondition{}
 	fired, err := c.Evaluate(context.Background(), plaidSecretMatchNoClientID("kingfisher.plaid.2"))
@@ -250,6 +302,20 @@ func TestPlaidSandboxContext_InAfter(t *testing.T) {
 		NamedGroups: map[string][]byte{"token": []byte(fakePlaidSecret)},
 		Snippet: types.Snippet{
 			After: []byte("environment: Sandbox\n"),
+		},
+	}
+	c := &plaidSandboxContextCondition{}
+	fired, err := c.Evaluate(context.Background(), m)
+	assert.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestPlaidSandboxContext_InMatching(t *testing.T) {
+	m := &types.Match{
+		RuleID:      "kingfisher.plaid.2",
+		NamedGroups: map[string][]byte{"token": []byte(fakePlaidSecret)},
+		Snippet: types.Snippet{
+			Matching: []byte("PLAID_SANDBOX_SECRET=" + fakePlaidSecret),
 		},
 	}
 	c := &plaidSandboxContextCondition{}
@@ -326,6 +392,11 @@ func TestPlaidGoScorer_AllDynamic(t *testing.T) {
 	}
 }
 
+func TestPlaidGoScorer_ModifierCount(t *testing.T) {
+	s := PlaidGoScorer()
+	assert.Equal(t, 5, len(s.Modifiers))
+}
+
 func TestPlaidGoScorer_MissingToken(t *testing.T) {
 	s := PlaidGoScorer()
 	m := &types.Match{
@@ -360,7 +431,7 @@ func TestPlaidGoScorer_Scores(t *testing.T) {
 	assert.Equal(t, 5, byName["revoked-key"].Value)
 
 	require.Equal(t, ModifierKindSetScore, byName["sandbox-context"].Kind)
-	assert.Equal(t, 10, byName["sandbox-context"].Value)
+	assert.Equal(t, 5, byName["sandbox-context"].Value)
 }
 
 // plaidRedirectingClient redirects all requests to a test server URL.
@@ -379,4 +450,11 @@ func (c *plaidRedirectingClient) Do(req *http.Request) (*http.Response, error) {
 	}
 	newReq.Header = req.Header
 	return http.DefaultClient.Do(newReq)
+}
+
+// plaidFailingClient always returns a transport error.
+type plaidFailingClient struct{}
+
+func (c *plaidFailingClient) Do(_ *http.Request) (*http.Response, error) {
+	return nil, http.ErrServerClosed
 }

--- a/pkg/scoring/plaid_test.go
+++ b/pkg/scoring/plaid_test.go
@@ -1,0 +1,382 @@
+package scoring
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	fakePlaidClientID = "sd479fjropblyr5b4m2dutha"
+	fakePlaidSecret   = "wuxd6sw7ma4lv10xremyhz7ulf9owc"
+)
+
+func plaidSecretMatch(ruleID string) *types.Match {
+	return &types.Match{
+		RuleID: ruleID,
+		NamedGroups: map[string][]byte{
+			"token": []byte(fakePlaidSecret),
+		},
+		Snippet: types.Snippet{
+			Before: []byte(`PLAID_CLIENT_ID="` + fakePlaidClientID + `"` + "\n"),
+			After:  []byte("\n"),
+		},
+	}
+}
+
+func plaidSecretMatchNoClientID(ruleID string) *types.Match {
+	return &types.Match{
+		RuleID: ruleID,
+		NamedGroups: map[string][]byte{
+			"token": []byte(fakePlaidSecret),
+		},
+		Snippet: types.Snippet{
+			Before: []byte("some config\n"),
+			After:  []byte("\n"),
+		},
+	}
+}
+
+// --- extractPlaidSecret ---
+
+func TestExtractPlaidSecret_NamedGroup(t *testing.T) {
+	m := plaidSecretMatch("kingfisher.plaid.2")
+	s, ok := extractPlaidSecret(m)
+	assert.True(t, ok)
+	assert.Equal(t, fakePlaidSecret, s)
+}
+
+func TestExtractPlaidSecret_PositionalFallback(t *testing.T) {
+	m := &types.Match{
+		RuleID:      "kingfisher.plaid.2",
+		Groups:      [][]byte{[]byte(fakePlaidSecret)},
+		NamedGroups: map[string][]byte{},
+	}
+	s, ok := extractPlaidSecret(m)
+	assert.True(t, ok)
+	assert.Equal(t, fakePlaidSecret, s)
+}
+
+func TestExtractPlaidSecret_Nil(t *testing.T) {
+	_, ok := extractPlaidSecret(nil)
+	assert.False(t, ok)
+}
+
+func TestExtractPlaidSecret_Empty(t *testing.T) {
+	m := &types.Match{
+		RuleID:      "kingfisher.plaid.2",
+		Groups:      [][]byte{},
+		NamedGroups: map[string][]byte{},
+	}
+	_, ok := extractPlaidSecret(m)
+	assert.False(t, ok)
+}
+
+// --- extractPlaidClientID ---
+
+func TestExtractPlaidClientID_InBefore(t *testing.T) {
+	m := plaidSecretMatch("kingfisher.plaid.2")
+	id, ok := extractPlaidClientID(m)
+	assert.True(t, ok)
+	assert.Equal(t, fakePlaidClientID, id)
+}
+
+func TestExtractPlaidClientID_InAfter(t *testing.T) {
+	m := &types.Match{
+		RuleID:      "kingfisher.plaid.2",
+		NamedGroups: map[string][]byte{"token": []byte(fakePlaidSecret)},
+		Snippet: types.Snippet{
+			Before: []byte("something\n"),
+			After:  []byte(`plaid_client_id=` + fakePlaidClientID + "\n"),
+		},
+	}
+	id, ok := extractPlaidClientID(m)
+	assert.True(t, ok)
+	assert.Equal(t, fakePlaidClientID, id)
+}
+
+func TestExtractPlaidClientID_CaseInsensitive(t *testing.T) {
+	m := &types.Match{
+		RuleID:      "kingfisher.plaid.2",
+		NamedGroups: map[string][]byte{"token": []byte(fakePlaidSecret)},
+		Snippet: types.Snippet{
+			Before: []byte(`CLIENT_ID = "` + fakePlaidClientID + `"` + "\n"),
+		},
+	}
+	id, ok := extractPlaidClientID(m)
+	assert.True(t, ok)
+	assert.Equal(t, fakePlaidClientID, id)
+}
+
+func TestExtractPlaidClientID_NotFound(t *testing.T) {
+	m := plaidSecretMatchNoClientID("kingfisher.plaid.2")
+	_, ok := extractPlaidClientID(m)
+	assert.False(t, ok)
+}
+
+func TestExtractPlaidClientID_Nil(t *testing.T) {
+	_, ok := extractPlaidClientID(nil)
+	assert.False(t, ok)
+}
+
+// --- plaidEnvCheckCondition ---
+
+func TestPlaidEnvCheck_Valid(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"institutions":[],"total":0}`))
+	}))
+	defer server.Close()
+
+	c := &plaidEnvCheckCondition{
+		envURL: server.URL,
+		client: &plaidRedirectingClient{target: server.URL},
+	}
+
+	fired, err := c.Evaluate(context.Background(), plaidSecretMatch("kingfisher.plaid.2"))
+	assert.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestPlaidEnvCheck_InvalidKeys(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error_code":"INVALID_API_KEYS"}`))
+	}))
+	defer server.Close()
+
+	c := &plaidEnvCheckCondition{
+		envURL: server.URL,
+		client: &plaidRedirectingClient{target: server.URL},
+	}
+
+	fired, err := c.Evaluate(context.Background(), plaidSecretMatch("kingfisher.plaid.2"))
+	assert.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestPlaidEnvCheck_NoClientID(t *testing.T) {
+	c := &plaidEnvCheckCondition{
+		envURL: "https://production.plaid.com/institutions/get",
+	}
+	fired, err := c.Evaluate(context.Background(), plaidSecretMatchNoClientID("kingfisher.plaid.2"))
+	assert.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestPlaidEnvCheck_NilMatch(t *testing.T) {
+	c := &plaidEnvCheckCondition{
+		envURL: "https://production.plaid.com/institutions/get",
+	}
+	fired, err := c.Evaluate(context.Background(), nil)
+	assert.NoError(t, err)
+	assert.False(t, fired)
+}
+
+// --- plaidRevokedCondition ---
+
+func TestPlaidRevoked_AllReject(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error_code":"INVALID_API_KEYS"}`))
+	}))
+	defer server.Close()
+
+	c := &plaidRevokedCondition{
+		client: &plaidRedirectingClient{target: server.URL},
+	}
+
+	fired, err := c.Evaluate(context.Background(), plaidSecretMatch("kingfisher.plaid.2"))
+	assert.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestPlaidRevoked_OneAccepts(t *testing.T) {
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		if calls == 1 {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"institutions":[],"total":0}`))
+			return
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error_code":"INVALID_API_KEYS"}`))
+	}))
+	defer server.Close()
+
+	c := &plaidRevokedCondition{
+		client: &plaidRedirectingClient{target: server.URL},
+	}
+
+	fired, err := c.Evaluate(context.Background(), plaidSecretMatch("kingfisher.plaid.2"))
+	assert.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestPlaidRevoked_NoClientID(t *testing.T) {
+	c := &plaidRevokedCondition{}
+	fired, err := c.Evaluate(context.Background(), plaidSecretMatchNoClientID("kingfisher.plaid.2"))
+	assert.NoError(t, err)
+	assert.False(t, fired)
+}
+
+// --- plaidSandboxContextCondition ---
+
+func TestPlaidSandboxContext_InBefore(t *testing.T) {
+	m := &types.Match{
+		RuleID:      "kingfisher.plaid.2",
+		NamedGroups: map[string][]byte{"token": []byte(fakePlaidSecret)},
+		Snippet: types.Snippet{
+			Before: []byte("PLAID_ENV=sandbox\n"),
+		},
+	}
+	c := &plaidSandboxContextCondition{}
+	fired, err := c.Evaluate(context.Background(), m)
+	assert.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestPlaidSandboxContext_InAfter(t *testing.T) {
+	m := &types.Match{
+		RuleID:      "kingfisher.plaid.2",
+		NamedGroups: map[string][]byte{"token": []byte(fakePlaidSecret)},
+		Snippet: types.Snippet{
+			After: []byte("environment: Sandbox\n"),
+		},
+	}
+	c := &plaidSandboxContextCondition{}
+	fired, err := c.Evaluate(context.Background(), m)
+	assert.NoError(t, err)
+	assert.True(t, fired)
+}
+
+func TestPlaidSandboxContext_NotPresent(t *testing.T) {
+	m := plaidSecretMatch("kingfisher.plaid.2")
+	c := &plaidSandboxContextCondition{}
+	fired, err := c.Evaluate(context.Background(), m)
+	assert.NoError(t, err)
+	assert.False(t, fired)
+}
+
+func TestPlaidSandboxContext_Nil(t *testing.T) {
+	c := &plaidSandboxContextCondition{}
+	fired, err := c.Evaluate(context.Background(), nil)
+	assert.NoError(t, err)
+	assert.False(t, fired)
+}
+
+// --- PlaidGoScorer structure ---
+
+func TestPlaidGoScorer_Structure(t *testing.T) {
+	s := PlaidGoScorer()
+	assert.Equal(t, "plaid-secret-environment", s.Name)
+	assert.Contains(t, s.RuleIDs, "kingfisher.plaid.2")
+	assert.Contains(t, s.RuleIDs, "kingfisher.plaid.3")
+	assert.Equal(t, 5, len(s.Modifiers))
+
+	names := make([]string, len(s.Modifiers))
+	for i, mod := range s.Modifiers {
+		names[i] = mod.Name
+	}
+	assert.Contains(t, names, "sandbox-context")
+	assert.Contains(t, names, "production-verified")
+	assert.Contains(t, names, "development-verified")
+	assert.Contains(t, names, "sandbox-verified")
+	assert.Contains(t, names, "revoked-key")
+}
+
+func TestPlaidGoScorer_RuleIDsExist(t *testing.T) {
+	s := PlaidGoScorer()
+	for _, id := range s.RuleIDs {
+		assert.NotEmpty(t, id)
+	}
+}
+
+func TestPlaidGoScorer_PriorityOrder(t *testing.T) {
+	s := PlaidGoScorer()
+	byName := map[string]Modifier{}
+	for _, mod := range s.Modifiers {
+		byName[mod.Name] = mod
+	}
+
+	assert.Greater(t, byName["sandbox-context"].Priority, byName["production-verified"].Priority,
+		"static should evaluate before dynamic")
+	assert.Greater(t, byName["production-verified"].Priority, byName["sandbox-verified"].Priority,
+		"production check should evaluate before sandbox")
+	assert.Greater(t, byName["sandbox-verified"].Priority, byName["revoked-key"].Priority,
+		"env checks should evaluate before revoked")
+}
+
+func TestPlaidGoScorer_AllDynamic(t *testing.T) {
+	s := PlaidGoScorer()
+	for _, mod := range s.Modifiers {
+		if mod.Name == "sandbox-context" {
+			assert.False(t, mod.IsDynamic(), "sandbox-context should be static")
+			continue
+		}
+		assert.True(t, mod.IsDynamic(), "modifier %s should be dynamic", mod.Name)
+	}
+}
+
+func TestPlaidGoScorer_MissingToken(t *testing.T) {
+	s := PlaidGoScorer()
+	m := &types.Match{
+		RuleID:      "kingfisher.plaid.2",
+		Groups:      [][]byte{},
+		NamedGroups: map[string][]byte{},
+	}
+	for _, mod := range s.Modifiers {
+		fired, err := mod.Condition.Evaluate(context.Background(), m)
+		assert.NoError(t, err, "modifier %s should not error", mod.Name)
+		assert.False(t, fired, "modifier %s should not fire without token", mod.Name)
+	}
+}
+
+func TestPlaidGoScorer_Scores(t *testing.T) {
+	s := PlaidGoScorer()
+	byName := map[string]Modifier{}
+	for _, mod := range s.Modifiers {
+		byName[mod.Name] = mod
+	}
+
+	require.Equal(t, ModifierKindSetScore, byName["production-verified"].Kind)
+	assert.Equal(t, 95, byName["production-verified"].Value)
+
+	require.Equal(t, ModifierKindSetScore, byName["sandbox-verified"].Kind)
+	assert.Equal(t, 5, byName["sandbox-verified"].Value)
+
+	require.Equal(t, ModifierKindSetScore, byName["development-verified"].Kind)
+	assert.Equal(t, 60, byName["development-verified"].Value)
+
+	require.Equal(t, ModifierKindSetScore, byName["revoked-key"].Kind)
+	assert.Equal(t, 5, byName["revoked-key"].Value)
+
+	require.Equal(t, ModifierKindSetScore, byName["sandbox-context"].Kind)
+	assert.Equal(t, 10, byName["sandbox-context"].Value)
+}
+
+// plaidRedirectingClient redirects all requests to a test server URL.
+type plaidRedirectingClient struct {
+	target string
+}
+
+func (c *plaidRedirectingClient) Do(req *http.Request) (*http.Response, error) {
+	testURL := c.target + req.URL.Path
+	if req.URL.RawQuery != "" {
+		testURL += "?" + req.URL.RawQuery
+	}
+	newReq, err := http.NewRequestWithContext(req.Context(), req.Method, testURL, req.Body)
+	if err != nil {
+		return nil, err
+	}
+	newReq.Header = req.Header
+	return http.DefaultClient.Do(newReq)
+}


### PR DESCRIPTION
## Summary

- Adds a Go scorer for Plaid secrets (`kingfisher.plaid.2`, `kingfisher.plaid.3`) that determines which environment a secret belongs to by probing `POST /institutions/get` against all three Plaid environments (production, development, sandbox)
- **Production verified** → `set_score 95`, **development** → `60`, **sandbox** → `5`, **all reject (revoked)** → `5`
- Falls back to static "sandbox" keyword detection in surrounding context when no co-located `client_id` is available for dynamic verification
- Adds named capture groups (`(?P<token>...)`, `(?P<client_id>...)`) to all five Plaid rules

### Out of scope (deferred)
- Product-aware scoring (`auth`, `identity`, `assets` access level) — requires an access_token co-located with the secret, which is not reliably present

## Test plan

- [x] 17 new unit tests covering extraction, all condition types, scorer structure, priority ordering, and score values
- [x] All existing `pkg/scoring/` tests pass (including `TestBuiltinGoScorers_AllRuleIDsReferenceExtantRules` alignment guard)
- [x] All `pkg/matcher/TestRuleExamples` pass — named capture groups do not break detection
- [x] `go vet` clean, full build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)