### PR TITLE
feat(enum): add ServiceNow enumerator for Table API (LAB-4313)

### DIFF
--- a/cmd/titus/enum.go
+++ b/cmd/titus/enum.go
@@ -24,7 +24,7 @@ var (
 var enumCmd = &cobra.Command{
 	Use:   "enum",
 	Short: "Enumerate remote services for secrets",
-	Long: `Enumerate remote services (GitHub, GitLab, Slack, Notion, Linear, Confluence, Jira, Microsoft 365)
+	Long: `Enumerate remote services (GitHub, GitLab, Slack, Notion, Linear, Confluence, Jira, Microsoft 365, ServiceNow)
 for secrets using detection rules.`,
 }
 

--- a/cmd/titus/enum.go
+++ b/cmd/titus/enum.go
@@ -42,7 +42,7 @@ func registerEnumScanFlags(fs *pflag.FlagSet) {
 
 func init() {
 	registerEnumScanFlags(enumCmd.PersistentFlags())
-	enumCmd.AddCommand(githubCmd, gitlabCmd, slackCmd, notionCmd, linearCmd, confluenceCmd, jiraCmd, microsoftCmd)
+	enumCmd.AddCommand(githubCmd, gitlabCmd, slackCmd, notionCmd, linearCmd, confluenceCmd, jiraCmd, microsoftCmd, servicenowCmd)
 }
 
 // runEnumScan runs the shared enumeration pipeline: load rules → create matcher/store →

--- a/cmd/titus/enum_servicenow.go
+++ b/cmd/titus/enum_servicenow.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/praetorian-inc/titus/pkg/enum"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+var (
+	servicenowInstance          string
+	servicenowUsername          string
+	servicenowPassword          string
+	servicenowOAuthToken        string
+	servicenowTables            string
+	servicenowRateLimit         float64
+	servicenowAllowInsecureHTTP bool
+)
+
+var servicenowCmd = &cobra.Command{
+	Use:   "servicenow",
+	Short: "Scan a ServiceNow instance for secrets",
+	Long: `Scan a ServiceNow instance for secrets via the REST Table API.
+Enumerates records from configurable tables (default: incident, change_request, kb_knowledge).
+
+Authentication:
+  Basic auth: use --username and --password.
+  OAuth: use --oauth-token with a bearer token.
+
+Examples:
+  titus enum servicenow --instance https://mycompany.service-now.com --username admin --password s3cret
+  SERVICENOW_INSTANCE=https://mycompany.service-now.com SERVICENOW_OAUTH_TOKEN=tok titus enum servicenow
+  titus enum servicenow --instance https://mycompany.service-now.com --username admin --password s3cret --tables incident,kb_knowledge,sc_req_item`,
+	RunE: runServiceNowEnumScan,
+}
+
+func registerServiceNowFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&servicenowInstance, "instance", "", "ServiceNow instance URL (or SERVICENOW_INSTANCE env)")
+	fs.StringVar(&servicenowUsername, "username", "", "ServiceNow username for basic auth (or SERVICENOW_USERNAME env)")
+	fs.StringVar(&servicenowPassword, "password", "", "ServiceNow password for basic auth (or SERVICENOW_PASSWORD env)")
+	fs.StringVar(&servicenowOAuthToken, "oauth-token", "", "ServiceNow OAuth2 bearer token (or SERVICENOW_OAUTH_TOKEN env)")
+	fs.StringVar(&servicenowTables, "tables", "", "Comma-separated table names to scan (default: incident,change_request,kb_knowledge)")
+	fs.Float64Var(&servicenowRateLimit, "rate-limit", 3.0, "Requests per second")
+	fs.BoolVar(&servicenowAllowInsecureHTTP, "allow-insecure-http", false, "Allow plaintext HTTP instance URLs")
+}
+
+func init() {
+	registerServiceNowFlags(servicenowCmd.Flags())
+}
+
+func runServiceNowEnumScan(cmd *cobra.Command, args []string) error {
+	instance := servicenowInstance
+	if instance == "" {
+		instance = os.Getenv("SERVICENOW_INSTANCE")
+	}
+	if instance == "" {
+		return fmt.Errorf("servicenow instance URL is required: use --instance or SERVICENOW_INSTANCE env var")
+	}
+
+	username := servicenowUsername
+	if username == "" {
+		username = os.Getenv("SERVICENOW_USERNAME")
+	}
+
+	password := servicenowPassword
+	if password == "" {
+		password = os.Getenv("SERVICENOW_PASSWORD")
+	}
+
+	oauthToken := servicenowOAuthToken
+	if oauthToken == "" {
+		oauthToken = os.Getenv("SERVICENOW_OAUTH_TOKEN")
+	}
+
+	var tables []string
+	if servicenowTables != "" {
+		for _, t := range strings.Split(servicenowTables, ",") {
+			t = strings.TrimSpace(t)
+			if t != "" {
+				tables = append(tables, t)
+			}
+		}
+	}
+
+	var verboseWriter io.Writer
+	if verbose {
+		verboseWriter = cmd.ErrOrStderr()
+	}
+
+	enumerator, err := enum.NewServiceNowEnumerator(enum.ServiceNowConfig{
+		Instance:          instance,
+		Username:          username,
+		Password:          password,
+		OAuthToken:        oauthToken,
+		Tables:            tables,
+		RateLimit:         servicenowRateLimit,
+		AllowInsecureHTTP: servicenowAllowInsecureHTTP,
+		Verbose:           verboseWriter,
+	})
+	if err != nil {
+		return fmt.Errorf("creating ServiceNow enumerator: %w", err)
+	}
+
+	return runEnumScan(cmd, enumerator, "ServiceNow")
+}

--- a/cmd/titus/enum_test.go
+++ b/cmd/titus/enum_test.go
@@ -35,7 +35,7 @@ func TestEnumCmd_NotHidden(t *testing.T) {
 }
 
 // TestEnumCmd_SubcommandCount verifies that enumCmd has exactly the expected
-// 7 service subcommands + the microsoft parent (8 children total).
+// 8 service subcommands + the microsoft parent (9 children total).
 func TestEnumCmd_SubcommandCount(t *testing.T) {
 	cmd, _, err := rootCmd.Find([]string{"enum"})
 	require.NoError(t, err)
@@ -45,8 +45,8 @@ func TestEnumCmd_SubcommandCount(t *testing.T) {
 		names = append(names, sub.Name())
 	}
 
-	expected := []string{"confluence", "github", "gitlab", "jira", "linear", "microsoft", "notion", "slack"}
-	assert.ElementsMatch(t, expected, names, "enum should have exactly 7 service subcommands + microsoft parent (8 children total)")
+	expected := []string{"confluence", "github", "gitlab", "jira", "linear", "microsoft", "notion", "servicenow", "slack"}
+	assert.ElementsMatch(t, expected, names, "enum should have exactly 8 service subcommands + microsoft parent (9 children total)")
 }
 
 // TestEnumCmd_HasMicrosoftSubcommand verifies the microsoft parent is a child

--- a/pkg/enum/servicenow.go
+++ b/pkg/enum/servicenow.go
@@ -151,7 +151,7 @@ func (e *ServiceNowEnumerator) snGet(ctx context.Context, reqURL string) ([]byte
 		}
 
 		if resp.StatusCode == 429 || resp.StatusCode >= 500 {
-			resp.Body.Close()
+			_ = resp.Body.Close()
 			if attempt < maxAttempts-1 {
 				select {
 				case <-ctx.Done():
@@ -164,12 +164,12 @@ func (e *ServiceNowEnumerator) snGet(ctx context.Context, reqURL string) ([]byte
 		}
 
 		if resp.StatusCode != 200 {
-			resp.Body.Close()
+			_ = resp.Body.Close()
 			return nil, fmt.Errorf("servicenow API returned unexpected status %d", resp.StatusCode)
 		}
 
 		body, err := io.ReadAll(resp.Body)
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		if err != nil {
 			return nil, fmt.Errorf("read response body: %w", err)
 		}

--- a/pkg/enum/servicenow.go
+++ b/pkg/enum/servicenow.go
@@ -1,0 +1,284 @@
+package enum
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"golang.org/x/time/rate"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+)
+
+var snDefaultTables = []string{"incident", "change_request", "kb_knowledge"}
+
+// ServiceNowConfig configures the ServiceNow instance enumerator.
+type ServiceNowConfig struct {
+	Instance          string    // instance URL (e.g., https://mycompany.service-now.com)
+	Username          string    // basic auth username
+	Password          string    // basic auth password
+	OAuthToken        string    // OAuth2 bearer token (alternative to basic auth)
+	Tables            []string  // tables to scan (default: incident, change_request, kb_knowledge)
+	RateLimit         float64   // requests per second (default 3)
+	AllowInsecureHTTP bool      // allow plaintext HTTP instance URLs
+	Verbose           io.Writer // progress output (nil = silent)
+}
+
+// ServiceNowEnumerator enumerates blobs from a ServiceNow instance via the REST Table API.
+type ServiceNowEnumerator struct {
+	config  ServiceNowConfig
+	client  *http.Client
+	limiter *rate.Limiter
+	apiBase string
+}
+
+// NewServiceNowEnumerator creates a new ServiceNow enumerator.
+func NewServiceNowEnumerator(cfg ServiceNowConfig) (*ServiceNowEnumerator, error) {
+	if cfg.Instance == "" {
+		return nil, fmt.Errorf("servicenow instance URL is required")
+	}
+	if cfg.OAuthToken == "" && (cfg.Username == "" || cfg.Password == "") {
+		return nil, fmt.Errorf("servicenow auth required: provide --username + --password, or --oauth-token")
+	}
+
+	insecure, err := ValidateBaseURL(cfg.Instance)
+	if err != nil {
+		return nil, fmt.Errorf("servicenow instance URL: %w", err)
+	}
+	if insecure && !cfg.AllowInsecureHTTP {
+		return nil, fmt.Errorf("servicenow instance URL uses plaintext HTTP, which exposes credentials; use HTTPS or set AllowInsecureHTTP")
+	}
+
+	if cfg.RateLimit <= 0 {
+		cfg.RateLimit = 3.0
+	}
+	if len(cfg.Tables) == 0 {
+		cfg.Tables = snDefaultTables
+	}
+
+	apiBase := strings.TrimRight(cfg.Instance, "/") + "/api/now/table"
+
+	return &ServiceNowEnumerator{
+		config:  cfg,
+		client:  &http.Client{Timeout: 30 * time.Second},
+		limiter: rate.NewLimiter(rate.Limit(cfg.RateLimit), 1),
+		apiBase: apiBase,
+	}, nil
+}
+
+func snProvenance(table, sysID, number, shortDesc, recordURL string) types.ExtendedProvenance {
+	return types.ExtendedProvenance{
+		Payload: map[string]interface{}{
+			"source":     "servicenow",
+			"entityType": table,
+			"identifier": sysID,
+			"number":     number,
+			"title":      shortDesc,
+			"url":        recordURL,
+			"path":       recordURL,
+		},
+	}
+}
+
+func (e *ServiceNowEnumerator) logf(format string, args ...interface{}) {
+	if e.config.Verbose != nil {
+		_, _ = fmt.Fprintf(e.config.Verbose, format+"\n", args...)
+	}
+}
+
+func (e *ServiceNowEnumerator) progressf(format string, args ...interface{}) {
+	if e.config.Verbose != nil {
+		_, _ = fmt.Fprintf(e.config.Verbose, "\r%-80s", fmt.Sprintf(format, args...))
+	}
+}
+
+// snRecord holds the fields we extract from each ServiceNow table record.
+type snRecord struct {
+	SysID            string `json:"sys_id"`
+	Number           string `json:"number"`
+	ShortDescription string `json:"short_description"`
+	Description      string `json:"description"`
+	WorkNotes        string `json:"work_notes"`
+	Comments         string `json:"comments"`
+	// KB articles use different field names.
+	Text string `json:"text"`
+}
+
+// snTableResponse is the envelope returned by the Table API.
+type snTableResponse struct {
+	Result json.RawMessage `json:"result"`
+}
+
+// snGet performs a rate-limited GET with auth and retry.
+func (e *ServiceNowEnumerator) snGet(ctx context.Context, reqURL string) ([]byte, error) {
+	const maxAttempts = 3
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if err := e.limiter.Wait(ctx); err != nil {
+			return nil, fmt.Errorf("rate limiter: %w", err)
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+		if err != nil {
+			return nil, fmt.Errorf("build request: %w", err)
+		}
+
+		if e.config.OAuthToken != "" {
+			req.Header.Set("Authorization", "Bearer "+e.config.OAuthToken)
+		} else {
+			encoded := base64.StdEncoding.EncodeToString([]byte(e.config.Username + ":" + e.config.Password))
+			req.Header.Set("Authorization", "Basic "+encoded)
+		}
+		req.Header.Set("Accept", "application/json")
+
+		resp, err := e.client.Do(req)
+		if err != nil {
+			if attempt < maxAttempts-1 {
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(2 * time.Second):
+				}
+				continue
+			}
+			return nil, fmt.Errorf("http request: %w", err)
+		}
+
+		if resp.StatusCode == 429 || resp.StatusCode >= 500 {
+			resp.Body.Close()
+			if attempt < maxAttempts-1 {
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(2 * time.Second):
+				}
+				continue
+			}
+			return nil, fmt.Errorf("servicenow API returned %d after %d attempts", resp.StatusCode, maxAttempts)
+		}
+
+		if resp.StatusCode != 200 {
+			resp.Body.Close()
+			return nil, fmt.Errorf("servicenow API returned unexpected status %d", resp.StatusCode)
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("read response body: %w", err)
+		}
+		return body, nil
+	}
+	return nil, fmt.Errorf("snGet: exceeded max attempts")
+}
+
+// snFetchRecords retrieves all records from a table using offset pagination.
+func (e *ServiceNowEnumerator) snFetchRecords(ctx context.Context, table string) ([]snRecord, error) {
+	var all []snRecord
+	offset := 0
+	limit := 100
+	for {
+		reqURL := fmt.Sprintf("%s/%s?sysparm_limit=%d&sysparm_offset=%d&sysparm_fields=%s",
+			e.apiBase, url.PathEscape(table), limit, offset,
+			"sys_id,number,short_description,description,work_notes,comments,text")
+
+		body, err := e.snGet(ctx, reqURL)
+		if err != nil {
+			return nil, fmt.Errorf("fetch %s records: %w", table, err)
+		}
+
+		var resp snTableResponse
+		if err := json.Unmarshal(body, &resp); err != nil {
+			return nil, fmt.Errorf("decode %s response: %w", table, err)
+		}
+
+		var records []snRecord
+		if err := json.Unmarshal(resp.Result, &records); err != nil {
+			return nil, fmt.Errorf("decode %s records: %w", table, err)
+		}
+
+		all = append(all, records...)
+
+		if len(records) < limit {
+			break
+		}
+		offset += limit
+	}
+	return all, nil
+}
+
+// snBuildRecordBlob assembles a ServiceNow record into a single blob for scanning.
+func snBuildRecordBlob(table string, rec snRecord, instanceURL string) []byte {
+	var sb strings.Builder
+	sb.WriteString("Table: " + table + "\n")
+	if rec.Number != "" {
+		sb.WriteString("Number: " + rec.Number + "\n")
+	}
+	if rec.ShortDescription != "" {
+		sb.WriteString("Short Description: " + rec.ShortDescription + "\n")
+	}
+	recordURL := strings.TrimRight(instanceURL, "/") + "/" + table + ".do?sys_id=" + rec.SysID
+	sb.WriteString("URL: " + recordURL + "\n")
+	sb.WriteString("---\n")
+
+	if rec.Description != "" {
+		sb.WriteString(rec.Description + "\n")
+	}
+	if rec.Text != "" {
+		sb.WriteString(rec.Text + "\n")
+	}
+	if rec.WorkNotes != "" {
+		sb.WriteString("\n--- Work Notes ---\n")
+		sb.WriteString(rec.WorkNotes + "\n")
+	}
+	if rec.Comments != "" {
+		sb.WriteString("\n--- Comments ---\n")
+		sb.WriteString(rec.Comments + "\n")
+	}
+	return []byte(sb.String())
+}
+
+// Enumerate discovers content from a ServiceNow instance and yields blobs.
+func (e *ServiceNowEnumerator) Enumerate(ctx context.Context, callback func(content []byte, blobID types.BlobID, prov types.Provenance) error) error {
+	e.logf("Scanning %d tables: %s", len(e.config.Tables), strings.Join(e.config.Tables, ", "))
+
+	var count atomic.Int64
+	var errs []string
+
+	for _, table := range e.config.Tables {
+		records, err := e.snFetchRecords(ctx, table)
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("table %s: %v", table, err))
+			continue
+		}
+
+		e.logf("Table %s: %d records", table, len(records))
+
+		for _, rec := range records {
+			blob := snBuildRecordBlob(table, rec, e.config.Instance)
+			blobID := types.ComputeBlobID(blob)
+			recordURL := strings.TrimRight(e.config.Instance, "/") + "/" + table + ".do?sys_id=" + rec.SysID
+			prov := snProvenance(table, rec.SysID, rec.Number, rec.ShortDescription, recordURL)
+
+			n := count.Add(1)
+			e.progressf("Scanning records: %d", n)
+
+			if err := callback(blob, blobID, prov); err != nil {
+				return err
+			}
+		}
+	}
+
+	e.logf("Scanned %d records across %d tables", count.Load(), len(e.config.Tables))
+
+	if len(errs) > 0 {
+		return fmt.Errorf("enumeration errors: %s", strings.Join(errs, "; "))
+	}
+	return nil
+}

--- a/pkg/enum/servicenow_test.go
+++ b/pkg/enum/servicenow_test.go
@@ -1,0 +1,370 @@
+package enum
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var _ Enumerator = (*ServiceNowEnumerator)(nil)
+
+func TestServiceNowEnumerator_Construction(t *testing.T) {
+	e, err := NewServiceNowEnumerator(ServiceNowConfig{
+		Instance: "https://mycompany.service-now.com",
+		Username: "admin",
+		Password: "secret",
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, e)
+}
+
+func TestServiceNowEnumerator_RequiresInstance(t *testing.T) {
+	_, err := NewServiceNowEnumerator(ServiceNowConfig{
+		Username: "admin",
+		Password: "secret",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "instance")
+}
+
+func TestServiceNowEnumerator_RequiresAuth(t *testing.T) {
+	_, err := NewServiceNowEnumerator(ServiceNowConfig{
+		Instance: "https://mycompany.service-now.com",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "auth")
+}
+
+func TestServiceNowEnumerator_AcceptsOAuthToken(t *testing.T) {
+	e, err := NewServiceNowEnumerator(ServiceNowConfig{
+		Instance:   "https://mycompany.service-now.com",
+		OAuthToken: "bearer-token-here",
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, e)
+}
+
+func TestServiceNowEnumerator_RejectsInsecureHTTP(t *testing.T) {
+	_, err := NewServiceNowEnumerator(ServiceNowConfig{
+		Instance: "http://mycompany.service-now.com",
+		Username: "admin",
+		Password: "secret",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "plaintext HTTP")
+}
+
+func TestServiceNowEnumerator_AllowsInsecureHTTP(t *testing.T) {
+	e, err := NewServiceNowEnumerator(ServiceNowConfig{
+		Instance:          "http://mycompany.service-now.com",
+		Username:          "admin",
+		Password:          "secret",
+		AllowInsecureHTTP: true,
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, e)
+}
+
+func TestServiceNowEnumerator_DefaultTables(t *testing.T) {
+	e, err := NewServiceNowEnumerator(ServiceNowConfig{
+		Instance: "https://mycompany.service-now.com",
+		Username: "admin",
+		Password: "secret",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"incident", "change_request", "kb_knowledge"}, e.config.Tables)
+}
+
+func TestServiceNowEnumerator_CustomTables(t *testing.T) {
+	e, err := NewServiceNowEnumerator(ServiceNowConfig{
+		Instance: "https://mycompany.service-now.com",
+		Username: "admin",
+		Password: "secret",
+		Tables:   []string{"cmdb_ci", "sc_req_item"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"cmdb_ci", "sc_req_item"}, e.config.Tables)
+}
+
+func TestServiceNowEnumerator_DefaultRateLimit(t *testing.T) {
+	e, err := NewServiceNowEnumerator(ServiceNowConfig{
+		Instance: "https://mycompany.service-now.com",
+		Username: "admin",
+		Password: "secret",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 3.0, e.config.RateLimit)
+}
+
+func TestServiceNowProvenance(t *testing.T) {
+	prov := snProvenance("incident", "abc123", "INC0010001", "Server down", "https://mycompany.service-now.com/incident.do?sys_id=abc123")
+	assert.Equal(t, "extended", prov.Kind())
+	assert.Equal(t, "servicenow", prov.Payload["source"])
+	assert.Equal(t, "incident", prov.Payload["entityType"])
+	assert.Equal(t, "abc123", prov.Payload["identifier"])
+	assert.Equal(t, "INC0010001", prov.Payload["number"])
+	assert.Equal(t, "Server down", prov.Payload["title"])
+}
+
+func TestServiceNowBuildRecordBlob(t *testing.T) {
+	rec := snRecord{
+		SysID:            "abc123",
+		Number:           "INC0010001",
+		ShortDescription: "DB password exposed",
+		Description:      "Found password: hunter2 in config file",
+		WorkNotes:        "Rotated credential",
+		Comments:         "Customer confirmed rotation",
+	}
+	blob := snBuildRecordBlob("incident", rec, "https://mycompany.service-now.com")
+	content := string(blob)
+
+	assert.Contains(t, content, "Table: incident")
+	assert.Contains(t, content, "Number: INC0010001")
+	assert.Contains(t, content, "Short Description: DB password exposed")
+	assert.Contains(t, content, "hunter2")
+	assert.Contains(t, content, "--- Work Notes ---")
+	assert.Contains(t, content, "Rotated credential")
+	assert.Contains(t, content, "--- Comments ---")
+	assert.Contains(t, content, "Customer confirmed rotation")
+	assert.Contains(t, content, "incident.do?sys_id=abc123")
+}
+
+func TestServiceNowBuildRecordBlob_KBArticle(t *testing.T) {
+	rec := snRecord{
+		SysID:            "kb001",
+		Number:           "KB0010001",
+		ShortDescription: "SSH key setup",
+		Text:             "Use ssh-keygen to generate keys. Example key: AKIA...",
+	}
+	blob := snBuildRecordBlob("kb_knowledge", rec, "https://mycompany.service-now.com")
+	content := string(blob)
+
+	assert.Contains(t, content, "Table: kb_knowledge")
+	assert.Contains(t, content, "AKIA...")
+	assert.NotContains(t, content, "--- Work Notes ---")
+	assert.NotContains(t, content, "--- Comments ---")
+}
+
+func testServiceNowEnumerator(t *testing.T, serverURL string, tables []string) *ServiceNowEnumerator {
+	t.Helper()
+	if tables == nil {
+		tables = snDefaultTables
+	}
+	e, err := NewServiceNowEnumerator(ServiceNowConfig{
+		Instance: "https://mycompany.service-now.com",
+		Username: "admin",
+		Password: "secret",
+		Tables:   tables,
+		RateLimit: 1000,
+	})
+	require.NoError(t, err)
+	e.apiBase = serverURL
+	return e
+}
+
+func TestServiceNowAPI_BasicAuth(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, pass, ok := r.BasicAuth()
+		assert.True(t, ok, "expected Basic auth")
+		assert.Equal(t, "admin", user)
+		assert.Equal(t, "secret", pass)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"result": []interface{}{},
+		})
+	}))
+	defer server.Close()
+
+	e := testServiceNowEnumerator(t, server.URL, []string{"incident"})
+	_, err := e.snFetchRecords(context.Background(), "incident")
+	require.NoError(t, err)
+}
+
+func TestServiceNowAPI_BearerAuth(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer my-oauth-token", r.Header.Get("Authorization"))
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"result": []interface{}{},
+		})
+	}))
+	defer server.Close()
+
+	e, err := NewServiceNowEnumerator(ServiceNowConfig{
+		Instance:   "https://mycompany.service-now.com",
+		OAuthToken: "my-oauth-token",
+		Tables:     []string{"incident"},
+		RateLimit:  1000,
+	})
+	require.NoError(t, err)
+	e.apiBase = server.URL
+
+	_, err = e.snFetchRecords(context.Background(), "incident")
+	require.NoError(t, err)
+}
+
+func TestServiceNowAPI_FetchRecords(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.Path, "/incident")
+		assert.Equal(t, "application/json", r.Header.Get("Accept"))
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"result": []map[string]interface{}{
+				{
+					"sys_id":            "id1",
+					"number":            "INC0010001",
+					"short_description": "Test incident",
+					"description":       "Description with API_KEY=sk-abc123",
+					"work_notes":        "",
+					"comments":          "",
+				},
+				{
+					"sys_id":            "id2",
+					"number":            "INC0010002",
+					"short_description": "Another incident",
+					"description":       "Password: hunter2",
+					"work_notes":        "Rotated cred",
+					"comments":          "User notified",
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	e := testServiceNowEnumerator(t, server.URL, []string{"incident"})
+	records, err := e.snFetchRecords(context.Background(), "incident")
+	require.NoError(t, err)
+	assert.Len(t, records, 2)
+	assert.Equal(t, "INC0010001", records[0].Number)
+	assert.Contains(t, records[1].Description, "hunter2")
+}
+
+func TestServiceNowAPI_Pagination(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		offset := r.URL.Query().Get("sysparm_offset")
+
+		var records []map[string]interface{}
+		if offset == "0" || offset == "" {
+			for i := 0; i < 100; i++ {
+				records = append(records, map[string]interface{}{
+					"sys_id": fmt.Sprintf("page1-%d", i),
+					"number": fmt.Sprintf("INC%07d", i),
+				})
+			}
+		} else {
+			records = append(records, map[string]interface{}{
+				"sys_id": "page2-0",
+				"number": "INC0000100",
+			})
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"result": records,
+		})
+	}))
+	defer server.Close()
+
+	e := testServiceNowEnumerator(t, server.URL, []string{"incident"})
+	records, err := e.snFetchRecords(context.Background(), "incident")
+	require.NoError(t, err)
+	assert.Len(t, records, 101)
+	assert.Equal(t, 2, callCount, "should paginate with two requests")
+}
+
+func TestServiceNowEnumerate_EndToEnd(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if strings.Contains(r.URL.Path, "/incident") {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"result": []map[string]interface{}{
+					{
+						"sys_id":            "inc1",
+						"number":            "INC0010001",
+						"short_description": "Leaked key",
+						"description":       "Found AKIA1234567890EXAMPLE in config",
+					},
+				},
+			})
+		} else if strings.Contains(r.URL.Path, "/kb_knowledge") {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"result": []map[string]interface{}{
+					{
+						"sys_id":            "kb1",
+						"number":            "KB0010001",
+						"short_description": "Setup guide",
+						"text":              "Set DB_PASSWORD=s3cret in .env",
+					},
+				},
+			})
+		} else {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"result": []interface{}{},
+			})
+		}
+	}))
+	defer server.Close()
+
+	e := testServiceNowEnumerator(t, server.URL, []string{"incident", "kb_knowledge"})
+
+	var blobs []string
+	var provs []types.Provenance
+	err := e.Enumerate(context.Background(), func(content []byte, blobID types.BlobID, prov types.Provenance) error {
+		blobs = append(blobs, string(content))
+		provs = append(provs, prov)
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Len(t, blobs, 2)
+
+	assert.Contains(t, blobs[0], "AKIA1234567890EXAMPLE")
+	assert.Contains(t, blobs[0], "Table: incident")
+
+	assert.Contains(t, blobs[1], "DB_PASSWORD=s3cret")
+	assert.Contains(t, blobs[1], "Table: kb_knowledge")
+
+	ep0 := provs[0].(types.ExtendedProvenance)
+	assert.Equal(t, "servicenow", ep0.Payload["source"])
+	assert.Equal(t, "incident", ep0.Payload["entityType"])
+}
+
+func TestServiceNowEnumerate_TableError_ContinuesOtherTables(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/incident") {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"result": []map[string]interface{}{
+				{"sys_id": "kb1", "number": "KB001", "text": "some content"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	e := testServiceNowEnumerator(t, server.URL, []string{"incident", "kb_knowledge"})
+
+	var blobCount int
+	err := e.Enumerate(context.Background(), func(content []byte, blobID types.BlobID, prov types.Provenance) error {
+		blobCount++
+		return nil
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "table incident")
+	assert.Equal(t, 1, blobCount, "should still yield kb_knowledge records despite incident failure")
+}


### PR DESCRIPTION
## Summary
- Adds `pkg/enum/servicenow.go` — new ServiceNow enumerator fetching records from configurable tables via the REST Table API with offset pagination, rate limiting, and retry on 429/5xx
- Supports basic auth and OAuth bearer token authentication
- Default tables: `incident`, `change_request`, `kb_knowledge`
- Adds `cmd/titus/enum_servicenow.go` — `titus enum servicenow` cobra command with flags for instance URL, basic/OAuth auth, table list, rate limit, and insecure-HTTP override (all flags support SERVICENOW_* env vars)
- Comprehensive test suite (18 tests) covering construction, auth, pagination, provenance, blob building, and end-to-end enumeration
- Updates enum command tree and subcommand count test

## Test plan
- [x] `go build ./pkg/enum/` and `go build ./cmd/titus/` pass
- [x] `go test -v -run TestServiceNow ./pkg/enum/` — all 18 tests pass
- [x] `go test -v -run TestEnumCmd ./cmd/titus/` — subcommand count and wiring tests pass
- [ ] Reviewer: confirm enumerator follows the established pattern (cf. `confluence.go`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)