### PR TITLE
feat(scoring): add Netlify API key scorer

### DIFF
--- a/pkg/rule/rules/netlify.yml
+++ b/pkg/rule/rules/netlify.yml
@@ -9,7 +9,7 @@ rules:
       (?:SECRET|PRIVATE|ACCESS|KEY|TOKEN)
       (?:.|[\n\r]){0,32}?
       \b
-      (
+      (?P<token>
         [a-f0-9]{60,64}
       )
       \b
@@ -43,7 +43,7 @@ rules:
       (?:SECRET|PRIVATE|ACCESS|KEY|TOKEN)
       (?:.|[\n\r]){0,32}?
       \b
-      (
+      (?P<token>
         [A-Z0-9_-]{43,45}
       )
       \b

--- a/pkg/scoring/netlify_test.go
+++ b/pkg/scoring/netlify_test.go
@@ -1,0 +1,116 @@
+package scoring
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuiltinNetlifyScorer_IsRegisteredForRule(t *testing.T) {
+	for _, ruleID := range []string{"kingfisher.netlify.1", "kingfisher.netlify.2"} {
+		s := builtinScorerFor(t, ruleID)
+		assert.Equal(t, "netlify-key-scope", s.Name)
+
+		got := make(map[string]Modifier, len(s.Modifiers))
+		for _, m := range s.Modifiers {
+			got[m.Name] = m
+		}
+		for _, name := range []string{
+			"has-sites", "no-sites", "revoked-key",
+		} {
+			assert.Contains(t, got, name, "rule %s", ruleID)
+		}
+	}
+}
+
+func TestBuiltinNetlifyScorer_AllModifiersShareOneAuthedRequest(t *testing.T) {
+	s := builtinScorerFor(t, "kingfisher.netlify.1")
+	for _, m := range s.Modifiers {
+		cond, ok := m.Condition.(*httpCondition)
+		require.Truef(t, ok, "modifier %q should be http-backed", m.Name)
+		assert.Equal(t, "https://api.netlify.com/api/v1/sites", cond.url, "modifier %q", m.Name)
+		assert.Equal(t, "GET", cond.method, "modifier %q", m.Name)
+		assert.Equal(t, "bearer", cond.auth.Type, "modifier %q", m.Name)
+		assert.Equal(t, "token", cond.auth.SecretGroup, "modifier %q", m.Name)
+	}
+}
+
+func TestBuiltinNetlifyScorer_RevokedKeyIsLowestPriority(t *testing.T) {
+	s := builtinScorerFor(t, "kingfisher.netlify.1")
+	prio := make(map[string]int, len(s.Modifiers))
+	for _, m := range s.Modifiers {
+		prio[m.Name] = m.Priority
+	}
+	for name, p := range prio {
+		if name == "revoked-key" {
+			continue
+		}
+		assert.Less(t, prio["revoked-key"], p,
+			"revoked-key must evaluate last; %q has lower or equal priority", name)
+	}
+}
+
+func TestBuiltinNetlifyScorer_OnlyRevokedUsesSetScore(t *testing.T) {
+	s := builtinScorerFor(t, "kingfisher.netlify.1")
+	for _, m := range s.Modifiers {
+		if m.Kind == ModifierKindSetScore {
+			assert.Equal(t, "revoked-key", m.Name,
+				"only revoked-key should use set_score")
+		}
+	}
+}
+
+func TestBuiltinNetlifyScorer_NoSitesIsNegated(t *testing.T) {
+	s := builtinScorerFor(t, "kingfisher.netlify.1")
+	for _, m := range s.Modifiers {
+		if m.Name != "no-sites" {
+			continue
+		}
+		cond, ok := m.Condition.(*httpCondition)
+		require.True(t, ok)
+		_, ok = cond.firesWhen.(*negatedLeaf)
+		assert.True(t, ok, "no-sites should use negative: true")
+		return
+	}
+	t.Fatal("no-sites modifier not found")
+}
+
+func TestBuiltinNetlifyScorer_HasSitesChecksRootArray(t *testing.T) {
+	s := builtinScorerFor(t, "kingfisher.netlify.1")
+	for _, m := range s.Modifiers {
+		if m.Name != "has-sites" {
+			continue
+		}
+		cond, ok := m.Condition.(*httpCondition)
+		require.True(t, ok)
+		leaf, ok := cond.firesWhen.(*jsonArrayLengthGteLeaf)
+		require.True(t, ok, "has-sites should use json_array_length_gte")
+		assert.Equal(t, ".", leaf.Path)
+		assert.Equal(t, 1, leaf.Value)
+		return
+	}
+	t.Fatal("has-sites modifier not found")
+}
+
+func TestBuiltinNetlifyScorer_RevokedKeyCovers403(t *testing.T) {
+	s := builtinScorerFor(t, "kingfisher.netlify.1")
+	for _, m := range s.Modifiers {
+		if m.Name != "revoked-key" {
+			continue
+		}
+		cond, ok := m.Condition.(*httpCondition)
+		require.True(t, ok)
+		leaf, ok := cond.firesWhen.(*statusCodeInLeaf)
+		require.True(t, ok, "revoked-key should use status_code_in")
+		assert.Contains(t, leaf.Codes, 401)
+		assert.Contains(t, leaf.Codes, 403)
+		return
+	}
+	t.Fatal("revoked-key modifier not found")
+}
+
+func TestBuiltinNetlifyScorer_ModifierCount(t *testing.T) {
+	s := builtinScorerFor(t, "kingfisher.netlify.1")
+	assert.Len(t, s.Modifiers, 3)
+}

--- a/pkg/scoring/scorers/netlify.yaml
+++ b/pkg/scoring/scorers/netlify.yaml
@@ -1,0 +1,64 @@
+# Netlify API key scorer — site access scope (LAB-3356).
+#
+# Rule IDs covered:
+#   kingfisher.netlify.1 — Netlify API Key (hex, 60-64 chars): base_score 75
+#   kingfisher.netlify.2 — Netlify API Key (base62, 43-45 chars): base_score 75
+#
+# GET /api/v1/sites returns the sites accessible to the token. Netlify
+# personal access tokens grant full account access — deploys, DNS,
+# environment variables (which often contain other secrets).
+#
+# Keys that can manage sites pose a direct supply-chain risk: an
+# attacker can deploy malicious code to production. Keys with no
+# accessible sites are valid but lower risk.
+#
+# All modifiers issue the SAME request. One network call per finding.
+#
+# Score outcomes (base 75):
+#   has sites:  75 + 10 = 85
+#   no sites:   75 - 10 = 65
+#   revoked:                5
+#
+# API documentation:
+#   https://docs.netlify.com/api/get-started/
+scorers:
+  - name: netlify-key-scope
+    rule_ids:
+      - kingfisher.netlify.1
+      - kingfisher.netlify.2
+    modifiers:
+      # --- Has sites: can deploy to production ---
+      # /api/v1/sites returns an array of site objects. At least one
+      # site means the key can manage live deployments.
+      - name: has-sites
+        priority: 90
+        http: &netlify_sites
+          method: GET
+          url: https://api.netlify.com/api/v1/sites
+          auth:
+            type: bearer
+            secret_group: "token"
+        fires_when:
+          json_array_length_gte:
+            path: "."
+            value: 1
+        delta: 10
+
+      # --- No sites: valid key but no deployable targets ---
+      - name: no-sites
+        priority: 70
+        http: *netlify_sites
+        fires_when:
+          negative: true
+          json_array_length_gte:
+            path: "."
+            value: 1
+        delta: -10
+
+      # --- Dead key: evaluated last, wins outright ---
+      - name: revoked-key
+        priority: 10
+        http: *netlify_sites
+        fires_when:
+          status_code_in: [401, 403]
+        set_score: 5


### PR DESCRIPTION
## Summary
- Add site-access-aware scoring for Netlify API keys (`kingfisher.netlify.1` and `.2`, base 75)
- Probes `GET /api/v1/sites` with bearer auth to check site count
- Keys with sites score 85, no sites score 65, revoked keys score 5
- Update both rule regexes to use named capture groups `(?P<token>...)` for scorer engine compatibility

## Test plan
- [x] 8 unit tests covering both rule IDs, auth config, priority ordering, negation, root array path, condition types, modifier count
- [x] Full `pkg/scoring` and `pkg/rule` test suites pass
- [ ] Bot review

Part of LAB-3356 scorer backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)