### PR TITLE
feat(scoring): HuggingFace token scope scorer

### DIFF
--- a/pkg/rule/rules/huggingface.yml
+++ b/pkg/rule/rules/huggingface.yml
@@ -4,7 +4,7 @@ rules:
   id: np.huggingface.1
   base_score: 60
 
-  pattern: '\b(hf_[a-zA-Z]{34})\b'
+  pattern: '\b(?P<token>hf_[a-zA-Z]{34})\b'
 
   categories: [api, secret]
 

--- a/pkg/scoring/huggingface_test.go
+++ b/pkg/scoring/huggingface_test.go
@@ -1,0 +1,110 @@
+package scoring
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuiltinHuggingFaceScorer_IsRegisteredForRule(t *testing.T) {
+	s := builtinScorerFor(t, "np.huggingface.1")
+	assert.Equal(t, "huggingface-token-scope", s.Name)
+
+	got := make(map[string]Modifier, len(s.Modifiers))
+	for _, m := range s.Modifiers {
+		got[m.Name] = m
+	}
+	for _, name := range []string{
+		"write-access", "read-only-access", "fine-grained-token",
+		"org-member", "revoked-key",
+	} {
+		assert.Contains(t, got, name)
+	}
+}
+
+func TestBuiltinHuggingFaceScorer_AllModifiersShareOneAuthedRequest(t *testing.T) {
+	s := builtinScorerFor(t, "np.huggingface.1")
+	for _, m := range s.Modifiers {
+		cond, ok := m.Condition.(*httpCondition)
+		require.Truef(t, ok, "modifier %q should be http-backed", m.Name)
+		assert.Equal(t, "https://huggingface.co/api/whoami-v2", cond.url, "modifier %q", m.Name)
+		assert.Equal(t, "GET", cond.method, "modifier %q", m.Name)
+		assert.Equal(t, "bearer", cond.auth.Type, "modifier %q", m.Name)
+		assert.Equal(t, "token", cond.auth.SecretGroup, "modifier %q", m.Name)
+	}
+}
+
+func TestBuiltinHuggingFaceScorer_RevokedKeyIsLowestPriority(t *testing.T) {
+	s := builtinScorerFor(t, "np.huggingface.1")
+	prio := make(map[string]int, len(s.Modifiers))
+	for _, m := range s.Modifiers {
+		prio[m.Name] = m.Priority
+	}
+
+	for name, p := range prio {
+		if name == "revoked-key" {
+			continue
+		}
+		assert.Less(t, prio["revoked-key"], p,
+			"revoked-key must evaluate last; %q has lower or equal priority", name)
+	}
+}
+
+func TestBuiltinHuggingFaceScorer_OnlyRevokedUsesSetScore(t *testing.T) {
+	s := builtinScorerFor(t, "np.huggingface.1")
+	for _, m := range s.Modifiers {
+		if m.Kind == ModifierKindSetScore {
+			assert.Equal(t, "revoked-key", m.Name,
+				"only revoked-key should use set_score")
+		}
+	}
+}
+
+func TestBuiltinHuggingFaceScorer_RoleModifiersCheckCorrectPaths(t *testing.T) {
+	s := builtinScorerFor(t, "np.huggingface.1")
+
+	want := map[string]struct {
+		path  string
+		value string
+	}{
+		"write-access":      {".auth.accessToken.role", "write"},
+		"read-only-access":  {".auth.accessToken.role", "read"},
+		"fine-grained-token": {".auth.accessToken.role", "fineGrained"},
+	}
+
+	for _, m := range s.Modifiers {
+		exp, ok := want[m.Name]
+		if !ok {
+			continue
+		}
+		cond, ok := m.Condition.(*httpCondition)
+		require.Truef(t, ok, "modifier %q should be http-backed", m.Name)
+		leaf, ok := cond.firesWhen.(*jsonPathEqualsLeaf)
+		require.Truef(t, ok, "modifier %q should use json_path_equals", m.Name)
+		assert.Equal(t, exp.path, leaf.Path, "modifier %q json path", m.Name)
+		assert.Equal(t, exp.value, leaf.Value, "modifier %q expected value", m.Name)
+	}
+}
+
+func TestBuiltinHuggingFaceScorer_OrgMemberChecksOrgsArray(t *testing.T) {
+	s := builtinScorerFor(t, "np.huggingface.1")
+	for _, m := range s.Modifiers {
+		if m.Name != "org-member" {
+			continue
+		}
+		cond, ok := m.Condition.(*httpCondition)
+		require.True(t, ok)
+		leaf, ok := cond.firesWhen.(*jsonArrayLengthGteLeaf)
+		require.True(t, ok, "org-member should use json_array_length_gte")
+		assert.Equal(t, ".orgs", leaf.Path)
+		assert.Equal(t, 1, leaf.Value)
+		return
+	}
+	t.Fatal("org-member modifier not found")
+}
+
+func TestBuiltinHuggingFaceScorer_ModifierCount(t *testing.T) {
+	s := builtinScorerFor(t, "np.huggingface.1")
+	assert.Len(t, s.Modifiers, 5)
+}

--- a/pkg/scoring/scorers/huggingface.yaml
+++ b/pkg/scoring/scorers/huggingface.yaml
@@ -1,0 +1,86 @@
+# HuggingFace token scorer — read vs write, org membership (LAB-3398).
+#
+# Rule ID covered:
+#   np.huggingface.1 — HuggingFace User Access Token (hf_...): base_score 60
+#
+# GET /api/whoami-v2 returns the calling token's role and the user's org
+# memberships. The response includes:
+#   .auth.accessToken.role — "read", "write", or "fineGrained"
+#   .orgs                  — array of org objects (empty if no memberships)
+#
+# Write tokens can publish models and datasets, creating supply-chain risk.
+# Org membership broadens the blast radius. Fine-grained tokens have limited
+# scope but unknown permissions, so they get a smaller downgrade than read-only.
+#
+# All modifiers issue the SAME request. The engine caches HTTP responses on
+# (method, url, secret), so a finding costs one network call, not five.
+#
+# Score outcomes (base 60):
+#   write + org:      60 + 15 + 10 = 85
+#   write, no org:    60 + 15      = 75
+#   fine-grained+org: 60 - 10 + 10 = 60
+#   read-only + org:  60 - 20 + 10 = 50
+#   fine-grained:     60 - 10      = 50
+#   read-only:        60 - 20      = 40
+#   revoked:                         5
+#
+# API documentation:
+#   https://huggingface.co/docs/hub/security-tokens
+#   https://huggingface.co/docs/hub/api#get-apiwhoami-v2
+scorers:
+  - name: huggingface-token-scope
+    rule_ids:
+      - np.huggingface.1
+    modifiers:
+      # --- Write access: can publish models/datasets (supply chain risk) ---
+      - name: write-access
+        priority: 90
+        http: &hf_whoami
+          method: GET
+          url: https://huggingface.co/api/whoami-v2
+          auth:
+            type: bearer
+            secret_group: "token"
+        fires_when:
+          json_path_equals:
+            path: ".auth.accessToken.role"
+            value: "write"
+        delta: 15
+
+      # --- Read-only: limited blast radius ---
+      - name: read-only-access
+        priority: 80
+        http: *hf_whoami
+        fires_when:
+          json_path_equals:
+            path: ".auth.accessToken.role"
+            value: "read"
+        delta: -20
+
+      # --- Fine-grained token: limited scope, smaller downgrade than read ---
+      - name: fine-grained-token
+        priority: 75
+        http: *hf_whoami
+        fires_when:
+          json_path_equals:
+            path: ".auth.accessToken.role"
+            value: "fineGrained"
+        delta: -10
+
+      # --- Org membership: broader blast radius ---
+      - name: org-member
+        priority: 70
+        http: *hf_whoami
+        fires_when:
+          json_array_length_gte:
+            path: ".orgs"
+            value: 1
+        delta: 10
+
+      # --- Dead key: evaluated last, wins outright ---
+      - name: revoked-key
+        priority: 10
+        http: *hf_whoami
+        fires_when:
+          status_code: 401
+        set_score: 5


### PR DESCRIPTION
## Summary
- Adds a YAML scorer for `np.huggingface.1` that probes `GET /api/whoami-v2` to distinguish token capabilities
- Write tokens with org membership score 85 (supply chain risk — can publish models/datasets); read-only personal tokens score 40; revoked tokens score 5
- Adds named capture group `(?P<token>)` to the detection rule pattern (required for scorer bearer auth)
- 7 structure tests verifying modifier registration, priority ordering, condition paths, and auth consistency

## Score outcomes (base 60)
| Scenario | Score |
|----------|-------|
| write + org | 85 |
| write, no org | 75 |
| fine-grained + org | 60 |
| read-only + org | 50 |
| fine-grained, no org | 50 |
| read-only, no org | 40 |
| revoked | 5 |

## Test plan
- [x] `go test ./pkg/scoring/ -run TestBuiltinHuggingFace` — 7/7 pass
- [x] `go test ./pkg/matcher/ -run TestRuleExamples` — rule example still passes with named capture group
- [x] `go test ./pkg/validator/ -run Test_huggingface` — validator cassette tests unaffected

Fixes LAB-3398

🤖 Generated with [Claude Code](https://claude.com/claude-code)