### PR TITLE
feat(scoring): Asana PAT workspace breadth scorer (LAB-3400)

### DIFF
--- a/pkg/scoring/asana_test.go
+++ b/pkg/scoring/asana_test.go
@@ -1,0 +1,101 @@
+package scoring
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuiltinAsanaScorer_IsRegisteredForRule(t *testing.T) {
+	s := builtinScorerFor(t, "kingfisher.asana.3")
+	assert.Equal(t, "asana-token-scope", s.Name)
+}
+
+func TestBuiltinAsanaScorer_DoesNotCoverClientIDOrSecret(t *testing.T) {
+	scorers, err := NewLoader().LoadBuiltinScorers()
+	require.NoError(t, err)
+	for _, s := range scorers {
+		for _, id := range []string{"kingfisher.asana.1", "kingfisher.asana.2"} {
+			if s.canScore(id) {
+				t.Fatalf("%s should not be scored — client IDs and secrets cannot authenticate as bearer tokens", id)
+			}
+		}
+	}
+}
+
+func TestBuiltinAsanaScorer_AllModifiersShareOneAuthedRequest(t *testing.T) {
+	s := builtinScorerFor(t, "kingfisher.asana.3")
+	for _, m := range s.Modifiers {
+		cond, ok := m.Condition.(*httpCondition)
+		require.Truef(t, ok, "modifier %q should be http-backed", m.Name)
+		assert.Equal(t, "https://app.asana.com/api/1.0/users/me", cond.url, "modifier %q", m.Name)
+		assert.Equal(t, "GET", cond.method, "modifier %q", m.Name)
+		assert.Equal(t, "bearer", cond.auth.Type, "modifier %q", m.Name)
+		assert.Equal(t, "token", cond.auth.SecretGroup, "modifier %q", m.Name)
+	}
+}
+
+func TestBuiltinAsanaScorer_RevokedKeyIsLowestPriority(t *testing.T) {
+	s := builtinScorerFor(t, "kingfisher.asana.3")
+	prio := make(map[string]int, len(s.Modifiers))
+	for _, m := range s.Modifiers {
+		prio[m.Name] = m.Priority
+	}
+	for name, p := range prio {
+		if name == "revoked-key" {
+			continue
+		}
+		assert.Less(t, prio["revoked-key"], p,
+			"revoked-key must evaluate last; %q has lower or equal priority", name)
+	}
+}
+
+func TestBuiltinAsanaScorer_OnlyRevokedUsesSetScore(t *testing.T) {
+	s := builtinScorerFor(t, "kingfisher.asana.3")
+	for _, m := range s.Modifiers {
+		if m.Kind == ModifierKindSetScore {
+			assert.Equal(t, "revoked-key", m.Name,
+				"only revoked-key should use set_score")
+		}
+	}
+}
+
+func TestBuiltinAsanaScorer_WorkspaceModifiersCheckCorrectPath(t *testing.T) {
+	s := builtinScorerFor(t, "kingfisher.asana.3")
+	for _, m := range s.Modifiers {
+		if m.Name != "multiple-workspaces" && m.Name != "single-workspace-only" {
+			continue
+		}
+		cond, ok := m.Condition.(*httpCondition)
+		require.Truef(t, ok, "modifier %q should be http-backed", m.Name)
+
+		var leaf *jsonArrayLengthGteLeaf
+		if neg, isNeg := cond.firesWhen.(*negatedLeaf); isNeg {
+			leaf, ok = neg.inner.(*jsonArrayLengthGteLeaf)
+		} else {
+			leaf, ok = cond.firesWhen.(*jsonArrayLengthGteLeaf)
+		}
+		require.Truef(t, ok, "modifier %q should use json_array_length_gte", m.Name)
+		assert.Equal(t, ".data.workspaces", leaf.Path, "modifier %q json path", m.Name)
+		assert.Equal(t, 2, leaf.Value, "modifier %q threshold", m.Name)
+	}
+}
+
+func TestBuiltinAsanaScorer_SingleWorkspaceIsNegated(t *testing.T) {
+	s := builtinScorerFor(t, "kingfisher.asana.3")
+	for _, m := range s.Modifiers {
+		if m.Name != "single-workspace-only" {
+			continue
+		}
+		cond, ok := m.Condition.(*httpCondition)
+		require.Truef(t, ok, "modifier %q should be http-backed", m.Name)
+		_, isNegated := cond.firesWhen.(*negatedLeaf)
+		assert.Truef(t, isNegated, "single-workspace-only must use negative: true (negatedLeaf wrapper)")
+	}
+}
+
+func TestBuiltinAsanaScorer_ModifierCount(t *testing.T) {
+	s := builtinScorerFor(t, "kingfisher.asana.3")
+	assert.Len(t, s.Modifiers, 3)
+}

--- a/pkg/scoring/asana_test.go
+++ b/pkg/scoring/asana_test.go
@@ -29,7 +29,7 @@ func TestBuiltinAsanaScorer_AllModifiersShareOneAuthedRequest(t *testing.T) {
 	for _, m := range s.Modifiers {
 		cond, ok := m.Condition.(*httpCondition)
 		require.Truef(t, ok, "modifier %q should be http-backed", m.Name)
-		assert.Equal(t, "https://app.asana.com/api/1.0/users/me", cond.url, "modifier %q", m.Name)
+		assert.Equal(t, "https://app.asana.com/api/1.0/users/me?opt_fields=workspaces", cond.url, "modifier %q", m.Name)
 		assert.Equal(t, "GET", cond.method, "modifier %q", m.Name)
 		assert.Equal(t, "bearer", cond.auth.Type, "modifier %q", m.Name)
 		assert.Equal(t, "token", cond.auth.SecretGroup, "modifier %q", m.Name)

--- a/pkg/scoring/scorers/asana.yaml
+++ b/pkg/scoring/scorers/asana.yaml
@@ -32,7 +32,7 @@ scorers:
         priority: 90
         http: &asana_me
           method: GET
-          url: https://app.asana.com/api/1.0/users/me
+          url: https://app.asana.com/api/1.0/users/me?opt_fields=workspaces
           auth:
             type: bearer
             secret_group: "token"

--- a/pkg/scoring/scorers/asana.yaml
+++ b/pkg/scoring/scorers/asana.yaml
@@ -1,0 +1,62 @@
+# Asana Personal Access Token scorer — workspace access breadth (LAB-3400).
+#
+# Rule IDs covered:
+#   kingfisher.asana.3 — Asana OAuth / Personal Access Token: base_score 62
+#
+# kingfisher.asana.1 (Client ID, base_score 15) and kingfisher.asana.2
+# (Client Secret, base_score 60) are excluded: they cannot authenticate
+# as bearer tokens against the REST API.
+#
+# GET /api/1.0/users/me returns the authenticated user's profile, including
+# the .data.workspaces array listing every workspace the token can access.
+#
+# A token with access to multiple workspaces is significantly higher risk —
+# it can read tasks, projects, attachments, and comments across every
+# workspace, broadening the blast radius of a leak.
+#
+# All modifiers issue the SAME request. One network call per finding.
+#
+# Score outcomes (base 62):
+#   multiple workspaces → 72, single workspace → 47, revoked → 5
+#
+# API documentation:
+#   https://developers.asana.com/reference/getuser
+#   https://developers.asana.com/docs/personal-access-token
+scorers:
+  - name: asana-token-scope
+    rule_ids:
+      - kingfisher.asana.3
+    modifiers:
+      # --- Access to 2+ workspaces: broader blast radius ---
+      - name: multiple-workspaces
+        priority: 90
+        http: &asana_me
+          method: GET
+          url: https://app.asana.com/api/1.0/users/me
+          auth:
+            type: bearer
+            secret_group: "token"
+        fires_when:
+          json_array_length_gte:
+            path: ".data.workspaces"
+            value: 2
+        delta: 10
+
+      # --- Single workspace only: limited scope ---
+      - name: single-workspace-only
+        priority: 70
+        http: *asana_me
+        fires_when:
+          negative: true
+          json_array_length_gte:
+            path: ".data.workspaces"
+            value: 2
+        delta: -15
+
+      # --- Dead key: evaluated last, wins outright ---
+      - name: revoked-key
+        priority: 10
+        http: *asana_me
+        fires_when:
+          status_code: 401
+        set_score: 5


### PR DESCRIPTION
## Summary
- Adds YAML scorer for Asana Personal Access Tokens that probes `GET /api/1.0/users/me` to measure workspace access breadth
- Tokens with 2+ workspaces get delta +10 (broader blast radius); single-workspace tokens get delta -15 (limited scope)
- Revoked keys get `set_score: 5`
- Covers `kingfisher.asana.3` only — `.1` (Client ID) and `.2` (Client Secret) cannot authenticate as bearer tokens

## Test plan
- [x] 8 structure tests covering registration, exclusions, shared request, priority, set_score, workspace path/threshold, negation, and modifier count
- [x] Full `go test ./pkg/scoring/ ./pkg/matcher/ ./pkg/validator/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)