### PR TITLE
feat(scoring): add Ngrok API key scorer

### DIFF
--- a/pkg/rule/rules/ngrok.yml
+++ b/pkg/rule/rules/ngrok.yml
@@ -9,7 +9,7 @@ rules:
       (?:.|[\\n\r]){0,32}?
       (?:SECRET|PRIVATE|ACCESS|KEY|TOKEN)
       (?:.|[\n\r]){0,32}?
-      (
+      (?P<token>
         (?:[a-z0-9]{25,30}_\d[a-z0-9]{20}
         |
         (?:cr_|ak_)[a-z0-9]{25,30})

--- a/pkg/scoring/ngrok_test.go
+++ b/pkg/scoring/ngrok_test.go
@@ -67,12 +67,15 @@ func TestBuiltinNgrokScorer_RevokedKeyIsLowestPriority(t *testing.T) {
 
 func TestBuiltinNgrokScorer_OnlyRevokedUsesSetScore(t *testing.T) {
 	s := builtinScorerFor(t, "kingfisher.ngrok.1")
+	found := false
 	for _, m := range s.Modifiers {
 		if m.Kind == ModifierKindSetScore {
+			found = true
 			assert.Equal(t, "revoked-key", m.Name,
 				"only revoked-key should use set_score")
 		}
 	}
+	assert.True(t, found, "revoked-key should use set_score")
 }
 
 func TestBuiltinNgrokScorer_NoActiveEndpointsIsNegated(t *testing.T) {

--- a/pkg/scoring/ngrok_test.go
+++ b/pkg/scoring/ngrok_test.go
@@ -1,0 +1,113 @@
+package scoring
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuiltinNgrokScorer_IsRegisteredForRule(t *testing.T) {
+	s := builtinScorerFor(t, "kingfisher.ngrok.1")
+	assert.Equal(t, "ngrok-key-scope", s.Name)
+
+	got := make(map[string]Modifier, len(s.Modifiers))
+	for _, m := range s.Modifiers {
+		got[m.Name] = m
+	}
+	for _, name := range []string{
+		"has-active-endpoints", "no-active-endpoints", "revoked-key",
+	} {
+		assert.Contains(t, got, name)
+	}
+}
+
+func TestBuiltinNgrokScorer_AllModifiersShareOneAuthedRequest(t *testing.T) {
+	s := builtinScorerFor(t, "kingfisher.ngrok.1")
+	for _, m := range s.Modifiers {
+		cond, ok := m.Condition.(*httpCondition)
+		require.Truef(t, ok, "modifier %q should be http-backed", m.Name)
+		assert.Equal(t, "https://api.ngrok.com/endpoints", cond.url, "modifier %q", m.Name)
+		assert.Equal(t, "GET", cond.method, "modifier %q", m.Name)
+		assert.Equal(t, "bearer", cond.auth.Type, "modifier %q", m.Name)
+		assert.Equal(t, "token", cond.auth.SecretGroup, "modifier %q", m.Name)
+	}
+}
+
+func TestBuiltinNgrokScorer_NgrokVersionHeader(t *testing.T) {
+	s := builtinScorerFor(t, "kingfisher.ngrok.1")
+	for _, m := range s.Modifiers {
+		cond, ok := m.Condition.(*httpCondition)
+		require.Truef(t, ok, "modifier %q should be http-backed", m.Name)
+		found := false
+		for _, h := range cond.headers {
+			if h.Name == "ngrok-version" {
+				assert.Equal(t, "2", h.Value)
+				found = true
+			}
+		}
+		assert.Truef(t, found, "modifier %q missing ngrok-version header", m.Name)
+	}
+}
+
+func TestBuiltinNgrokScorer_RevokedKeyIsLowestPriority(t *testing.T) {
+	s := builtinScorerFor(t, "kingfisher.ngrok.1")
+	prio := make(map[string]int, len(s.Modifiers))
+	for _, m := range s.Modifiers {
+		prio[m.Name] = m.Priority
+	}
+	for name, p := range prio {
+		if name == "revoked-key" {
+			continue
+		}
+		assert.Less(t, prio["revoked-key"], p,
+			"revoked-key must evaluate last; %q has lower or equal priority", name)
+	}
+}
+
+func TestBuiltinNgrokScorer_OnlyRevokedUsesSetScore(t *testing.T) {
+	s := builtinScorerFor(t, "kingfisher.ngrok.1")
+	for _, m := range s.Modifiers {
+		if m.Kind == ModifierKindSetScore {
+			assert.Equal(t, "revoked-key", m.Name,
+				"only revoked-key should use set_score")
+		}
+	}
+}
+
+func TestBuiltinNgrokScorer_NoActiveEndpointsIsNegated(t *testing.T) {
+	s := builtinScorerFor(t, "kingfisher.ngrok.1")
+	for _, m := range s.Modifiers {
+		if m.Name != "no-active-endpoints" {
+			continue
+		}
+		cond, ok := m.Condition.(*httpCondition)
+		require.True(t, ok)
+		_, ok = cond.firesWhen.(*negatedLeaf)
+		assert.True(t, ok, "no-active-endpoints should use negative: true")
+		return
+	}
+	t.Fatal("no-active-endpoints modifier not found")
+}
+
+func TestBuiltinNgrokScorer_RevokedKeyCovers403(t *testing.T) {
+	s := builtinScorerFor(t, "kingfisher.ngrok.1")
+	for _, m := range s.Modifiers {
+		if m.Name != "revoked-key" {
+			continue
+		}
+		cond, ok := m.Condition.(*httpCondition)
+		require.True(t, ok)
+		leaf, ok := cond.firesWhen.(*statusCodeInLeaf)
+		require.True(t, ok, "revoked-key should use status_code_in")
+		assert.Contains(t, leaf.Codes, 401)
+		assert.Contains(t, leaf.Codes, 403)
+		return
+	}
+	t.Fatal("revoked-key modifier not found")
+}
+
+func TestBuiltinNgrokScorer_ModifierCount(t *testing.T) {
+	s := builtinScorerFor(t, "kingfisher.ngrok.1")
+	assert.Len(t, s.Modifiers, 3)
+}

--- a/pkg/scoring/scorers/ngrok.yaml
+++ b/pkg/scoring/scorers/ngrok.yaml
@@ -1,0 +1,66 @@
+# Ngrok API key scorer — active endpoint exposure (LAB-3356).
+#
+# Rule ID covered:
+#   kingfisher.ngrok.1 — Ngrok API Key: base_score 70
+#
+# GET /endpoints returns the list of active ngrok endpoints (tunnels).
+# The response JSON contains an "endpoints" array.
+#
+# Ngrok requires a bearer token and an ngrok-version header.
+#
+# Keys with active endpoints expose internal services to the internet,
+# making them a direct lateral-movement and data-exfiltration risk.
+# Keys with no active endpoints are valid but currently less dangerous.
+#
+# All modifiers issue the SAME request. One network call per finding.
+#
+# Score outcomes (base 70):
+#   active endpoints:  70 + 10 = 80
+#   no endpoints:      70 - 10 = 60
+#   revoked:                      5
+#
+# API documentation:
+#   https://ngrok.com/docs/api/resources/endpoints/
+scorers:
+  - name: ngrok-key-scope
+    rule_ids:
+      - kingfisher.ngrok.1
+    modifiers:
+      # --- Active endpoints: tunnels currently exposing services ---
+      # json_array_length_gte on .endpoints >= 1 means at least one
+      # active tunnel exists.
+      - name: has-active-endpoints
+        priority: 90
+        http: &ngrok_endpoints
+          method: GET
+          url: https://api.ngrok.com/endpoints
+          auth:
+            type: bearer
+            secret_group: "token"
+          headers:
+            - name: ngrok-version
+              value: "2"
+        fires_when:
+          json_array_length_gte:
+            path: ".endpoints"
+            value: 1
+        delta: 10
+
+      # --- No active endpoints: valid key but nothing exposed ---
+      - name: no-active-endpoints
+        priority: 70
+        http: *ngrok_endpoints
+        fires_when:
+          negative: true
+          json_array_length_gte:
+            path: ".endpoints"
+            value: 1
+        delta: -10
+
+      # --- Dead key: evaluated last, wins outright ---
+      - name: revoked-key
+        priority: 10
+        http: *ngrok_endpoints
+        fires_when:
+          status_code_in: [401, 403]
+        set_score: 5


### PR DESCRIPTION
## Summary
- Add endpoint-exposure-aware scoring for Ngrok API keys (`kingfisher.ngrok.1`, base 70)
- Probes `GET /endpoints` with bearer auth and `ngrok-version: 2` header
- Keys with active endpoints score 80, no endpoints score 60, revoked keys score 5
- Update rule regex to use named capture group `(?P<token>...)` for scorer engine compatibility

## Test plan
- [x] 8 unit tests covering registration, auth config, custom header, priority ordering, negation, condition types, modifier count
- [x] Full `pkg/scoring` and `pkg/rule` test suites pass
- [ ] Bot review

Part of LAB-3356 scorer backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)