### PR TITLE
fix(scoring,validator): add fallback_urls for SendGrid EU data residency (LAB-6047)

### DIFF
--- a/pkg/scoring/condition_http.go
+++ b/pkg/scoring/condition_http.go
@@ -25,12 +25,13 @@ type firesWhenLeaf interface {
 // goroutines concurrently wrote to the cache field of shared *httpCondition
 // instances.
 type httpCondition struct {
-	method    string
-	url       string         // may contain {{group}} placeholders
-	headers   []scorerHeader
-	body      string
-	auth      scorerAuth
-	firesWhen firesWhenLeaf
+	method       string
+	url          string         // may contain {{group}} placeholders
+	fallbackURLs []string      // tried in order on 401 from the primary URL
+	headers      []scorerHeader
+	body         string
+	auth         scorerAuth
+	firesWhen    firesWhenLeaf
 }
 
 // markDynamic implements the networkCondition marker interface.
@@ -78,10 +79,34 @@ func (c *httpCondition) evaluateWithCache(ctx context.Context, m *types.Match, c
 		if err != nil {
 			return false, fmt.Errorf("http condition request: %w", err)
 		}
-		// Always cache the response — including 429/5xx — so that subsequent
-		// calls for the same secret/URL fast-fail without hitting the network
-		// again.
 		cache.put(key, resp)
+	}
+
+	// Regional fallback: if the primary host returned 401 and fallback URLs
+	// are configured, try each in order. The first non-401 response wins.
+	// This handles providers with regional endpoints (e.g. SendGrid EU) where
+	// a key valid on one host is rejected by the other.
+	if resp.StatusCode == http.StatusUnauthorized && len(c.fallbackURLs) > 0 {
+		for _, fbURL := range c.fallbackURLs {
+			fbRendered := renderRequest(c.method, fbURL, c.headers, c.body, m.NamedGroups)
+			fbKey := httpCacheKey(fbRendered, c.auth, secretBytes)
+
+			fbResp, fbFound := cache.get(fbKey)
+			if !fbFound {
+				var err error
+				fbResp, err = withRetry(ctx, func() (*cachedHTTPResponse, error) {
+					return sendRenderedRequest(ctx, fbRendered, c.auth, string(secretBytes))
+				})
+				if err != nil {
+					continue
+				}
+				cache.put(fbKey, fbResp)
+			}
+			if fbResp.StatusCode != http.StatusUnauthorized {
+				resp = fbResp
+				break
+			}
+		}
 	}
 
 	// Classify persistent 429/5xx as sentinel errors so trackError increments the

--- a/pkg/scoring/condition_http_test.go
+++ b/pkg/scoring/condition_http_test.go
@@ -454,3 +454,151 @@ func TestHTTPCondition_CachedRateLimit_StaysClassified(t *testing.T) {
 	assert.NotErrorIs(t, err2, ErrConditionNotApplicable,
 		"a throttled API must never be silently skipped")
 }
+
+// --- Fallback URL tests (LAB-6047) ---
+
+func TestHTTPCondition_FallbackURL_UsedOn401(t *testing.T) {
+	// Primary returns 401, fallback returns 200 with scopes.
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(401)
+		_, _ = w.Write([]byte(`{"errors":[{"message":"authorization required"}]}`))
+	}))
+	defer primary.Close()
+
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"scopes":["mail.send"]}`))
+	}))
+	defer fallback.Close()
+
+	cond := &httpCondition{
+		method:       "GET",
+		url:          primary.URL,
+		fallbackURLs: []string{fallback.URL},
+		auth:         scorerAuth{},
+		firesWhen:    &responseBodyContainsLeaf{Value: `"mail.send"`},
+	}
+
+	fired, err := cond.Evaluate(context.Background(), matchWithGroups(nil))
+	require.NoError(t, err)
+	assert.True(t, fired, "should fire against fallback response")
+}
+
+func TestHTTPCondition_FallbackURL_NotUsedOnSuccess(t *testing.T) {
+	var fallbackCalled bool
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"scopes":["mail.send"]}`))
+	}))
+	defer primary.Close()
+
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fallbackCalled = true
+		w.WriteHeader(200)
+	}))
+	defer fallback.Close()
+
+	cond := &httpCondition{
+		method:       "GET",
+		url:          primary.URL,
+		fallbackURLs: []string{fallback.URL},
+		auth:         scorerAuth{},
+		firesWhen:    &statusCodeLeaf{Code: 200},
+	}
+
+	fired, err := cond.Evaluate(context.Background(), matchWithGroups(nil))
+	require.NoError(t, err)
+	assert.True(t, fired)
+	assert.False(t, fallbackCalled, "fallback should not be called when primary succeeds")
+}
+
+func TestHTTPCondition_FallbackURL_BothReject(t *testing.T) {
+	// Both hosts return 401 → revoked-key should fire.
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(401)
+	}))
+	defer primary.Close()
+
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(401)
+	}))
+	defer fallback.Close()
+
+	cond := &httpCondition{
+		method:       "GET",
+		url:          primary.URL,
+		fallbackURLs: []string{fallback.URL},
+		auth:         scorerAuth{},
+		firesWhen:    &statusCodeLeaf{Code: 401},
+	}
+
+	fired, err := cond.Evaluate(context.Background(), matchWithGroups(nil))
+	require.NoError(t, err)
+	assert.True(t, fired, "revoked-key should fire when both hosts reject")
+}
+
+func TestHTTPCondition_FallbackURL_CachesIndependently(t *testing.T) {
+	var primaryCalls, fallbackCalls int
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		primaryCalls++
+		w.WriteHeader(401)
+	}))
+	defer primary.Close()
+
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fallbackCalls++
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"scopes":["mail.send"]}`))
+	}))
+	defer fallback.Close()
+
+	cache := newHTTPResponseCache()
+	cond := &httpCondition{
+		method:       "GET",
+		url:          primary.URL,
+		fallbackURLs: []string{fallback.URL},
+		auth:         scorerAuth{},
+		firesWhen:    &responseBodyContainsLeaf{Value: `"mail.send"`},
+	}
+	m := matchWithGroups(nil)
+
+	// First call: hits both servers.
+	_, err := cond.evaluateWithCache(context.Background(), m, cache)
+	require.NoError(t, err)
+	assert.Equal(t, 1, primaryCalls)
+	assert.Equal(t, 1, fallbackCalls)
+
+	// Second call: both responses cached — no new HTTP calls.
+	_, err = cond.evaluateWithCache(context.Background(), m, cache)
+	require.NoError(t, err)
+	assert.Equal(t, 1, primaryCalls, "primary should be cached")
+	assert.Equal(t, 1, fallbackCalls, "fallback should be cached")
+}
+
+func TestHTTPCondition_FallbackURL_SkipsOn403(t *testing.T) {
+	// Fallback is only tried on 401, not on other error codes.
+	var fallbackCalled bool
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(403)
+	}))
+	defer primary.Close()
+
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fallbackCalled = true
+		w.WriteHeader(200)
+	}))
+	defer fallback.Close()
+
+	cond := &httpCondition{
+		method:       "GET",
+		url:          primary.URL,
+		fallbackURLs: []string{fallback.URL},
+		auth:         scorerAuth{},
+		firesWhen:    &statusCodeLeaf{Code: 403},
+	}
+
+	fired, err := cond.Evaluate(context.Background(), matchWithGroups(nil))
+	require.NoError(t, err)
+	assert.True(t, fired)
+	assert.False(t, fallbackCalled, "fallback should not be tried on 403")
+}

--- a/pkg/scoring/loader.go
+++ b/pkg/scoring/loader.go
@@ -212,12 +212,13 @@ func convertYAMLModifier(ym yamlModifier) (Modifier, error) {
 			return Modifier{}, fmt.Errorf("modifier %q fires_when: %w", ym.Name, err)
 		}
 		cond = &httpCondition{
-			method:    ym.HTTP.Method,
-			url:       ym.HTTP.URL,
-			auth:      yamlAuthToScorerAuth(ym.HTTP.Auth),
-			headers:   yamlHeadersToScorerHeaders(ym.HTTP.Headers),
-			body:      ym.HTTP.Body,
-			firesWhen: leaf,
+			method:       ym.HTTP.Method,
+			url:          ym.HTTP.URL,
+			fallbackURLs: ym.HTTP.FallbackURLs,
+			auth:         yamlAuthToScorerAuth(ym.HTTP.Auth),
+			headers:      yamlHeadersToScorerHeaders(ym.HTTP.Headers),
+			body:         ym.HTTP.Body,
+			firesWhen:    leaf,
 		}
 	}
 	if condCount != 1 {

--- a/pkg/scoring/scorers/sendgrid.yaml
+++ b/pkg/scoring/scorers/sendgrid.yaml
@@ -32,21 +32,6 @@
 # The 100 / 25 thresholds are breadth heuristics and are the intended tuning
 # knobs; they should be calibrated against a real Full Access key's scope count.
 #
-# KNOWN LIMITATION -- EU data residency:
-# This scorer probes only the global host. SendGrid EU regional subusers have
-# their own API keys served from https://api.eu.sendgrid.com, so an EU key is
-# expected to fail against the global host and would then be scored 5 by
-# revoked-key -- a live credential reported as dead.
-#
-# This is not fixable in the current DSL. Distinguishing "revoked" from "wrong
-# region" means firing revoked-key only when BOTH hosts reject the key, and
-# fires_when has no conjunction: each modifier carries exactly one leaf. Adding
-# EU modifiers alongside the global ones does not help, because revoked-key
-# evaluates last and its set_score would still overwrite them.
-#
-# The same gap already exists in pkg/validator/validators/sendgrid.yaml, which
-# also checks only the global host. Tracked separately; see LAB-3371 follow-up.
-#
 # API documentation:
 #   https://www.twilio.com/docs/sendgrid/api-reference/api-key-permissions
 #   https://www.twilio.com/docs/sendgrid/data-residency/faq
@@ -65,6 +50,8 @@ scorers:
         http: &sendgrid_scopes
           method: GET
           url: https://api.sendgrid.com/v3/scopes
+          fallback_urls:
+            - https://api.eu.sendgrid.com/v3/scopes
           auth:
             type: bearer
             secret_group: "token"

--- a/pkg/scoring/sendgrid_test.go
+++ b/pkg/scoring/sendgrid_test.go
@@ -127,3 +127,14 @@ func TestBuiltinSendGridScorer_OnlyTerminalStatesUseSetScore(t *testing.T) {
 		}
 	}
 }
+
+func TestBuiltinSendGridScorer_AllModifiersHaveEUFallback(t *testing.T) {
+	s := builtinScorerFor(t, "np.sendgrid.1")
+	for _, m := range s.Modifiers {
+		cond, ok := m.Condition.(*httpCondition)
+		require.Truef(t, ok, "modifier %q should be http-backed", m.Name)
+		require.Lenf(t, cond.fallbackURLs, 1, "modifier %q should have one fallback URL", m.Name)
+		assert.Equal(t, "https://api.eu.sendgrid.com/v3/scopes", cond.fallbackURLs[0],
+			"modifier %q fallback should be the EU endpoint", m.Name)
+	}
+}

--- a/pkg/scoring/yaml.go
+++ b/pkg/scoring/yaml.go
@@ -44,11 +44,12 @@ type yamlModifier struct {
 
 // yamlHTTPDef mirrors pkg/validator/yaml.go HTTPDef but lives in the scorer package.
 type yamlHTTPDef struct {
-	Method  string         `yaml:"method"`
-	URL     string         `yaml:"url"`
-	Auth    yamlScorerAuth `yaml:"auth,omitempty"`
-	Headers []yamlHeader   `yaml:"headers,omitempty"`
-	Body    string         `yaml:"body,omitempty"`
+	Method       string         `yaml:"method"`
+	URL          string         `yaml:"url"`
+	FallbackURLs []string      `yaml:"fallback_urls,omitempty"`
+	Auth         yamlScorerAuth `yaml:"auth,omitempty"`
+	Headers      []yamlHeader   `yaml:"headers,omitempty"`
+	Body         string         `yaml:"body,omitempty"`
 }
 
 type yamlScorerAuth struct {

--- a/pkg/validator/http.go
+++ b/pkg/validator/http.go
@@ -47,16 +47,32 @@ func (v *HTTPValidator) CanValidate(ruleID string) bool {
 
 // Validate performs HTTP validation against the configured endpoint.
 func (v *HTTPValidator) Validate(ctx context.Context, match *types.Match) (*types.ValidationResult, error) {
-	// Extract secret from match
 	secret, err := v.extractSecret(match)
 	if err != nil {
 		return types.NewValidationResult(types.StatusUndetermined, 0, err.Error()), nil
 	}
 
-	// Substitute URL templates with named capture group values
-	url := substituteTemplateVars(v.def.HTTP.URL, match.NamedGroups)
+	urls := append([]string{v.def.HTTP.URL}, v.def.HTTP.FallbackURLs...)
 
-	// Build request with optional body (also substitute template vars)
+	for i, rawURL := range urls {
+		result, err := v.tryURL(ctx, match, secret, rawURL)
+		if err != nil {
+			return result, err
+		}
+		// If the primary URL indicates failure and there are more URLs to try,
+		// fall through to the next one. This handles regional endpoints where a
+		// key valid on one host is rejected by the other.
+		if result.Status != types.StatusInvalid || i == len(urls)-1 {
+			return result, nil
+		}
+	}
+
+	return types.NewValidationResult(types.StatusUndetermined, 0, "no URLs to try"), nil
+}
+
+func (v *HTTPValidator) tryURL(ctx context.Context, match *types.Match, secret, rawURL string) (*types.ValidationResult, error) {
+	url := substituteTemplateVars(rawURL, match.NamedGroups)
+
 	var body io.Reader
 	if v.def.HTTP.Body != "" {
 		body = strings.NewReader(substituteTemplateVars(v.def.HTTP.Body, match.NamedGroups))
@@ -66,24 +82,20 @@ func (v *HTTPValidator) Validate(ctx context.Context, match *types.Match) (*type
 		return types.NewValidationResult(types.StatusUndetermined, 0, fmt.Sprintf("failed to create request: %v", err)), nil
 	}
 
-	// Apply auth
 	if err := v.applyAuth(req, secret); err != nil {
 		return types.NewValidationResult(types.StatusUndetermined, 0, err.Error()), nil
 	}
 
-	// Apply custom headers (with template substitution)
 	for _, h := range v.def.HTTP.Headers {
 		req.Header.Set(h.Name, substituteTemplateVars(h.Value, match.NamedGroups))
 	}
 
-	// Execute request
 	resp, err := v.client.Do(req)
 	if err != nil {
 		return types.NewValidationResult(types.StatusUndetermined, 0, fmt.Sprintf("request failed: %v", err)), nil
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	// Read response body if needed for body-based validation
 	var respBody []byte
 	if v.def.HTTP.SuccessBodyContains != "" || v.def.HTTP.FailureBodyContains != "" {
 		respBody, err = io.ReadAll(resp.Body)
@@ -94,7 +106,6 @@ func (v *HTTPValidator) Validate(ctx context.Context, match *types.Match) (*type
 		_, _ = io.Copy(io.Discard, resp.Body)
 	}
 
-	// Check response code and body
 	return v.evaluateResponse(resp.StatusCode, respBody), nil
 }
 

--- a/pkg/validator/http_test.go
+++ b/pkg/validator/http_test.go
@@ -650,3 +650,114 @@ func TestHTTPValidator_Validate_FailureBodyContains(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, types.StatusInvalid, result.Status)
 }
+
+// --- Fallback URL tests (LAB-6047) ---
+
+func TestHTTPValidator_FallbackURL_UsedOnFailure(t *testing.T) {
+	// Primary rejects the key, fallback accepts it (regional endpoint).
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer primary.Close()
+
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer fallback.Close()
+
+	def := ValidatorDef{
+		Name:    "sendgrid-regional",
+		RuleIDs: []string{"np.sendgrid.1"},
+		HTTP: HTTPDef{
+			Method:       "GET",
+			URL:          primary.URL,
+			FallbackURLs: []string{fallback.URL},
+			Auth:         AuthDef{Type: "bearer", SecretGroup: "token"},
+			SuccessCodes: []int{200},
+			FailureCodes: []int{401, 403},
+		},
+	}
+
+	v := NewHTTPValidator(def, nil)
+	match := &types.Match{
+		RuleID:      "np.sendgrid.1",
+		NamedGroups: map[string][]byte{"token": []byte("SG.test")},
+	}
+
+	result, err := v.Validate(context.Background(), match)
+	assert.NoError(t, err)
+	assert.Equal(t, types.StatusValid, result.Status, "should be valid via fallback")
+}
+
+func TestHTTPValidator_FallbackURL_NotUsedOnSuccess(t *testing.T) {
+	var fallbackCalled bool
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer primary.Close()
+
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fallbackCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer fallback.Close()
+
+	def := ValidatorDef{
+		Name:    "sendgrid-regional",
+		RuleIDs: []string{"np.sendgrid.1"},
+		HTTP: HTTPDef{
+			Method:       "GET",
+			URL:          primary.URL,
+			FallbackURLs: []string{fallback.URL},
+			Auth:         AuthDef{Type: "bearer", SecretGroup: "token"},
+			SuccessCodes: []int{200},
+			FailureCodes: []int{401, 403},
+		},
+	}
+
+	v := NewHTTPValidator(def, nil)
+	match := &types.Match{
+		RuleID:      "np.sendgrid.1",
+		NamedGroups: map[string][]byte{"token": []byte("SG.test")},
+	}
+
+	result, err := v.Validate(context.Background(), match)
+	assert.NoError(t, err)
+	assert.Equal(t, types.StatusValid, result.Status)
+	assert.False(t, fallbackCalled, "fallback should not be called when primary succeeds")
+}
+
+func TestHTTPValidator_FallbackURL_BothReject(t *testing.T) {
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer primary.Close()
+
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer fallback.Close()
+
+	def := ValidatorDef{
+		Name:    "sendgrid-regional",
+		RuleIDs: []string{"np.sendgrid.1"},
+		HTTP: HTTPDef{
+			Method:       "GET",
+			URL:          primary.URL,
+			FallbackURLs: []string{fallback.URL},
+			Auth:         AuthDef{Type: "bearer", SecretGroup: "token"},
+			SuccessCodes: []int{200},
+			FailureCodes: []int{401, 403},
+		},
+	}
+
+	v := NewHTTPValidator(def, nil)
+	match := &types.Match{
+		RuleID:      "np.sendgrid.1",
+		NamedGroups: map[string][]byte{"token": []byte("SG.test")},
+	}
+
+	result, err := v.Validate(context.Background(), match)
+	assert.NoError(t, err)
+	assert.Equal(t, types.StatusInvalid, result.Status, "should be invalid when both reject")
+}

--- a/pkg/validator/validators/sendgrid.yaml
+++ b/pkg/validator/validators/sendgrid.yaml
@@ -8,6 +8,8 @@ validators:
     http:
       method: GET
       url: https://api.sendgrid.com/v3/scopes
+      fallback_urls:
+        - https://api.eu.sendgrid.com/v3/scopes
       auth:
         type: bearer
         secret_group: "token"  # Matches (?P<token>...) in rule regex

--- a/pkg/validator/yaml.go
+++ b/pkg/validator/yaml.go
@@ -23,6 +23,7 @@ type ValidatorDef struct {
 type HTTPDef struct {
 	Method              string   `yaml:"method"`
 	URL                 string   `yaml:"url"`
+	FallbackURLs        []string `yaml:"fallback_urls,omitempty"` // tried in order when primary returns a failure code
 	Auth                AuthDef  `yaml:"auth"`
 	Headers             []Header `yaml:"headers,omitempty"`
 	Body                string   `yaml:"body,omitempty"` // Static request body for POST/PUT


### PR DESCRIPTION
## Summary

- Adds `fallback_urls` to the HTTP block in both the scorer DSL and the validator YAML schema
- On a 401 from the primary URL, each fallback is tried in order; the first non-401 response is used
- Each URL gets its own cache entry so a finding costs at most two network calls across all seven modifiers (one per host)
- Wires the SendGrid EU endpoint (`api.eu.sendgrid.com`) into both the scorer and validator via YAML anchor inheritance

Fixes the silent-failure case where EU regional subuser keys were scored as revoked (set_score: 5) because the global endpoint returned 401.

## Test plan

- [x] 5 new scorer fallback unit tests (401→fallback, success skips fallback, both reject, independent caching, 403 skips fallback)
- [x] 1 new SendGrid integration test (all 7 modifiers carry the EU fallback URL)
- [x] 3 new validator fallback unit tests (401→fallback valid, success skips fallback, both reject invalid)
- [x] Full `go test ./pkg/scoring/... ./pkg/validator/...` passes
- [x] `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)