### PR TITLE
feat(scoring): add Anthropic API key scorer (LAB-3385)

### DIFF
--- a/pkg/scoring/anthropic_test.go
+++ b/pkg/scoring/anthropic_test.go
@@ -27,7 +27,7 @@ func TestBuiltinAnthropicScorer_AllModifiersShareOneAuthedRequest(t *testing.T) 
 	for _, m := range s.Modifiers {
 		cond, ok := m.Condition.(*httpCondition)
 		require.Truef(t, ok, "modifier %q should be http-backed", m.Name)
-		assert.Equal(t, "https://api.anthropic.com/v1/models", cond.url, "modifier %q", m.Name)
+		assert.Equal(t, "https://api.anthropic.com/v1/models?limit=1000", cond.url, "modifier %q", m.Name)
 		assert.Equal(t, "GET", cond.method, "modifier %q", m.Name)
 		assert.Equal(t, "header", cond.auth.Type, "modifier %q", m.Name)
 		assert.Equal(t, "x-api-key", cond.auth.HeaderName, "modifier %q", m.Name)

--- a/pkg/scoring/anthropic_test.go
+++ b/pkg/scoring/anthropic_test.go
@@ -1,0 +1,114 @@
+package scoring
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuiltinAnthropicScorer_IsRegisteredForRule(t *testing.T) {
+	s := builtinScorerFor(t, "np.anthropic.1")
+	assert.Equal(t, "anthropic-key-scope", s.Name)
+
+	got := make(map[string]Modifier, len(s.Modifiers))
+	for _, m := range s.Modifiers {
+		got[m.Name] = m
+	}
+	for _, name := range []string{
+		"has-opus-access", "no-opus-access", "revoked-key",
+	} {
+		assert.Contains(t, got, name)
+	}
+}
+
+func TestBuiltinAnthropicScorer_AllModifiersShareOneAuthedRequest(t *testing.T) {
+	s := builtinScorerFor(t, "np.anthropic.1")
+	for _, m := range s.Modifiers {
+		cond, ok := m.Condition.(*httpCondition)
+		require.Truef(t, ok, "modifier %q should be http-backed", m.Name)
+		assert.Equal(t, "https://api.anthropic.com/v1/models", cond.url, "modifier %q", m.Name)
+		assert.Equal(t, "GET", cond.method, "modifier %q", m.Name)
+		assert.Equal(t, "header", cond.auth.Type, "modifier %q", m.Name)
+		assert.Equal(t, "x-api-key", cond.auth.HeaderName, "modifier %q", m.Name)
+		assert.Equal(t, "token", cond.auth.SecretGroup, "modifier %q", m.Name)
+	}
+}
+
+func TestBuiltinAnthropicScorer_AnthropicVersionHeader(t *testing.T) {
+	s := builtinScorerFor(t, "np.anthropic.1")
+	for _, m := range s.Modifiers {
+		cond, ok := m.Condition.(*httpCondition)
+		require.Truef(t, ok, "modifier %q should be http-backed", m.Name)
+		found := false
+		for _, h := range cond.headers {
+			if h.Name == "anthropic-version" {
+				assert.Equal(t, "2023-06-01", h.Value)
+				found = true
+			}
+		}
+		assert.Truef(t, found, "modifier %q missing anthropic-version header", m.Name)
+	}
+}
+
+func TestBuiltinAnthropicScorer_RevokedKeyIsLowestPriority(t *testing.T) {
+	s := builtinScorerFor(t, "np.anthropic.1")
+	prio := make(map[string]int, len(s.Modifiers))
+	for _, m := range s.Modifiers {
+		prio[m.Name] = m.Priority
+	}
+	for name, p := range prio {
+		if name == "revoked-key" {
+			continue
+		}
+		assert.Less(t, prio["revoked-key"], p,
+			"revoked-key must evaluate last; %q has lower or equal priority", name)
+	}
+}
+
+func TestBuiltinAnthropicScorer_OnlyRevokedUsesSetScore(t *testing.T) {
+	s := builtinScorerFor(t, "np.anthropic.1")
+	for _, m := range s.Modifiers {
+		if m.Kind == ModifierKindSetScore {
+			assert.Equal(t, "revoked-key", m.Name,
+				"only revoked-key should use set_score")
+		}
+	}
+}
+
+func TestBuiltinAnthropicScorer_NoOpusIsNegated(t *testing.T) {
+	s := builtinScorerFor(t, "np.anthropic.1")
+	for _, m := range s.Modifiers {
+		if m.Name != "no-opus-access" {
+			continue
+		}
+		cond, ok := m.Condition.(*httpCondition)
+		require.True(t, ok)
+		_, ok = cond.firesWhen.(*negatedLeaf)
+		assert.True(t, ok, "no-opus-access should use negative: true")
+		return
+	}
+	t.Fatal("no-opus-access modifier not found")
+}
+
+func TestBuiltinAnthropicScorer_RevokedKeyCovers403(t *testing.T) {
+	s := builtinScorerFor(t, "np.anthropic.1")
+	for _, m := range s.Modifiers {
+		if m.Name != "revoked-key" {
+			continue
+		}
+		cond, ok := m.Condition.(*httpCondition)
+		require.True(t, ok)
+		leaf, ok := cond.firesWhen.(*statusCodeInLeaf)
+		require.True(t, ok, "revoked-key should use status_code_in")
+		assert.Contains(t, leaf.Codes, 401)
+		assert.Contains(t, leaf.Codes, 403)
+		return
+	}
+	t.Fatal("revoked-key modifier not found")
+}
+
+func TestBuiltinAnthropicScorer_ModifierCount(t *testing.T) {
+	s := builtinScorerFor(t, "np.anthropic.1")
+	assert.Len(t, s.Modifiers, 3)
+}

--- a/pkg/scoring/scorers/anthropic.yaml
+++ b/pkg/scoring/scorers/anthropic.yaml
@@ -1,0 +1,63 @@
+# Anthropic API key scorer — model access tier (LAB-3385).
+#
+# Rule ID covered:
+#   np.anthropic.1 — Anthropic API Key (sk-ant-api...): base_score 70
+#
+# GET /v1/models returns the list of models the key can access. The Anthropic
+# API requires an x-api-key header (not Bearer) and an anthropic-version
+# header.
+#
+# Keys with access to Claude Opus models are highest risk — they have the
+# most capable model and highest per-token cost. Keys without Opus access
+# are limited to cheaper tiers.
+#
+# All modifiers issue the SAME request. One network call per finding.
+#
+# Score outcomes (base 70):
+#   Opus access:    70 + 10 = 80
+#   no Opus access: 70 - 15 = 55
+#   revoked:                   5
+#
+# API documentation:
+#   https://docs.anthropic.com/en/api/models-list
+scorers:
+  - name: anthropic-key-scope
+    rule_ids:
+      - np.anthropic.1
+    modifiers:
+      # --- Opus access: highest-capability model available ---
+      # The /v1/models response contains model ID strings. If "claude-opus"
+      # appears in the body, the key has access to the most capable tier.
+      - name: has-opus-access
+        priority: 90
+        http: &anthropic_models
+          method: GET
+          url: https://api.anthropic.com/v1/models
+          auth:
+            type: header
+            header_name: x-api-key
+            secret_group: "token"
+          headers:
+            - name: anthropic-version
+              value: "2023-06-01"
+        fires_when:
+          response_body_contains: '"claude-opus'
+        delta: 10
+
+      # --- No Opus: limited to lower-tier models ---
+      - name: no-opus-access
+        priority: 70
+        http: *anthropic_models
+        fires_when:
+          negative: true
+          response_body_contains: '"claude-opus'
+        delta: -15
+
+      # --- Dead key: evaluated last, wins outright ---
+      # Anthropic returns 401 for invalid keys, 403 for disabled keys.
+      - name: revoked-key
+        priority: 10
+        http: *anthropic_models
+        fires_when:
+          status_code_in: [401, 403]
+        set_score: 5

--- a/pkg/scoring/scorers/anthropic.yaml
+++ b/pkg/scoring/scorers/anthropic.yaml
@@ -26,13 +26,14 @@ scorers:
       - np.anthropic.1
     modifiers:
       # --- Opus access: highest-capability model available ---
-      # The /v1/models response contains model ID strings. If "claude-opus"
-      # appears in the body, the key has access to the most capable tier.
+      # The /v1/models response lists model IDs. Matching "opus" catches both
+      # legacy claude-3-opus-* and current claude-opus-4-* naming conventions.
+      # ?limit=1000 avoids pagination cutting off results.
       - name: has-opus-access
         priority: 90
         http: &anthropic_models
           method: GET
-          url: https://api.anthropic.com/v1/models
+          url: https://api.anthropic.com/v1/models?limit=1000
           auth:
             type: header
             header_name: x-api-key
@@ -41,7 +42,7 @@ scorers:
             - name: anthropic-version
               value: "2023-06-01"
         fires_when:
-          response_body_contains: '"claude-opus'
+          response_body_contains: 'opus'
         delta: 10
 
       # --- No Opus: limited to lower-tier models ---
@@ -50,7 +51,7 @@ scorers:
         http: *anthropic_models
         fires_when:
           negative: true
-          response_body_contains: '"claude-opus'
+          response_body_contains: 'opus'
         delta: -15
 
       # --- Dead key: evaluated last, wins outright ---


### PR DESCRIPTION
## Summary
- Add YAML scorer for Anthropic API keys (`np.anthropic.1`, base score 70)
- Probes `GET /v1/models` with header auth (`x-api-key`) and `anthropic-version` header
- Claude Opus access → score 80, no Opus → score 55, revoked → score 5
- Covers both 401 and 403 failure codes per the validator

## Test plan
- [x] 8 unit tests covering registration, shared request, anthropic-version header, priority ordering, set_score exclusivity, negation, 403 coverage, modifier count
- [x] Full scoring test suite passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)