### PR TITLE
feat(enum): add titus enum gdrive subcommand (LAB-4309)

### DIFF
--- a/cmd/titus/enum.go
+++ b/cmd/titus/enum.go
@@ -42,7 +42,7 @@ func registerEnumScanFlags(fs *pflag.FlagSet) {
 
 func init() {
 	registerEnumScanFlags(enumCmd.PersistentFlags())
-	enumCmd.AddCommand(githubCmd, gitlabCmd, slackCmd, notionCmd, linearCmd, confluenceCmd, jiraCmd, microsoftCmd)
+	enumCmd.AddCommand(githubCmd, gitlabCmd, slackCmd, notionCmd, linearCmd, confluenceCmd, jiraCmd, microsoftCmd, gdriveCmd)
 }
 
 // runEnumScan runs the shared enumeration pipeline: load rules → create matcher/store →

--- a/cmd/titus/enum_gdrive.go
+++ b/cmd/titus/enum_gdrive.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/praetorian-inc/titus/pkg/enum"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+var (
+	gdriveToken        string
+	gdriveRefreshToken string
+	gdriveClientID     string
+	gdriveClientSecret string
+	gdriveScope        string
+	gdriveDriveID      string
+	gdriveRateLimit    float64
+	gdriveConcurrency  int
+)
+
+var gdriveCmd = &cobra.Command{
+	Use:   "gdrive",
+	Short: "Scan Google Drive for secrets",
+	Long: `Scan Google Drive files for secrets via the Drive API v3.
+Enumerates Google Docs, Sheets, Slides, and uploaded files.
+
+Authentication:
+  Use an OAuth access token, or a refresh token with client credentials for
+  automatic token renewal on long scans.
+
+  --token or GOOGLE_DRIVE_TOKEN: short-lived OAuth access token.
+  --refresh-token + --client-id + --client-secret: auto-refreshing credentials.
+
+Scope:
+  --scope controls which slice of Drive to enumerate:
+    all             My Drive + shared-with-me + all shared drives (default)
+    mine            Only files in My Drive
+    shared-with-me  Only files shared with the authenticated user
+    shared-drives   All shared drives (no My Drive or shared-with-me)
+
+  --drive-id scans a single shared drive by ID.
+
+Examples:
+  GOOGLE_DRIVE_TOKEN=ya29.xxx titus enum gdrive
+  titus enum gdrive --token ya29.xxx --scope mine
+  titus enum gdrive --token ya29.xxx --drive-id 0ABcd1EfGhIjKl
+  titus enum gdrive --refresh-token 1//xxx --client-id CID --client-secret CS --scope shared-drives`,
+	RunE: runGDriveEnumScan,
+}
+
+func registerGDriveFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&gdriveToken, "token", "", "OAuth access token (or GOOGLE_DRIVE_TOKEN env)")
+	fs.StringVar(&gdriveRefreshToken, "refresh-token", "", "OAuth refresh token (or GOOGLE_DRIVE_REFRESH_TOKEN env)")
+	fs.StringVar(&gdriveClientID, "client-id", "", "OAuth client ID (or GOOGLE_DRIVE_CLIENT_ID env)")
+	fs.StringVar(&gdriveClientSecret, "client-secret", "", "OAuth client secret (or GOOGLE_DRIVE_CLIENT_SECRET env)")
+	fs.StringVar(&gdriveScope, "scope", "all", "Drive scope: all, mine, shared-with-me, shared-drives")
+	fs.StringVar(&gdriveDriveID, "drive-id", "", "Scan a single shared drive by ID")
+	fs.Float64Var(&gdriveRateLimit, "rate-limit", 16, "Requests per second")
+	fs.IntVar(&gdriveConcurrency, "concurrency", 5, "Number of parallel file download workers")
+}
+
+func init() {
+	registerGDriveFlags(gdriveCmd.Flags())
+}
+
+func runGDriveEnumScan(cmd *cobra.Command, args []string) error {
+	token := envOrFlag(gdriveToken, "GOOGLE_DRIVE_TOKEN")
+	refresh := envOrFlag(gdriveRefreshToken, "GOOGLE_DRIVE_REFRESH_TOKEN")
+	clientID := envOrFlag(gdriveClientID, "GOOGLE_DRIVE_CLIENT_ID")
+	clientSecret := envOrFlag(gdriveClientSecret, "GOOGLE_DRIVE_CLIENT_SECRET")
+
+	if token == "" && refresh == "" {
+		return fmt.Errorf("auth required: set --token / GOOGLE_DRIVE_TOKEN, or --refresh-token + --client-id + --client-secret")
+	}
+
+	scope, err := parseGDriveScope(gdriveScope, gdriveDriveID)
+	if err != nil {
+		return err
+	}
+
+	var verboseWriter io.Writer
+	if verbose {
+		verboseWriter = cmd.ErrOrStderr()
+	}
+
+	enumerator, err := enum.NewGDriveEnumerator(enum.GDriveConfig{
+		Token:        token,
+		RefreshToken: refresh,
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		Scope:        scope,
+		DriveID:      gdriveDriveID,
+		Verbose:      verboseWriter,
+		RateLimit:    gdriveRateLimit,
+		Concurrency:  gdriveConcurrency,
+	})
+	if err != nil {
+		return fmt.Errorf("creating Google Drive enumerator: %w", err)
+	}
+
+	return runEnumScan(cmd, enumerator, "Google Drive")
+}
+
+func parseGDriveScope(scopeStr, driveID string) (enum.GDriveScope, error) {
+	if driveID != "" {
+		return enum.GDriveScopeSingleDrive, nil
+	}
+	switch scopeStr {
+	case "all":
+		return enum.GDriveScopeAll, nil
+	case "mine":
+		return enum.GDriveScopeMine, nil
+	case "shared-with-me":
+		return enum.GDriveScopeSharedWithMe, nil
+	case "shared-drives":
+		return enum.GDriveScopeSharedDrives, nil
+	default:
+		return 0, fmt.Errorf("unknown --scope %q (expected all, mine, shared-with-me, shared-drives)", scopeStr)
+	}
+}
+
+func envOrFlag(flag, envVar string) string {
+	if flag != "" {
+		return flag
+	}
+	return os.Getenv(envVar)
+}

--- a/cmd/titus/enum_gdrive.go
+++ b/cmd/titus/enum_gdrive.go
@@ -19,6 +19,8 @@ var (
 	gdriveDriveID      string
 	gdriveRateLimit    float64
 	gdriveConcurrency  int
+	gdriveMaxFileSize  int64
+	gdriveExtract      string
 )
 
 var gdriveCmd = &cobra.Command{
@@ -60,6 +62,8 @@ func registerGDriveFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&gdriveDriveID, "drive-id", "", "Scan a single shared drive by ID")
 	fs.Float64Var(&gdriveRateLimit, "rate-limit", 16, "Requests per second")
 	fs.IntVar(&gdriveConcurrency, "concurrency", 5, "Number of parallel file download workers")
+	fs.Int64Var(&gdriveMaxFileSize, "max-file-size", 10*1024*1024, "Maximum file size to scan in bytes (0 = unlimited)")
+	fs.StringVar(&gdriveExtract, "extract", "xlsx", "Extract text from binary files (extensions: xlsx,docx,pdf,zip or 'all')")
 }
 
 func init() {
@@ -96,6 +100,10 @@ func runGDriveEnumScan(cmd *cobra.Command, args []string) error {
 		Verbose:      verboseWriter,
 		RateLimit:    gdriveRateLimit,
 		Concurrency:  gdriveConcurrency,
+		Config: enum.Config{
+			MaxFileSize:     gdriveMaxFileSize,
+			ExtractArchives: gdriveExtract,
+		},
 	})
 	if err != nil {
 		return fmt.Errorf("creating Google Drive enumerator: %w", err)

--- a/cmd/titus/enum_test.go
+++ b/cmd/titus/enum_test.go
@@ -35,7 +35,7 @@ func TestEnumCmd_NotHidden(t *testing.T) {
 }
 
 // TestEnumCmd_SubcommandCount verifies that enumCmd has exactly the expected
-// 7 service subcommands + the microsoft parent (8 children total).
+// service subcommands.
 func TestEnumCmd_SubcommandCount(t *testing.T) {
 	cmd, _, err := rootCmd.Find([]string{"enum"})
 	require.NoError(t, err)
@@ -45,8 +45,8 @@ func TestEnumCmd_SubcommandCount(t *testing.T) {
 		names = append(names, sub.Name())
 	}
 
-	expected := []string{"confluence", "github", "gitlab", "jira", "linear", "microsoft", "notion", "slack"}
-	assert.ElementsMatch(t, expected, names, "enum should have exactly 7 service subcommands + microsoft parent (8 children total)")
+	expected := []string{"confluence", "gdrive", "github", "gitlab", "jira", "linear", "microsoft", "notion", "slack"}
+	assert.ElementsMatch(t, expected, names, "enum subcommands should match")
 }
 
 // TestEnumCmd_HasMicrosoftSubcommand verifies the microsoft parent is a child


### PR DESCRIPTION
## Summary

- Adds `titus enum gdrive` subcommand exposing the existing Google Drive enumerator through the standard enum CLI pattern
- Supports OAuth access tokens and refresh-token-based auto-renewal for long scans
- Scope filtering via `--scope` (all/mine/shared-with-me/shared-drives) and `--drive-id` for single shared drives
- Rate limiting and concurrency flags match the existing `titus scan` gdrive:// integration

The enumerator itself (`pkg/enum/gdrive.go`) was already complete — this PR just adds the missing CLI entry point so `titus enum gdrive` works alongside `titus enum slack`, `titus enum notion`, etc.

## Test plan

- [x] `go build ./cmd/titus/` compiles cleanly
- [x] `titus enum gdrive --help` shows flags and examples
- [x] `TestEnumCmd_SubcommandCount` updated to include gdrive — all cmd tests pass
- [x] Full `go test ./cmd/titus/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)