### PR TITLE
feat(enum): add Trello enumerator (LAB-4310)

### DIFF
--- a/cmd/titus/enum.go
+++ b/cmd/titus/enum.go
@@ -24,7 +24,7 @@ var (
 var enumCmd = &cobra.Command{
 	Use:   "enum",
 	Short: "Enumerate remote services for secrets",
-	Long: `Enumerate remote services (GitHub, GitLab, Slack, Notion, Linear, Confluence, Jira, Microsoft 365, ServiceNow)
+	Long: `Enumerate remote services (GitHub, GitLab, Slack, Notion, Linear, Confluence, Jira, Microsoft 365, ServiceNow, Trello)
 for secrets using detection rules.`,
 }
 
@@ -42,7 +42,7 @@ func registerEnumScanFlags(fs *pflag.FlagSet) {
 
 func init() {
 	registerEnumScanFlags(enumCmd.PersistentFlags())
-	enumCmd.AddCommand(githubCmd, gitlabCmd, slackCmd, notionCmd, linearCmd, confluenceCmd, jiraCmd, microsoftCmd, gdriveCmd, servicenowCmd)
+	enumCmd.AddCommand(githubCmd, gitlabCmd, slackCmd, notionCmd, linearCmd, confluenceCmd, jiraCmd, microsoftCmd, gdriveCmd, servicenowCmd, trelloCmd)
 }
 
 // runEnumScan runs the shared enumeration pipeline: load rules → create matcher/store →

--- a/cmd/titus/enum_test.go
+++ b/cmd/titus/enum_test.go
@@ -45,7 +45,7 @@ func TestEnumCmd_SubcommandCount(t *testing.T) {
 		names = append(names, sub.Name())
 	}
 
-	expected := []string{"confluence", "gdrive", "github", "gitlab", "jira", "linear", "microsoft", "notion", "servicenow", "slack"}
+	expected := []string{"confluence", "gdrive", "github", "gitlab", "jira", "linear", "microsoft", "notion", "servicenow", "slack", "trello"}
 	assert.ElementsMatch(t, expected, names, "enum subcommands should match")
 }
 

--- a/cmd/titus/enum_trello.go
+++ b/cmd/titus/enum_trello.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/praetorian-inc/titus/pkg/enum"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+var (
+	trelloAPIKey    string
+	trelloToken     string
+	trelloBoards    string
+	trelloRateLimit float64
+)
+
+var trelloCmd = &cobra.Command{
+	Use:   "trello",
+	Short: "Scan Trello boards for secrets",
+	Long: `Scan Trello boards for secrets via the REST API.
+Enumerates cards, comments, and checklists across boards.
+
+Authentication:
+  Use --api-key and --token (Trello Power-Up API key + user token).
+
+Examples:
+  titus enum trello --api-key KEY --token TOKEN
+  TRELLO_API_KEY=KEY TRELLO_TOKEN=TOKEN titus enum trello
+  titus enum trello --api-key KEY --token TOKEN --boards boardId1,boardId2`,
+	RunE: runTrelloEnumScan,
+}
+
+func registerTrelloFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&trelloAPIKey, "api-key", "", "Trello API key (or TRELLO_API_KEY env)")
+	fs.StringVar(&trelloToken, "token", "", "Trello user token (or TRELLO_TOKEN env)")
+	fs.StringVar(&trelloBoards, "boards", "", "Comma-separated board IDs to scan (default: all)")
+	fs.Float64Var(&trelloRateLimit, "rate-limit", 3.0, "Requests per second")
+}
+
+func init() {
+	registerTrelloFlags(trelloCmd.Flags())
+}
+
+func runTrelloEnumScan(cmd *cobra.Command, args []string) error {
+	apiKey := trelloAPIKey
+	if apiKey == "" {
+		apiKey = os.Getenv("TRELLO_API_KEY")
+	}
+	if apiKey == "" {
+		return fmt.Errorf("trello API key is required: use --api-key or TRELLO_API_KEY env var")
+	}
+
+	token := trelloToken
+	if token == "" {
+		token = os.Getenv("TRELLO_TOKEN")
+	}
+	if token == "" {
+		return fmt.Errorf("trello token is required: use --token or TRELLO_TOKEN env var")
+	}
+
+	var boards []string
+	if trelloBoards != "" {
+		for _, b := range strings.Split(trelloBoards, ",") {
+			b = strings.TrimSpace(b)
+			if b != "" {
+				boards = append(boards, b)
+			}
+		}
+	}
+
+	var verboseWriter io.Writer
+	if verbose {
+		verboseWriter = cmd.ErrOrStderr()
+	}
+
+	enumerator, err := enum.NewTrelloEnumerator(enum.TrelloConfig{
+		APIKey:    apiKey,
+		Token:     token,
+		Boards:    boards,
+		RateLimit: trelloRateLimit,
+		Verbose:   verboseWriter,
+	})
+	if err != nil {
+		return fmt.Errorf("creating Trello enumerator: %w", err)
+	}
+
+	return runEnumScan(cmd, enumerator, "Trello")
+}

--- a/pkg/enum/trello.go
+++ b/pkg/enum/trello.go
@@ -189,7 +189,7 @@ func (e *TrelloEnumerator) trelloFetchBoards(ctx context.Context) ([]trelloBoard
 }
 
 func (e *TrelloEnumerator) trelloFetchCards(ctx context.Context, boardID string) ([]trelloCard, error) {
-	path := fmt.Sprintf("/boards/%s/cards?fields=id,name,desc,url", boardID)
+	path := fmt.Sprintf("/boards/%s/cards?fields=id,name,desc,url&filter=all", boardID)
 	body, err := e.trelloGet(ctx, path)
 	if err != nil {
 		return nil, fmt.Errorf("fetch cards for board %s: %w", boardID, err)
@@ -203,7 +203,7 @@ func (e *TrelloEnumerator) trelloFetchCards(ctx context.Context, boardID string)
 }
 
 func (e *TrelloEnumerator) trelloFetchComments(ctx context.Context, cardID string) ([]trelloAction, error) {
-	path := fmt.Sprintf("/cards/%s/actions?filter=commentCard", cardID)
+	path := fmt.Sprintf("/cards/%s/actions?filter=commentCard&limit=1000", cardID)
 	body, err := e.trelloGet(ctx, path)
 	if err != nil {
 		return nil, fmt.Errorf("fetch comments for card %s: %w", cardID, err)
@@ -244,7 +244,7 @@ func trelloBuildCardBlob(boardName string, card trelloCard, comments []trelloAct
 	}
 
 	for _, cl := range checklists {
-		sb.WriteString(fmt.Sprintf("\n--- Checklist: %s ---\n", cl.Name))
+		fmt.Fprintf(&sb, "\n--- Checklist: %s ---\n", cl.Name)
 		for _, item := range cl.CheckItems {
 			sb.WriteString("- " + item.Name + "\n")
 		}

--- a/pkg/enum/trello.go
+++ b/pkg/enum/trello.go
@@ -1,0 +1,332 @@
+package enum
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"golang.org/x/time/rate"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+)
+
+const trelloAPIBase = "https://api.trello.com/1"
+
+// TrelloConfig configures the Trello enumerator.
+type TrelloConfig struct {
+	APIKey    string    // Trello Power-Up API key
+	Token     string    // Trello user token
+	Boards    []string  // board IDs to scan (empty = all)
+	RateLimit float64   // requests per second (default 3)
+	Verbose   io.Writer // progress output (nil = silent)
+}
+
+// TrelloEnumerator enumerates blobs from Trello boards via the REST API.
+type TrelloEnumerator struct {
+	config  TrelloConfig
+	client  *http.Client
+	limiter *rate.Limiter
+	apiBase string
+}
+
+// NewTrelloEnumerator creates a new Trello enumerator.
+func NewTrelloEnumerator(cfg TrelloConfig) (*TrelloEnumerator, error) {
+	if cfg.APIKey == "" {
+		return nil, fmt.Errorf("trello API key is required")
+	}
+	if cfg.Token == "" {
+		return nil, fmt.Errorf("trello token is required")
+	}
+
+	if cfg.RateLimit <= 0 {
+		cfg.RateLimit = 3.0
+	}
+
+	return &TrelloEnumerator{
+		config:  cfg,
+		client:  &http.Client{Timeout: 30 * time.Second},
+		limiter: rate.NewLimiter(rate.Limit(cfg.RateLimit), 1),
+		apiBase: trelloAPIBase,
+	}, nil
+}
+
+func trelloProvenance(entityType, id, title, recordURL string) types.ExtendedProvenance {
+	return types.ExtendedProvenance{
+		Payload: map[string]interface{}{
+			"source":     "trello",
+			"entityType": entityType,
+			"identifier": id,
+			"title":      title,
+			"url":        recordURL,
+			"path":       recordURL,
+		},
+	}
+}
+
+func (e *TrelloEnumerator) logf(format string, args ...interface{}) {
+	if e.config.Verbose != nil {
+		_, _ = fmt.Fprintf(e.config.Verbose, format+"\n", args...)
+	}
+}
+
+func (e *TrelloEnumerator) progressf(format string, args ...interface{}) {
+	if e.config.Verbose != nil {
+		_, _ = fmt.Fprintf(e.config.Verbose, "\r%-80s", fmt.Sprintf(format, args...))
+	}
+}
+
+// trelloGet performs a rate-limited GET with Trello auth and retry.
+func (e *TrelloEnumerator) trelloGet(ctx context.Context, path string) ([]byte, error) {
+	const maxAttempts = 3
+
+	sep := "?"
+	if strings.Contains(path, "?") {
+		sep = "&"
+	}
+	reqURL := fmt.Sprintf("%s%s%skey=%s&token=%s", e.apiBase, path, sep, e.config.APIKey, e.config.Token)
+
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if err := e.limiter.Wait(ctx); err != nil {
+			return nil, fmt.Errorf("rate limiter: %w", err)
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+		if err != nil {
+			return nil, fmt.Errorf("build request: %w", err)
+		}
+		req.Header.Set("Accept", "application/json")
+
+		resp, err := e.client.Do(req)
+		if err != nil {
+			if attempt < maxAttempts-1 {
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(2 * time.Second):
+				}
+				continue
+			}
+			return nil, fmt.Errorf("http request: %w", err)
+		}
+
+		if resp.StatusCode == 429 || resp.StatusCode >= 500 {
+			_ = resp.Body.Close()
+			if attempt < maxAttempts-1 {
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(2 * time.Second):
+				}
+				continue
+			}
+			return nil, fmt.Errorf("trello API returned %d after %d attempts", resp.StatusCode, maxAttempts)
+		}
+
+		if resp.StatusCode != 200 {
+			_ = resp.Body.Close()
+			return nil, fmt.Errorf("trello API returned unexpected status %d", resp.StatusCode)
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("read response body: %w", err)
+		}
+		return body, nil
+	}
+	return nil, fmt.Errorf("trelloGet: exceeded max attempts")
+}
+
+type trelloBoard struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Desc string `json:"desc"`
+	URL  string `json:"url"`
+}
+
+type trelloCard struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Desc string `json:"desc"`
+	URL  string `json:"url"`
+}
+
+type trelloAction struct {
+	ID   string `json:"id"`
+	Type string `json:"type"`
+	Data struct {
+		Text string `json:"text"`
+	} `json:"data"`
+}
+
+type trelloChecklist struct {
+	ID         string              `json:"id"`
+	Name       string              `json:"name"`
+	CheckItems []trelloCheckItem   `json:"checkItems"`
+}
+
+type trelloCheckItem struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func (e *TrelloEnumerator) trelloFetchBoards(ctx context.Context) ([]trelloBoard, error) {
+	body, err := e.trelloGet(ctx, "/members/me/boards?fields=id,name,desc,url")
+	if err != nil {
+		return nil, fmt.Errorf("fetch boards: %w", err)
+	}
+
+	var boards []trelloBoard
+	if err := json.Unmarshal(body, &boards); err != nil {
+		return nil, fmt.Errorf("decode boards: %w", err)
+	}
+	return boards, nil
+}
+
+func (e *TrelloEnumerator) trelloFetchCards(ctx context.Context, boardID string) ([]trelloCard, error) {
+	path := fmt.Sprintf("/boards/%s/cards?fields=id,name,desc,url", boardID)
+	body, err := e.trelloGet(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("fetch cards for board %s: %w", boardID, err)
+	}
+
+	var cards []trelloCard
+	if err := json.Unmarshal(body, &cards); err != nil {
+		return nil, fmt.Errorf("decode cards for board %s: %w", boardID, err)
+	}
+	return cards, nil
+}
+
+func (e *TrelloEnumerator) trelloFetchComments(ctx context.Context, cardID string) ([]trelloAction, error) {
+	path := fmt.Sprintf("/cards/%s/actions?filter=commentCard", cardID)
+	body, err := e.trelloGet(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("fetch comments for card %s: %w", cardID, err)
+	}
+
+	var actions []trelloAction
+	if err := json.Unmarshal(body, &actions); err != nil {
+		return nil, fmt.Errorf("decode comments for card %s: %w", cardID, err)
+	}
+	return actions, nil
+}
+
+func (e *TrelloEnumerator) trelloFetchChecklists(ctx context.Context, cardID string) ([]trelloChecklist, error) {
+	path := fmt.Sprintf("/cards/%s/checklists", cardID)
+	body, err := e.trelloGet(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("fetch checklists for card %s: %w", cardID, err)
+	}
+
+	var checklists []trelloChecklist
+	if err := json.Unmarshal(body, &checklists); err != nil {
+		return nil, fmt.Errorf("decode checklists for card %s: %w", cardID, err)
+	}
+	return checklists, nil
+}
+
+func trelloBuildCardBlob(boardName string, card trelloCard, comments []trelloAction, checklists []trelloChecklist) []byte {
+	var sb strings.Builder
+	sb.WriteString("Board: " + boardName + "\n")
+	sb.WriteString("Card: " + card.Name + "\n")
+	if card.URL != "" {
+		sb.WriteString("URL: " + card.URL + "\n")
+	}
+	sb.WriteString("---\n")
+
+	if card.Desc != "" {
+		sb.WriteString(card.Desc + "\n")
+	}
+
+	for _, cl := range checklists {
+		sb.WriteString(fmt.Sprintf("\n--- Checklist: %s ---\n", cl.Name))
+		for _, item := range cl.CheckItems {
+			sb.WriteString("- " + item.Name + "\n")
+		}
+	}
+
+	for _, c := range comments {
+		if c.Data.Text != "" {
+			sb.WriteString("\n--- Comment ---\n")
+			sb.WriteString(c.Data.Text + "\n")
+		}
+	}
+	return []byte(sb.String())
+}
+
+// Enumerate discovers content from Trello boards and yields blobs.
+func (e *TrelloEnumerator) Enumerate(ctx context.Context, callback func(content []byte, blobID types.BlobID, prov types.Provenance) error) error {
+	e.logf("Scanning Trello boards")
+
+	var count atomic.Int64
+	var errs []string
+
+	boards, err := e.trelloFetchBoards(ctx)
+	if err != nil {
+		return fmt.Errorf("fetching boards: %w", err)
+	}
+
+	// Filter boards if specific ones requested.
+	if len(e.config.Boards) > 0 {
+		boardSet := make(map[string]bool, len(e.config.Boards))
+		for _, b := range e.config.Boards {
+			boardSet[b] = true
+		}
+		var filtered []trelloBoard
+		for _, b := range boards {
+			if boardSet[b.ID] {
+				filtered = append(filtered, b)
+			}
+		}
+		boards = filtered
+	}
+
+	e.logf("Found %d boards", len(boards))
+
+	for _, board := range boards {
+		cards, err := e.trelloFetchCards(ctx, board.ID)
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("board %s: %v", board.ID, err))
+			continue
+		}
+
+		e.logf("Board %q: %d cards", board.Name, len(cards))
+
+		for _, card := range cards {
+			comments, err := e.trelloFetchComments(ctx, card.ID)
+			if err != nil {
+				errs = append(errs, fmt.Sprintf("card %s comments: %v", card.ID, err))
+				comments = nil
+			}
+
+			checklists, err := e.trelloFetchChecklists(ctx, card.ID)
+			if err != nil {
+				errs = append(errs, fmt.Sprintf("card %s checklists: %v", card.ID, err))
+				checklists = nil
+			}
+
+			blob := trelloBuildCardBlob(board.Name, card, comments, checklists)
+			blobID := types.ComputeBlobID(blob)
+			prov := trelloProvenance("card", card.ID, card.Name, card.URL)
+
+			n := count.Add(1)
+			e.progressf("Scanning cards: %d", n)
+
+			if err := callback(blob, blobID, prov); err != nil {
+				return err
+			}
+		}
+	}
+
+	e.logf("Scanned %d cards across %d boards", count.Load(), len(boards))
+
+	if len(errs) > 0 {
+		return fmt.Errorf("enumeration errors: %s", strings.Join(errs, "; "))
+	}
+	return nil
+}

--- a/pkg/enum/trello_test.go
+++ b/pkg/enum/trello_test.go
@@ -1,0 +1,340 @@
+package enum
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/praetorian-inc/titus/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testTrelloEnumerator(t *testing.T, handler http.Handler) *TrelloEnumerator {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	e, err := NewTrelloEnumerator(TrelloConfig{
+		APIKey:    "test-key",
+		Token:     "test-token",
+		RateLimit: 100,
+	})
+	require.NoError(t, err)
+	e.apiBase = srv.URL
+	return e
+}
+
+func TestNewTrelloEnumerator(t *testing.T) {
+	e, err := NewTrelloEnumerator(TrelloConfig{
+		APIKey: "key",
+		Token:  "tok",
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, e)
+}
+
+func TestNewTrelloEnumerator_MissingAPIKey(t *testing.T) {
+	_, err := NewTrelloEnumerator(TrelloConfig{
+		Token: "tok",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "API key is required")
+}
+
+func TestNewTrelloEnumerator_MissingToken(t *testing.T) {
+	_, err := NewTrelloEnumerator(TrelloConfig{
+		APIKey: "key",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "token is required")
+}
+
+func TestNewTrelloEnumerator_DefaultRateLimit(t *testing.T) {
+	e, err := NewTrelloEnumerator(TrelloConfig{
+		APIKey: "key",
+		Token:  "tok",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 3.0, e.config.RateLimit)
+}
+
+func TestTrelloProvenance(t *testing.T) {
+	prov := trelloProvenance("card", "card123", "My Card", "https://trello.com/c/card123")
+
+	assert.Equal(t, "trello", prov.Payload["source"])
+	assert.Equal(t, "card", prov.Payload["entityType"])
+	assert.Equal(t, "card123", prov.Payload["identifier"])
+	assert.Equal(t, "My Card", prov.Payload["title"])
+	assert.Equal(t, "https://trello.com/c/card123", prov.Payload["url"])
+}
+
+func TestTrelloBuildCardBlob_Basic(t *testing.T) {
+	card := trelloCard{
+		ID:   "c1",
+		Name: "Test Card",
+		Desc: "A description",
+		URL:  "https://trello.com/c/c1",
+	}
+	blob := trelloBuildCardBlob("My Board", card, nil, nil)
+	s := string(blob)
+
+	assert.Contains(t, s, "Board: My Board")
+	assert.Contains(t, s, "Card: Test Card")
+	assert.Contains(t, s, "URL: https://trello.com/c/c1")
+	assert.Contains(t, s, "A description")
+}
+
+func TestTrelloBuildCardBlob_WithComments(t *testing.T) {
+	card := trelloCard{ID: "c1", Name: "Card", Desc: "desc"}
+	comments := []trelloAction{
+		{ID: "a1", Data: struct {
+			Text string `json:"text"`
+		}{Text: "first comment"}},
+		{ID: "a2", Data: struct {
+			Text string `json:"text"`
+		}{Text: "second comment"}},
+	}
+	blob := trelloBuildCardBlob("Board", card, comments, nil)
+	s := string(blob)
+
+	assert.Contains(t, s, "first comment")
+	assert.Contains(t, s, "second comment")
+	assert.Equal(t, 2, strings.Count(s, "--- Comment ---"))
+}
+
+func TestTrelloBuildCardBlob_WithChecklists(t *testing.T) {
+	card := trelloCard{ID: "c1", Name: "Card", Desc: ""}
+	checklists := []trelloChecklist{
+		{
+			ID:   "cl1",
+			Name: "TODO",
+			CheckItems: []trelloCheckItem{
+				{ID: "ci1", Name: "Item A"},
+				{ID: "ci2", Name: "Item B"},
+			},
+		},
+	}
+	blob := trelloBuildCardBlob("Board", card, nil, checklists)
+	s := string(blob)
+
+	assert.Contains(t, s, "--- Checklist: TODO ---")
+	assert.Contains(t, s, "- Item A")
+	assert.Contains(t, s, "- Item B")
+}
+
+func TestTrelloAuth_QueryParams(t *testing.T) {
+	var gotKey, gotToken string
+	e := testTrelloEnumerator(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotKey = r.URL.Query().Get("key")
+		gotToken = r.URL.Query().Get("token")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte("[]"))
+	}))
+
+	_, _ = e.trelloGet(context.Background(), "/test")
+	assert.Equal(t, "test-key", gotKey)
+	assert.Equal(t, "test-token", gotToken)
+}
+
+func TestTrelloFetchBoards(t *testing.T) {
+	boards := []trelloBoard{
+		{ID: "b1", Name: "Board One", Desc: "desc1", URL: "https://trello.com/b/b1"},
+		{ID: "b2", Name: "Board Two", Desc: "desc2", URL: "https://trello.com/b/b2"},
+	}
+	e := testTrelloEnumerator(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/members/me/boards") {
+			_ = json.NewEncoder(w).Encode(boards)
+			return
+		}
+		w.WriteHeader(404)
+	}))
+
+	result, err := e.trelloFetchBoards(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.Equal(t, "Board One", result[0].Name)
+}
+
+func TestTrelloFetchCards(t *testing.T) {
+	cards := []trelloCard{
+		{ID: "c1", Name: "Card A", Desc: "desc", URL: "https://trello.com/c/c1"},
+	}
+	e := testTrelloEnumerator(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/boards/b1/cards") {
+			_ = json.NewEncoder(w).Encode(cards)
+			return
+		}
+		w.WriteHeader(404)
+	}))
+
+	result, err := e.trelloFetchCards(context.Background(), "b1")
+	require.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, "Card A", result[0].Name)
+}
+
+func TestTrelloFetchComments(t *testing.T) {
+	actions := []trelloAction{
+		{ID: "a1", Type: "commentCard", Data: struct {
+			Text string `json:"text"`
+		}{Text: "hello world"}},
+	}
+	e := testTrelloEnumerator(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/cards/c1/actions") {
+			_ = json.NewEncoder(w).Encode(actions)
+			return
+		}
+		w.WriteHeader(404)
+	}))
+
+	result, err := e.trelloFetchComments(context.Background(), "c1")
+	require.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, "hello world", result[0].Data.Text)
+}
+
+func TestTrelloFetchChecklists(t *testing.T) {
+	checklists := []trelloChecklist{
+		{
+			ID:   "cl1",
+			Name: "My List",
+			CheckItems: []trelloCheckItem{
+				{ID: "ci1", Name: "Do thing"},
+			},
+		},
+	}
+	e := testTrelloEnumerator(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/cards/c1/checklists") {
+			_ = json.NewEncoder(w).Encode(checklists)
+			return
+		}
+		w.WriteHeader(404)
+	}))
+
+	result, err := e.trelloFetchChecklists(context.Background(), "c1")
+	require.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, "My List", result[0].Name)
+	assert.Len(t, result[0].CheckItems, 1)
+}
+
+func TestTrelloEnumerate_EndToEnd(t *testing.T) {
+	boards := []trelloBoard{
+		{ID: "b1", Name: "Board", URL: "https://trello.com/b/b1"},
+	}
+	cards := []trelloCard{
+		{ID: "c1", Name: "Card One", Desc: "secret data", URL: "https://trello.com/c/c1"},
+	}
+	comments := []trelloAction{
+		{ID: "a1", Data: struct {
+			Text string `json:"text"`
+		}{Text: "a comment"}},
+	}
+	checklists := []trelloChecklist{
+		{ID: "cl1", Name: "Steps", CheckItems: []trelloCheckItem{
+			{ID: "ci1", Name: "step 1"},
+		}},
+	}
+
+	e := testTrelloEnumerator(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/members/me/boards"):
+			_ = json.NewEncoder(w).Encode(boards)
+		case strings.Contains(r.URL.Path, "/boards/b1/cards"):
+			_ = json.NewEncoder(w).Encode(cards)
+		case strings.Contains(r.URL.Path, "/cards/c1/actions"):
+			_ = json.NewEncoder(w).Encode(comments)
+		case strings.Contains(r.URL.Path, "/cards/c1/checklists"):
+			_ = json.NewEncoder(w).Encode(checklists)
+		default:
+			w.WriteHeader(404)
+		}
+	}))
+
+	var blobs []string
+	var provs []types.Provenance
+	err := e.Enumerate(context.Background(), func(content []byte, blobID types.BlobID, prov types.Provenance) error {
+		blobs = append(blobs, string(content))
+		provs = append(provs, prov)
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.Len(t, blobs, 1)
+	assert.Contains(t, blobs[0], "secret data")
+	assert.Contains(t, blobs[0], "a comment")
+	assert.Contains(t, blobs[0], "step 1")
+
+	ep := provs[0].(types.ExtendedProvenance)
+	assert.Equal(t, "trello", ep.Payload["source"])
+	assert.Equal(t, "card", ep.Payload["entityType"])
+	assert.Equal(t, "c1", ep.Payload["identifier"])
+}
+
+func TestTrelloEnumerate_BoardFilter(t *testing.T) {
+	boards := []trelloBoard{
+		{ID: "b1", Name: "Include"},
+		{ID: "b2", Name: "Exclude"},
+	}
+
+	e := testTrelloEnumerator(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/members/me/boards"):
+			_ = json.NewEncoder(w).Encode(boards)
+		case strings.Contains(r.URL.Path, "/boards/b1/cards"):
+			_ = json.NewEncoder(w).Encode([]trelloCard{{ID: "c1", Name: "Kept", URL: "u"}})
+		case strings.Contains(r.URL.Path, "/cards/c1/actions"):
+			_ = json.NewEncoder(w).Encode([]trelloAction{})
+		case strings.Contains(r.URL.Path, "/cards/c1/checklists"):
+			_ = json.NewEncoder(w).Encode([]trelloChecklist{})
+		default:
+			w.WriteHeader(404)
+		}
+	}))
+	e.config.Boards = []string{"b1"}
+
+	var count int
+	err := e.Enumerate(context.Background(), func(content []byte, blobID types.BlobID, prov types.Provenance) error {
+		count++
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+}
+
+func TestTrelloEnumerate_ErrorResilience(t *testing.T) {
+	boards := []trelloBoard{
+		{ID: "b1", Name: "Board"},
+	}
+	cards := []trelloCard{
+		{ID: "c1", Name: "Card", Desc: "data", URL: "u"},
+	}
+
+	e := testTrelloEnumerator(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/members/me/boards"):
+			_ = json.NewEncoder(w).Encode(boards)
+		case strings.Contains(r.URL.Path, "/boards/b1/cards"):
+			_ = json.NewEncoder(w).Encode(cards)
+		case strings.Contains(r.URL.Path, "/cards/c1/actions"):
+			w.WriteHeader(403)
+		case strings.Contains(r.URL.Path, "/cards/c1/checklists"):
+			w.WriteHeader(403)
+		default:
+			w.WriteHeader(404)
+		}
+	}))
+
+	var count int
+	err := e.Enumerate(context.Background(), func(content []byte, blobID types.BlobID, prov types.Provenance) error {
+		count++
+		return nil
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "enumeration errors")
+	assert.Equal(t, 1, count)
+}


### PR DESCRIPTION
## Summary
- Adds Trello enumerator that scans boards, cards, comments, and checklists for secrets via the REST API
- Auth uses API key + user token as query parameters (`--api-key`, `--token`, or `TRELLO_API_KEY`/`TRELLO_TOKEN` env vars)
- Supports optional `--boards` flag to filter specific board IDs, and `--rate-limit` (default 3 req/s)
- 16 tests covering construction, validation, auth, fetching, blob building, board filtering, error resilience, and end-to-end

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/enum/ -run Trello` — all 16 tests pass
- [x] `go test ./cmd/titus/ -run TestEnumCmd` — subcommand list updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)