### PR TITLE
feat(scoring): add ElevenLabs API key scorer

### DIFF
--- a/pkg/rule/rules/elevenlabs.yml
+++ b/pkg/rule/rules/elevenlabs.yml
@@ -5,9 +5,9 @@ rules:
     pattern: |       
       (?xi)       
       \b    
-      (               
-        sk_           
-        [0-9a-f]{48}  
+      (?P<token>
+        sk_
+        [0-9a-f]{48}
       )
       \b
     pattern_requirements:

--- a/pkg/scoring/elevenlabs_test.go
+++ b/pkg/scoring/elevenlabs_test.go
@@ -1,0 +1,115 @@
+package scoring
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuiltinElevenLabsScorer_IsRegisteredForRule(t *testing.T) {
+	s := builtinScorerFor(t, "kingfisher.elevenlabs.1")
+	assert.Equal(t, "elevenlabs-key-scope", s.Name)
+
+	got := make(map[string]Modifier, len(s.Modifiers))
+	for _, m := range s.Modifiers {
+		got[m.Name] = m
+	}
+	for _, name := range []string{
+		"paid-tier", "free-tier", "revoked-key",
+	} {
+		assert.Contains(t, got, name)
+	}
+}
+
+func TestBuiltinElevenLabsScorer_AllModifiersShareOneAuthedRequest(t *testing.T) {
+	s := builtinScorerFor(t, "kingfisher.elevenlabs.1")
+	for _, m := range s.Modifiers {
+		cond, ok := m.Condition.(*httpCondition)
+		require.Truef(t, ok, "modifier %q should be http-backed", m.Name)
+		assert.Equal(t, "https://api.elevenlabs.io/v1/user/subscription", cond.url, "modifier %q", m.Name)
+		assert.Equal(t, "GET", cond.method, "modifier %q", m.Name)
+		assert.Equal(t, "header", cond.auth.Type, "modifier %q", m.Name)
+		assert.Equal(t, "xi-api-key", cond.auth.HeaderName, "modifier %q", m.Name)
+		assert.Equal(t, "token", cond.auth.SecretGroup, "modifier %q", m.Name)
+	}
+}
+
+func TestBuiltinElevenLabsScorer_RevokedKeyIsLowestPriority(t *testing.T) {
+	s := builtinScorerFor(t, "kingfisher.elevenlabs.1")
+	prio := make(map[string]int, len(s.Modifiers))
+	for _, m := range s.Modifiers {
+		prio[m.Name] = m.Priority
+	}
+	for name, p := range prio {
+		if name == "revoked-key" {
+			continue
+		}
+		assert.Less(t, prio["revoked-key"], p,
+			"revoked-key must evaluate last; %q has lower or equal priority", name)
+	}
+}
+
+func TestBuiltinElevenLabsScorer_OnlyRevokedUsesSetScore(t *testing.T) {
+	s := builtinScorerFor(t, "kingfisher.elevenlabs.1")
+	for _, m := range s.Modifiers {
+		if m.Kind == ModifierKindSetScore {
+			assert.Equal(t, "revoked-key", m.Name,
+				"only revoked-key should use set_score")
+		}
+	}
+}
+
+func TestBuiltinElevenLabsScorer_PaidTierIsNegated(t *testing.T) {
+	s := builtinScorerFor(t, "kingfisher.elevenlabs.1")
+	for _, m := range s.Modifiers {
+		if m.Name != "paid-tier" {
+			continue
+		}
+		cond, ok := m.Condition.(*httpCondition)
+		require.True(t, ok)
+		_, ok = cond.firesWhen.(*negatedLeaf)
+		assert.True(t, ok, "paid-tier should use negative: true")
+		return
+	}
+	t.Fatal("paid-tier modifier not found")
+}
+
+func TestBuiltinElevenLabsScorer_FreeTierChecksTierField(t *testing.T) {
+	s := builtinScorerFor(t, "kingfisher.elevenlabs.1")
+	for _, m := range s.Modifiers {
+		if m.Name != "free-tier" {
+			continue
+		}
+		cond, ok := m.Condition.(*httpCondition)
+		require.True(t, ok)
+		leaf, ok := cond.firesWhen.(*jsonPathEqualsLeaf)
+		require.True(t, ok, "free-tier should use json_path_equals")
+		assert.Equal(t, ".tier", leaf.Path)
+		assert.Equal(t, "free", leaf.Value)
+		return
+	}
+	t.Fatal("free-tier modifier not found")
+}
+
+func TestBuiltinElevenLabsScorer_RevokedKeyCovers403(t *testing.T) {
+	s := builtinScorerFor(t, "kingfisher.elevenlabs.1")
+	for _, m := range s.Modifiers {
+		if m.Name != "revoked-key" {
+			continue
+		}
+		cond, ok := m.Condition.(*httpCondition)
+		require.True(t, ok)
+		leaf, ok := cond.firesWhen.(*statusCodeInLeaf)
+		require.True(t, ok, "revoked-key should use status_code_in")
+		assert.Contains(t, leaf.Codes, 401)
+		assert.Contains(t, leaf.Codes, 403)
+		return
+	}
+	t.Fatal("revoked-key modifier not found")
+}
+
+func TestBuiltinElevenLabsScorer_ModifierCount(t *testing.T) {
+	s := builtinScorerFor(t, "kingfisher.elevenlabs.1")
+	assert.Len(t, s.Modifiers, 3)
+}

--- a/pkg/scoring/elevenlabs_test.go
+++ b/pkg/scoring/elevenlabs_test.go
@@ -52,12 +52,15 @@ func TestBuiltinElevenLabsScorer_RevokedKeyIsLowestPriority(t *testing.T) {
 
 func TestBuiltinElevenLabsScorer_OnlyRevokedUsesSetScore(t *testing.T) {
 	s := builtinScorerFor(t, "kingfisher.elevenlabs.1")
+	found := false
 	for _, m := range s.Modifiers {
 		if m.Kind == ModifierKindSetScore {
+			found = true
 			assert.Equal(t, "revoked-key", m.Name,
 				"only revoked-key should use set_score")
 		}
 	}
+	assert.True(t, found, "revoked-key should use set_score")
 }
 
 func TestBuiltinElevenLabsScorer_PaidTierIsNegated(t *testing.T) {

--- a/pkg/scoring/elevenlabs_test.go
+++ b/pkg/scoring/elevenlabs_test.go
@@ -92,7 +92,7 @@ func TestBuiltinElevenLabsScorer_FreeTierChecksTierField(t *testing.T) {
 	t.Fatal("free-tier modifier not found")
 }
 
-func TestBuiltinElevenLabsScorer_RevokedKeyCovers403(t *testing.T) {
+func TestBuiltinElevenLabsScorer_RevokedKeyIs401Only(t *testing.T) {
 	s := builtinScorerFor(t, "kingfisher.elevenlabs.1")
 	for _, m := range s.Modifiers {
 		if m.Name != "revoked-key" {
@@ -100,10 +100,9 @@ func TestBuiltinElevenLabsScorer_RevokedKeyCovers403(t *testing.T) {
 		}
 		cond, ok := m.Condition.(*httpCondition)
 		require.True(t, ok)
-		leaf, ok := cond.firesWhen.(*statusCodeInLeaf)
-		require.True(t, ok, "revoked-key should use status_code_in")
-		assert.Contains(t, leaf.Codes, 401)
-		assert.Contains(t, leaf.Codes, 403)
+		leaf, ok := cond.firesWhen.(*statusCodeLeaf)
+		require.True(t, ok, "revoked-key should use status_code (not status_code_in)")
+		assert.Equal(t, 401, leaf.Code)
 		return
 	}
 	t.Fatal("revoked-key modifier not found")

--- a/pkg/scoring/scorers/elevenlabs.yaml
+++ b/pkg/scoring/scorers/elevenlabs.yaml
@@ -28,9 +28,9 @@ scorers:
       - kingfisher.elevenlabs.1
     modifiers:
       # --- Paid tier: can generate significant voice content ---
-      # A free-tier response contains "free" in the tier field. Paid
-      # tiers (starter/creator/pro/scale/enterprise) do NOT contain
-      # "free", so negative response_body_contains fires on paid keys.
+      # A free-tier response has .tier = "free". Paid tiers
+      # (starter/creator/pro/scale/enterprise) have a different value,
+      # so negative json_path_equals fires on paid keys.
       - name: paid-tier
         priority: 90
         http: &elevenlabs_sub
@@ -58,10 +58,12 @@ scorers:
         delta: -15
 
       # --- Dead key: evaluated last, wins outright ---
-      # ElevenLabs returns 401 for invalid keys.
+      # ElevenLabs returns 401 for invalid keys. 403 is NOT included
+      # because scoped keys return 403 with "missing_permissions" when
+      # they lack subscription access — those are still live credentials.
       - name: revoked-key
         priority: 10
         http: *elevenlabs_sub
         fires_when:
-          status_code_in: [401, 403]
+          status_code: 401
         set_score: 5

--- a/pkg/scoring/scorers/elevenlabs.yaml
+++ b/pkg/scoring/scorers/elevenlabs.yaml
@@ -1,0 +1,67 @@
+# ElevenLabs API key scorer — subscription tier (LAB-3356).
+#
+# Rule ID covered:
+#   kingfisher.elevenlabs.1 — ElevenLabs API Key (sk_...): base_score 55
+#
+# GET /v1/user/subscription returns the calling key's subscription info.
+# The response includes a "tier" field: "free", "starter", "creator",
+# "pro", "scale", or "enterprise".
+#
+# ElevenLabs uses a custom header (xi-api-key) for authentication.
+#
+# Paid-tier keys can generate large volumes of synthetic voice content,
+# making them a deepfake and social-engineering risk. Free-tier keys
+# have strict character limits and limited voice options.
+#
+# All modifiers issue the SAME request. One network call per finding.
+#
+# Score outcomes (base 55):
+#   paid tier:  55 + 15 = 70
+#   free tier:  55 - 15 = 40
+#   revoked:               5
+#
+# API documentation:
+#   https://elevenlabs.io/docs/api-reference/user/subscription/get
+scorers:
+  - name: elevenlabs-key-scope
+    rule_ids:
+      - kingfisher.elevenlabs.1
+    modifiers:
+      # --- Paid tier: can generate significant voice content ---
+      # A free-tier response contains "free" in the tier field. Paid
+      # tiers (starter/creator/pro/scale/enterprise) do NOT contain
+      # "free", so negative response_body_contains fires on paid keys.
+      - name: paid-tier
+        priority: 90
+        http: &elevenlabs_sub
+          method: GET
+          url: https://api.elevenlabs.io/v1/user/subscription
+          auth:
+            type: header
+            header_name: xi-api-key
+            secret_group: "token"
+        fires_when:
+          negative: true
+          json_path_equals:
+            path: ".tier"
+            value: "free"
+        delta: 15
+
+      # --- Free tier: limited character quota ---
+      - name: free-tier
+        priority: 70
+        http: *elevenlabs_sub
+        fires_when:
+          json_path_equals:
+            path: ".tier"
+            value: "free"
+        delta: -15
+
+      # --- Dead key: evaluated last, wins outright ---
+      # ElevenLabs returns 401 for invalid keys.
+      - name: revoked-key
+        priority: 10
+        http: *elevenlabs_sub
+        fires_when:
+          status_code_in: [401, 403]
+        set_score: 5


### PR DESCRIPTION
## Summary
- Add subscription-tier-aware scoring for ElevenLabs API keys (`kingfisher.elevenlabs.1`, base 55)
- Probes `GET /v1/user/subscription` with `xi-api-key` header to determine tier
- Paid-tier keys score 70, free-tier keys score 40, revoked keys score 5
- Update rule regex to use named capture group `(?P<token>...)` so the scorer engine can extract the secret via `NamedGroups`

## Test plan
- [x] 8 unit tests covering registration, auth config, priority ordering, negation, condition types, modifier count
- [x] Full `pkg/scoring` and `pkg/rule` test suites pass
- [ ] Bot review

Part of LAB-3356 scorer backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)