### PR TITLE
feat(scoring): Notion token scope scorer (LAB-3404)

### DIFF
--- a/pkg/rule/rules/notion.yml
+++ b/pkg/rule/rules/notion.yml
@@ -7,7 +7,7 @@ rules:
       notion
       (?:.|[\\n\r]){0,32}?
       \b
-      (
+      (?P<token>
         secret_[A-Z0-9]{43}
       )
       \b
@@ -41,7 +41,7 @@ rules:
     pattern: |
       (?xi)
       \b
-      (
+      (?P<token>
         ntn_[0-9]{11}[A-Za-z0-9]{35}
       )
     min_entropy: 4.0

--- a/pkg/scoring/notion_test.go
+++ b/pkg/scoring/notion_test.go
@@ -1,0 +1,116 @@
+package scoring
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuiltinNotionScorer_IsRegisteredForRules(t *testing.T) {
+	for _, ruleID := range []string{"kingfisher.notion.1", "kingfisher.notion.2"} {
+		s := builtinScorerFor(t, ruleID)
+		assert.Equal(t, "notion-token-scope", s.Name)
+	}
+}
+
+func TestBuiltinNotionScorer_ModifierNames(t *testing.T) {
+	s := builtinScorerFor(t, "kingfisher.notion.1")
+	got := make(map[string]Modifier, len(s.Modifiers))
+	for _, m := range s.Modifiers {
+		got[m.Name] = m
+	}
+	for _, name := range []string{
+		"workspace-integration", "user-scoped-token", "revoked-key",
+	} {
+		assert.Contains(t, got, name)
+	}
+}
+
+func TestBuiltinNotionScorer_AllModifiersShareOneAuthedRequest(t *testing.T) {
+	s := builtinScorerFor(t, "kingfisher.notion.1")
+	for _, m := range s.Modifiers {
+		cond, ok := m.Condition.(*httpCondition)
+		require.Truef(t, ok, "modifier %q should be http-backed", m.Name)
+		assert.Equal(t, "https://api.notion.com/v1/users/me", cond.url, "modifier %q", m.Name)
+		assert.Equal(t, "GET", cond.method, "modifier %q", m.Name)
+		assert.Equal(t, "bearer", cond.auth.Type, "modifier %q", m.Name)
+		assert.Equal(t, "token", cond.auth.SecretGroup, "modifier %q", m.Name)
+	}
+}
+
+func TestBuiltinNotionScorer_NotionVersionHeader(t *testing.T) {
+	s := builtinScorerFor(t, "kingfisher.notion.1")
+	for _, m := range s.Modifiers {
+		cond, ok := m.Condition.(*httpCondition)
+		require.Truef(t, ok, "modifier %q should be http-backed", m.Name)
+		found := false
+		for _, h := range cond.headers {
+			if h.Name == "Notion-Version" {
+				assert.Equal(t, "2022-06-28", h.Value)
+				found = true
+			}
+		}
+		assert.Truef(t, found, "modifier %q missing Notion-Version header", m.Name)
+	}
+}
+
+func TestBuiltinNotionScorer_RevokedKeyIsLowestPriority(t *testing.T) {
+	s := builtinScorerFor(t, "kingfisher.notion.1")
+	prio := make(map[string]int, len(s.Modifiers))
+	for _, m := range s.Modifiers {
+		prio[m.Name] = m.Priority
+	}
+	for name, p := range prio {
+		if name == "revoked-key" {
+			continue
+		}
+		assert.Less(t, prio["revoked-key"], p,
+			"revoked-key must evaluate last; %q has lower or equal priority", name)
+	}
+}
+
+func TestBuiltinNotionScorer_OwnerTypeChecks(t *testing.T) {
+	s := builtinScorerFor(t, "kingfisher.notion.1")
+	want := map[string]string{
+		"workspace-integration": "workspace",
+		"user-scoped-token":     "user",
+	}
+	for _, m := range s.Modifiers {
+		exp, ok := want[m.Name]
+		if !ok {
+			continue
+		}
+		cond, ok := m.Condition.(*httpCondition)
+		require.Truef(t, ok, "modifier %q should be http-backed", m.Name)
+		leaf, ok := cond.firesWhen.(*jsonPathEqualsLeaf)
+		require.Truef(t, ok, "modifier %q should use json_path_equals", m.Name)
+		assert.Equal(t, ".bot.owner.type", leaf.Path, "modifier %q json path", m.Name)
+		assert.Equal(t, exp, leaf.Value, "modifier %q expected value", m.Name)
+	}
+}
+
+func TestBuiltinNotionScorer_OnlyRevokedUsesSetScore(t *testing.T) {
+	s := builtinScorerFor(t, "kingfisher.notion.1")
+	for _, m := range s.Modifiers {
+		if m.Kind == ModifierKindSetScore {
+			assert.Equal(t, "revoked-key", m.Name,
+				"only revoked-key should use set_score")
+		}
+	}
+}
+
+func TestBuiltinNotionScorer_DoesNotCoverRefreshToken(t *testing.T) {
+	scorers, err := NewLoader().LoadBuiltinScorers()
+	require.NoError(t, err)
+	for _, s := range scorers {
+		if s.canScore("kingfisher.notion.3") {
+			t.Fatal("kingfisher.notion.3 (refresh token) should not be scored — it cannot be probed directly")
+		}
+	}
+}
+
+func TestBuiltinNotionScorer_ModifierCount(t *testing.T) {
+	s := builtinScorerFor(t, "kingfisher.notion.1")
+	assert.Len(t, s.Modifiers, 3)
+}

--- a/pkg/scoring/scorers/notion.yaml
+++ b/pkg/scoring/scorers/notion.yaml
@@ -1,0 +1,72 @@
+# Notion API token scorer — workspace vs user-scoped access (LAB-3404).
+#
+# Rule IDs covered:
+#   kingfisher.notion.1 — Notion Legacy Token (secret_...): base_score 55
+#   kingfisher.notion.2 — Notion Token (ntn_...): base_score 58
+#
+# kingfisher.notion.3 (OAuth refresh token, nrt_...) is excluded because
+# refresh tokens cannot call the API directly — they must be exchanged for
+# an access token first, so no probe is possible.
+#
+# GET /v1/users/me returns the bot info and its owner type:
+#   .bot.owner.type = "workspace" — internal integration with workspace-wide
+#                                    access to all shared content
+#   .bot.owner.type = "user"      — OAuth integration scoped to pages the
+#                                    authorizing user granted access to
+#
+# Workspace integrations are significantly higher risk: they can access any
+# page/database shared with the integration, which in many workspaces means
+# HR docs, customer lists, and credentials.
+#
+# Notion requires a Notion-Version header on all API calls.
+#
+# All modifiers issue the SAME request. One network call per finding.
+#
+# Score outcomes:
+#   notion.1 (base 55): workspace → 70, user-scoped → 35, revoked → 5
+#   notion.2 (base 58): workspace → 73, user-scoped → 38, revoked → 5
+#
+# API documentation:
+#   https://developers.notion.com/reference/get-self
+#   https://developers.notion.com/docs/authorization
+scorers:
+  - name: notion-token-scope
+    rule_ids:
+      - kingfisher.notion.1
+      - kingfisher.notion.2
+    modifiers:
+      # --- Workspace integration: broad access to shared content ---
+      - name: workspace-integration
+        priority: 90
+        http: &notion_me
+          method: GET
+          url: https://api.notion.com/v1/users/me
+          auth:
+            type: bearer
+            secret_group: "token"
+          headers:
+            - name: Notion-Version
+              value: "2022-06-28"
+        fires_when:
+          json_path_equals:
+            path: ".bot.owner.type"
+            value: "workspace"
+        delta: 15
+
+      # --- User-scoped OAuth: limited to granted pages ---
+      - name: user-scoped-token
+        priority: 80
+        http: *notion_me
+        fires_when:
+          json_path_equals:
+            path: ".bot.owner.type"
+            value: "user"
+        delta: -20
+
+      # --- Dead key: evaluated last, wins outright ---
+      - name: revoked-key
+        priority: 10
+        http: *notion_me
+        fires_when:
+          status_code: 401
+        set_score: 5


### PR DESCRIPTION
## Summary
- Adds YAML scorer for Notion API tokens that probes `GET /v1/users/me` to distinguish workspace integrations (+15) from user-scoped OAuth tokens (-20)
- Revoked keys get `set_score: 5`; covers `kingfisher.notion.1` and `.2` (excludes `.3` refresh tokens — they can't call the API directly)
- Adds `(?P<token>...)` named capture groups to notion.1 and .2 rule patterns so scorer auth can extract the secret

## Test plan
- [x] 9 structure tests covering registration, header, priority, owner-type conditions, set_score, modifier count, and refresh-token exclusion
- [x] Full `go test ./pkg/scoring/ ./pkg/matcher/ ./pkg/validator/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)